### PR TITLE
Fix VS Code config and tidy up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ orig/*
 # Search patterns covering folders that need to be persisted must end with an asterisk,
 # or else this file will always be ignored
 !*.gitkeep
+
+# General-purpose ignore
+ignore/
+ignored/
+*.ignore.*
+*.ignored.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,23 @@
-__pycache__
-.idea
+# Cache directories
+.idea/
+.vs/
+__pycache__/
+
+# Ninja
+build/
 .ninja_deps
 .ninja_log
-*.exe
-build
 build.ninja
 objdiff.json
-orig/*/*
-!orig/*/.gitkeep
+
+# Excluded tools
 tools/mwcc_compiler/*
-!tools/mwcc_compiler/.gitkeep
-/*.txt
+
+# Original game files
+orig/*
+!orig/SZBE69.sha1
+
+# Used to persist certain empty folders
+# Search patterns covering folders that need to be persisted must end with an asterisk,
+# or else this file will always be ignored
+!*.gitkeep

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,8 +3,8 @@
         {
             "name": "Linux",
             "includePath": [
-                "${workspaceFolder}/include/**",
-                "${workspaceFolder}/libc/**"
+                "${workspaceFolder}/src/",
+                "${workspaceFolder}/src/**"
             ],
             "cStandard": "c99",
             "cppStandard": "c++98",
@@ -13,8 +13,8 @@
             "configurationProvider": "ms-vscode.makefile-tools",
             "browse": {
                 "path": [
-                    "${workspaceFolder}/include",
-                    "${workspaceFolder}/libc"
+                    "${workspaceFolder}/src/",
+                    "${workspaceFolder}/src/**"
                 ],
                 "limitSymbolsToIncludedHeaders": true
             }


### PR DESCRIPTION
'Cause someone's gotta do it eventually lol

- Fix the include/browse paths in the VS Code C/C++ config
- Tidy up and comment .gitignore to make it more understandable/maintainable
- Add missing .gitkeep for `tools/mwcc_compiler`, was in the .gitignore but not in the repo itself for some reason
- Add general-purpose ignore entries: name a folder `ignore`/`ignored` or suffix a file with `.ignore`/`.ignored` before its extension (e.g. `text.ignored.txt`) to exclude it. Meant for scratch work or temporary items that shouldn't be committed.