### PR TITLE
Match json_tokener.c, and reformat all of json-c

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -322,7 +322,7 @@ config.libs = [
         "objects": [
             Object(Matching, "json-c/arraylist.c"),
             Object(Matching, "json-c/json_object.c"),
-            Object(NonMatching, "json-c/json_tokener.c"),
+            Object(NonMatching, "json-c/json_tokener.c"), # Matches but doesn't link
             Object(Matching, "json-c/linkhash.c"),
             Object(Matching, "json-c/printbuf.c")
         ]

--- a/src/json-c/arraylist.c
+++ b/src/json-c/arraylist.c
@@ -12,83 +12,88 @@
 #include "config.h"
 
 #if STDC_HEADERS
-# include <stdlib.h>
-# include <string.h>
+#include <stdlib.h>
+#include <string.h>
 #endif /* STDC_HEADERS */
 
 #if defined HAVE_STRINGS_H && !defined _STRING_H && !defined __USE_BSD
-# include <strings.h>
+#include <strings.h>
 #endif /* HAVE_STRINGS_H */
 
 #include "bits.h"
 #include "arraylist.h"
 
-struct array_list*
-array_list_new(array_list_free_fn *free_fn)
+struct array_list *array_list_new(array_list_free_fn *free_fn)
 {
-  struct array_list *arr;
+	struct array_list *arr;
 
-  arr = (struct array_list*)calloc(1, sizeof(struct array_list));
-  if(!arr) return NULL;
-  arr->size = ARRAY_LIST_DEFAULT_SIZE;
-  arr->length = 0;
-  arr->free_fn = free_fn;
-  if(!(arr->array = (void**)calloc(sizeof(void*), arr->size))) {
-    free(arr);
-    return NULL;
-  }
-  return arr;
+	arr = (struct array_list *)calloc(1, sizeof(struct array_list));
+	if (!arr)
+		return NULL;
+	arr->size = ARRAY_LIST_DEFAULT_SIZE;
+	arr->length = 0;
+	arr->free_fn = free_fn;
+	if (!(arr->array = (void **)calloc(sizeof(void *), arr->size))) {
+		free(arr);
+		return NULL;
+	}
+	return arr;
 }
 
-extern void
-array_list_free(struct array_list *arr)
+extern void array_list_free(struct array_list *arr)
 {
-  int i;
-  for(i = 0; i < arr->length; i++)
-    if(arr->array[i]) arr->free_fn(arr->array[i]);
-  free(arr->array);
-  free(arr);
+	int i;
+	for (i = 0; i < arr->length; i++)
+		if (arr->array[i])
+			arr->free_fn(arr->array[i]);
+	free(arr->array);
+	free(arr);
 }
 
-void*
-array_list_get_idx(struct array_list *arr, int i)
+void *array_list_get_idx(struct array_list *arr, int i)
 {
-  if(i >= arr->length) return NULL;
-  return arr->array[i];
+	if (i >= arr->length)
+		return NULL;
+	return arr->array[i];
 }
 
 static int array_list_expand_internal(struct array_list *arr, int max)
 {
-  void *t;
-  int new_size;
+	void *t;
+	int new_size;
 
-  if(max < arr->size) return 0;
-  new_size = json_max(arr->size << 1, max);
-  if(!(t = realloc(arr->array, new_size*sizeof(void*)))) return -1;
-  arr->array = (void**)t;
-  (void)memset(arr->array + arr->size, 0, (new_size-arr->size)*sizeof(void*));
-  arr->size = new_size;
-  return 0;
+	if (max < arr->size)
+		return 0;
+	new_size = json_max(arr->size << 1, max);
+	if (!(t = realloc(arr->array, new_size * sizeof(void *))))
+		return -1;
+	arr->array = (void **)t;
+	(void)memset(
+		arr->array + arr->size,
+		0,
+		(new_size - arr->size) * sizeof(void *));
+	arr->size = new_size;
+	return 0;
 }
 
-int
-array_list_put_idx(struct array_list *arr, int idx, void *data)
+int array_list_put_idx(struct array_list *arr, int idx, void *data)
 {
-  if(array_list_expand_internal(arr, idx)) return -1;
-  if(arr->array[idx]) arr->free_fn(arr->array[idx]);
-  arr->array[idx] = data;
-  if(arr->length <= idx) arr->length = idx + 1;
-  return 0;
+	if (array_list_expand_internal(arr, idx))
+		return -1;
+	if (arr->array[idx])
+		arr->free_fn(arr->array[idx]);
+	arr->array[idx] = data;
+	if (arr->length <= idx)
+		arr->length = idx + 1;
+	return 0;
 }
 
-int
-array_list_add(struct array_list *arr, void *data)
+int array_list_add(struct array_list *arr, void *data)
 {
-  return array_list_put_idx(arr, arr->length, data);
+	return array_list_put_idx(arr, arr->length, data);
 }
 
-int
-array_list_length(struct array_list *arr)
+int array_list_length(struct array_list *arr)
 {
-  return arr->length;
+	return arr->length;
 }

--- a/src/json-c/arraylist.h
+++ b/src/json-c/arraylist.h
@@ -18,33 +18,26 @@ extern "C" {
 
 #define ARRAY_LIST_DEFAULT_SIZE 32
 
-typedef void (array_list_free_fn) (void *data);
+typedef void(array_list_free_fn)(void *data);
 
-struct array_list
-{
-  void **array;
-  int length;
-  int size;
-  array_list_free_fn *free_fn;
+struct array_list {
+	void **array;
+	int length;
+	int size;
+	array_list_free_fn *free_fn;
 };
 
-extern struct array_list*
-array_list_new(array_list_free_fn *free_fn);
+extern struct array_list *array_list_new(array_list_free_fn *free_fn);
 
-extern void
-array_list_free(struct array_list *al);
+extern void array_list_free(struct array_list *al);
 
-extern void*
-array_list_get_idx(struct array_list *al, int i);
+extern void *array_list_get_idx(struct array_list *al, int i);
 
-extern int
-array_list_put_idx(struct array_list *al, int i, void *data);
+extern int array_list_put_idx(struct array_list *al, int i, void *data);
 
-extern int
-array_list_add(struct array_list *al, void *data);
+extern int array_list_add(struct array_list *al, void *data);
 
-extern int
-array_list_length(struct array_list *al);
+extern int array_list_length(struct array_list *al);
 
 #ifdef __cplusplus
 }

--- a/src/json-c/bits.h
+++ b/src/json-c/bits.h
@@ -13,15 +13,15 @@
 #define _bits_h_
 
 #ifndef json_min
-#define json_min(a,b) ((a) < (b) ? (a) : (b))
+#define json_min(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
 #ifndef json_max
-#define json_max(a,b) ((a) > (b) ? (a) : (b))
+#define json_max(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
 #define hexdigit(x) (((x) <= '9') ? (x) - '0' : ((x) & 7) + 9)
-#define error_ptr(error) ((void*)error)
+#define error_ptr(error) ((void *)error)
 #define is_error(ptr) ((unsigned long)ptr > (unsigned long)-4000L)
 
 #endif

--- a/src/json-c/debug.c
+++ b/src/json-c/debug.c
@@ -17,11 +17,11 @@
 #include <stdarg.h>
 
 #if HAVE_SYSLOG_H
-# include <syslog.h>
+#include <syslog.h>
 #endif /* HAVE_SYSLOG_H */
 
 #if HAVE_UNISTD_H
-# include <unistd.h>
+#include <unistd.h>
 #endif /* HAVE_UNISTD_H */
 
 #if HAVE_SYS_PARAM_H
@@ -33,66 +33,71 @@
 static int _syslog = 0;
 static int _debug = 0;
 
-void mc_set_debug(int debug) { _debug = debug; }
-int mc_get_debug(void) { return _debug; }
+void mc_set_debug(int debug)
+{
+	_debug = debug;
+}
+int mc_get_debug(void)
+{
+	return _debug;
+}
 
 extern void mc_set_syslog(int syslog)
 {
-  _syslog = syslog;
+	_syslog = syslog;
 }
 
 void mc_abort(const char *msg, ...)
 {
-  va_list ap;
-  va_start(ap, msg);
+	va_list ap;
+	va_start(ap, msg);
 #if HAVE_VSYSLOG
-  if(_syslog) {
-	  vsyslog(LOG_ERR, msg, ap);
-  } else
-#endif
-	  vprintf(msg, ap);
-  va_end(ap);
-  exit(1);
-}
-
-
-void mc_debug(const char *msg, ...)
-{
-  va_list ap;
-  if(_debug) {
-    va_start(ap, msg);
-#if HAVE_VSYSLOG
-    if(_syslog) {
-		vsyslog(LOG_DEBUG, msg, ap);
+	if (_syslog) {
+		vsyslog(LOG_ERR, msg, ap);
 	} else
 #endif
 		vprintf(msg, ap);
-    va_end(ap);
-  }
+	va_end(ap);
+	exit(1);
+}
+
+void mc_debug(const char *msg, ...)
+{
+	va_list ap;
+	if (_debug) {
+		va_start(ap, msg);
+#if HAVE_VSYSLOG
+		if (_syslog) {
+			vsyslog(LOG_DEBUG, msg, ap);
+		} else
+#endif
+			vprintf(msg, ap);
+		va_end(ap);
+	}
 }
 
 void mc_error(const char *msg, ...)
 {
-  va_list ap;
-  va_start(ap, msg);
+	va_list ap;
+	va_start(ap, msg);
 #if HAVE_VSYSLOG
-    if(_syslog) {
+	if (_syslog) {
 		vsyslog(LOG_ERR, msg, ap);
 	} else
 #endif
 		vfprintf(stderr, msg, ap);
-  va_end(ap);
+	va_end(ap);
 }
 
 void mc_info(const char *msg, ...)
 {
-  va_list ap;
-  va_start(ap, msg);
+	va_list ap;
+	va_start(ap, msg);
 #if HAVE_VSYSLOG
-    if(_syslog) {
+	if (_syslog) {
 		vsyslog(LOG_INFO, msg, ap);
-	} else 
+	} else
 #endif
 		vfprintf(stderr, msg, ap);
-  va_end(ap);
+	va_end(ap);
 }

--- a/src/json-c/debug.h
+++ b/src/json-c/debug.h
@@ -34,13 +34,25 @@ extern void mc_info(const char *msg, ...);
 #define MC_ERROR(x, ...) mc_error(x, ##__VA_ARGS__)
 #define MC_INFO(x, ...) mc_info(x, ##__VA_ARGS__)
 #else
-#define MC_SET_DEBUG(x) if (0) mc_set_debug(x)
+#define MC_SET_DEBUG(x)                                                        \
+	if (0)                                                                     \
+	mc_set_debug(x)
 #define MC_GET_DEBUG() (0)
-#define MC_SET_SYSLOG(x) if (0) mc_set_syslog(x)
-#define MC_ABORT(x, ...) if (0) mc_abort(x, ##__VA_ARGS__)
-#define MC_DEBUG(x, ...) if (0) mc_debug(x, ##__VA_ARGS__)
-#define MC_ERROR(x, ...) if (0) mc_error(x, ##__VA_ARGS__)
-#define MC_INFO(x, ...) if (0) mc_info(x, ##__VA_ARGS__)
+#define MC_SET_SYSLOG(x)                                                       \
+	if (0)                                                                     \
+	mc_set_syslog(x)
+#define MC_ABORT(x, ...)                                                       \
+	if (0)                                                                     \
+	mc_abort(x, ##__VA_ARGS__)
+#define MC_DEBUG(x, ...)                                                       \
+	if (0)                                                                     \
+	mc_debug(x, ##__VA_ARGS__)
+#define MC_ERROR(x, ...)                                                       \
+	if (0)                                                                     \
+	mc_error(x, ##__VA_ARGS__)
+#define MC_INFO(x, ...)                                                        \
+	if (0)                                                                     \
+	mc_info(x, ##__VA_ARGS__)
 #endif
 
 #ifdef __cplusplus

--- a/src/json-c/json_object.c
+++ b/src/json-c/json_object.c
@@ -24,7 +24,7 @@
 #include "json_object_private.h"
 
 #if !HAVE_STRNDUP
-  char* strndup(const char* str, size_t n);
+char *strndup(const char *str, size_t n);
 #endif /* !HAVE_STRNDUP */
 
 /* #define REFCOUNT_DEBUG 1 */
@@ -33,20 +33,13 @@ const char *json_number_chars = "0123456789.+-eE";
 const char *json_hex_chars = "0123456789abcdef";
 
 #ifdef REFCOUNT_DEBUG
-static const char* json_type_name[] = {
-  "null",
-  "boolean",
-  "double",
-  "int",
-  "object",
-  "array",
-  "string",
+static const char *json_type_name[] = {
+	"null", "boolean", "double", "int", "object", "array", "string",
 };
 #endif /* REFCOUNT_DEBUG */
 
-static void json_object_generic_delete(struct json_object* jso);
-static struct json_object* json_object_new(enum json_type o_type);
-
+static void json_object_generic_delete(struct json_object *jso);
+static struct json_object *json_object_new(enum json_type o_type);
 
 /* ref count debugging */
 
@@ -54,459 +47,497 @@ static struct json_object* json_object_new(enum json_type o_type);
 
 static struct lh_table *json_object_table;
 
-static void json_object_init(void) __attribute__ ((constructor));
-static void json_object_init(void) {
-  MC_DEBUG("json_object_init: creating object table\n");
-  json_object_table = lh_kptr_table_new(128, "json_object_table", NULL);
+static void json_object_init(void) __attribute__((constructor));
+static void json_object_init(void)
+{
+	MC_DEBUG("json_object_init: creating object table\n");
+	json_object_table = lh_kptr_table_new(128, "json_object_table", NULL);
 }
 
-static void json_object_fini(void) __attribute__ ((destructor));
-static void json_object_fini(void) {
-  struct lh_entry *ent;
-  if(MC_GET_DEBUG()) {
-    if (json_object_table->count) {
-      MC_DEBUG("json_object_fini: %d referenced objects at exit\n",
-  	       json_object_table->count);
-      lh_foreach(json_object_table, ent) {
-        struct json_object* obj = (struct json_object*)ent->v;
-        MC_DEBUG("\t%s:%p\n", json_type_name[obj->o_type], obj);
-      }
-    }
-  }
-  MC_DEBUG("json_object_fini: freeing object table\n");
-  lh_table_free(json_object_table);
+static void json_object_fini(void) __attribute__((destructor));
+static void json_object_fini(void)
+{
+	struct lh_entry *ent;
+	if (MC_GET_DEBUG()) {
+		if (json_object_table->count) {
+			MC_DEBUG(
+				"json_object_fini: %d referenced objects at exit\n",
+				json_object_table->count);
+			lh_foreach(json_object_table, ent)
+			{
+				struct json_object *obj = (struct json_object *)ent->v;
+				MC_DEBUG("\t%s:%p\n", json_type_name[obj->o_type], obj);
+			}
+		}
+	}
+	MC_DEBUG("json_object_fini: freeing object table\n");
+	lh_table_free(json_object_table);
 }
 #endif /* REFCOUNT_DEBUG */
-
 
 /* string escaping */
 
 static int json_escape_str(struct printbuf *pb, char *str)
 {
-  int pos = 0, start_offset = 0;
-  unsigned char c;
-  do {
-    c = str[pos];
-    switch(c) {
-    case '\0':
-      break;
-    case '\b':
-    case '\n':
-    case '\r':
-    case '\t':
-    case '"':
-    case '\\':
-    case '/':
-      if(pos - start_offset > 0)
-	printbuf_memappend(pb, str + start_offset, pos - start_offset);
-      if(c == '\b') printbuf_memappend(pb, "\\b", 2);
-      else if(c == '\n') printbuf_memappend(pb, "\\n", 2);
-      else if(c == '\r') printbuf_memappend(pb, "\\r", 2);
-      else if(c == '\t') printbuf_memappend(pb, "\\t", 2);
-      else if(c == '"') printbuf_memappend(pb, "\\\"", 2);
-      else if(c == '\\') printbuf_memappend(pb, "\\\\", 2);
-      else if(c == '/') printbuf_memappend(pb, "\\/", 2);
-      start_offset = ++pos;
-      break;
-    default:
-      if(c < ' ') {
-	if(pos - start_offset > 0)
-	  printbuf_memappend(pb, str + start_offset, pos - start_offset);
-	sprintbuf(pb, "\\u00%c%c",
-		  json_hex_chars[c >> 4],
-		  json_hex_chars[c & 0xf]);
-	start_offset = ++pos;
-      } else pos++;
-    }
-  } while(c);
-  if(pos - start_offset > 0)
-    printbuf_memappend(pb, str + start_offset, pos - start_offset);
-  return 0;
+	int pos = 0, start_offset = 0;
+	unsigned char c;
+	do {
+		c = str[pos];
+		switch (c) {
+		case '\0':
+			break;
+		case '\b':
+		case '\n':
+		case '\r':
+		case '\t':
+		case '"':
+		case '\\':
+		case '/':
+			if (pos - start_offset > 0)
+				printbuf_memappend(pb, str + start_offset, pos - start_offset);
+			if (c == '\b')
+				printbuf_memappend(pb, "\\b", 2);
+			else if (c == '\n')
+				printbuf_memappend(pb, "\\n", 2);
+			else if (c == '\r')
+				printbuf_memappend(pb, "\\r", 2);
+			else if (c == '\t')
+				printbuf_memappend(pb, "\\t", 2);
+			else if (c == '"')
+				printbuf_memappend(pb, "\\\"", 2);
+			else if (c == '\\')
+				printbuf_memappend(pb, "\\\\", 2);
+			else if (c == '/')
+				printbuf_memappend(pb, "\\/", 2);
+			start_offset = ++pos;
+			break;
+		default:
+			if (c < ' ') {
+				if (pos - start_offset > 0)
+					printbuf_memappend(
+						pb,
+						str + start_offset,
+						pos - start_offset);
+				sprintbuf(
+					pb,
+					"\\u00%c%c",
+					json_hex_chars[c >> 4],
+					json_hex_chars[c & 0xf]);
+				start_offset = ++pos;
+			} else
+				pos++;
+		}
+	} while (c);
+	if (pos - start_offset > 0)
+		printbuf_memappend(pb, str + start_offset, pos - start_offset);
+	return 0;
 }
-
 
 /* reference counting */
 
-extern struct json_object* json_object_get(struct json_object *jso)
+extern struct json_object *json_object_get(struct json_object *jso)
 {
-  if(jso) {
-    jso->_ref_count++;
-  }
-  return jso;
+	if (jso) {
+		jso->_ref_count++;
+	}
+	return jso;
 }
 
 extern void json_object_put(struct json_object *jso)
 {
-  if(jso) {
-    jso->_ref_count--;
-    if(!jso->_ref_count) jso->_delete(jso);
-  }
+	if (jso) {
+		jso->_ref_count--;
+		if (!jso->_ref_count)
+			jso->_delete(jso);
+	}
 }
-
 
 /* generic object construction and destruction parts */
 
-static void json_object_generic_delete(struct json_object* jso)
+static void json_object_generic_delete(struct json_object *jso)
 {
 #ifdef REFCOUNT_DEBUG
-  MC_DEBUG("json_object_delete_%s: %p\n",
-	   json_type_name[jso->o_type], jso);
-  lh_table_delete(json_object_table, jso);
+	MC_DEBUG("json_object_delete_%s: %p\n", json_type_name[jso->o_type], jso);
+	lh_table_delete(json_object_table, jso);
 #endif /* REFCOUNT_DEBUG */
-  printbuf_free(jso->_pb);
-  free(jso);
+	printbuf_free(jso->_pb);
+	free(jso);
 }
 
-static struct json_object* json_object_new(enum json_type o_type)
+static struct json_object *json_object_new(enum json_type o_type)
 {
-  struct json_object *jso;
+	struct json_object *jso;
 
-  jso = (struct json_object*)calloc(sizeof(struct json_object), 1);
-  if(!jso) return NULL;
-  jso->o_type = o_type;
-  jso->_ref_count = 1;
-  jso->_delete = &json_object_generic_delete;
+	jso = (struct json_object *)calloc(sizeof(struct json_object), 1);
+	if (!jso)
+		return NULL;
+	jso->o_type = o_type;
+	jso->_ref_count = 1;
+	jso->_delete = &json_object_generic_delete;
 #ifdef REFCOUNT_DEBUG
-  lh_table_insert(json_object_table, jso, jso);
-  MC_DEBUG("json_object_new_%s: %p\n", json_type_name[jso->o_type], jso);
+	lh_table_insert(json_object_table, jso, jso);
+	MC_DEBUG("json_object_new_%s: %p\n", json_type_name[jso->o_type], jso);
 #endif /* REFCOUNT_DEBUG */
-  return jso;
+	return jso;
 }
-
 
 /* type checking functions */
 
 int json_object_is_type(struct json_object *jso, enum json_type type)
 {
-  return (jso->o_type == type);
+	return (jso->o_type == type);
 }
 
 enum json_type json_object_get_type(struct json_object *jso)
 {
-  return jso->o_type;
+	return jso->o_type;
 }
-
 
 /* json_object_to_json_string */
 
-const char* json_object_to_json_string(struct json_object *jso)
+const char *json_object_to_json_string(struct json_object *jso)
 {
-  if(!jso) return "null";
-  if(!jso->_pb) {
-    if(!(jso->_pb = printbuf_new())) return NULL;
-  } else {
-    printbuf_reset(jso->_pb);
-  }
-  if(jso->_to_json_string(jso, jso->_pb) < 0) return NULL;
-  return jso->_pb->buf;
+	if (!jso)
+		return "null";
+	if (!jso->_pb) {
+		if (!(jso->_pb = printbuf_new()))
+			return NULL;
+	} else {
+		printbuf_reset(jso->_pb);
+	}
+	if (jso->_to_json_string(jso, jso->_pb) < 0)
+		return NULL;
+	return jso->_pb->buf;
 }
-
 
 /* json_object_object */
 
-static int json_object_object_to_json_string(struct json_object* jso,
-					     struct printbuf *pb)
+static int
+json_object_object_to_json_string(struct json_object *jso, struct printbuf *pb)
 {
-  int i=0;
-  struct json_object_iter iter;
-  sprintbuf(pb, "{");
+	int i = 0;
+	struct json_object_iter iter;
+	sprintbuf(pb, "{");
 
-  /* CAW: scope operator to make ANSI correctness */
-  /* CAW: switched to json_object_object_foreachC which uses an iterator struct */
-	json_object_object_foreachC(jso, iter) {
-			if(i) sprintbuf(pb, ",");
-			sprintbuf(pb, " \"");
-			json_escape_str(pb, iter.key);
-			sprintbuf(pb, "\": ");
-			if(iter.val == NULL) sprintbuf(pb, "null");
-			else iter.val->_to_json_string(iter.val, pb);
-			i++;
+	/* CAW: scope operator to make ANSI correctness */
+	/* CAW: switched to json_object_object_foreachC which uses an iterator struct */
+	json_object_object_foreachC(jso, iter)
+	{
+		if (i)
+			sprintbuf(pb, ",");
+		sprintbuf(pb, " \"");
+		json_escape_str(pb, iter.key);
+		sprintbuf(pb, "\": ");
+		if (iter.val == NULL)
+			sprintbuf(pb, "null");
+		else
+			iter.val->_to_json_string(iter.val, pb);
+		i++;
 	}
 
-  return sprintbuf(pb, " }");
+	return sprintbuf(pb, " }");
 }
 
 static void json_object_lh_entry_free(struct lh_entry *ent)
 {
-  free(ent->k);
-  json_object_put((struct json_object*)ent->v);
+	free(ent->k);
+	json_object_put((struct json_object *)ent->v);
 }
 
-static void json_object_object_delete(struct json_object* jso)
+static void json_object_object_delete(struct json_object *jso)
 {
-  lh_table_free(jso->o.c_object);
-  json_object_generic_delete(jso);
+	lh_table_free(jso->o.c_object);
+	json_object_generic_delete(jso);
 }
 
-struct json_object* json_object_new_object(void)
+struct json_object *json_object_new_object(void)
 {
-  struct json_object *jso = json_object_new(json_type_object);
-  if(!jso) return NULL;
-  jso->_delete = &json_object_object_delete;
-  jso->_to_json_string = &json_object_object_to_json_string;
-  jso->o.c_object = lh_kchar_table_new(JSON_OBJECT_DEF_HASH_ENTRIES,
-					NULL, &json_object_lh_entry_free);
-  return jso;
+	struct json_object *jso = json_object_new(json_type_object);
+	if (!jso)
+		return NULL;
+	jso->_delete = &json_object_object_delete;
+	jso->_to_json_string = &json_object_object_to_json_string;
+	jso->o.c_object = lh_kchar_table_new(
+		JSON_OBJECT_DEF_HASH_ENTRIES,
+		NULL,
+		&json_object_lh_entry_free);
+	return jso;
 }
 
-struct lh_table* json_object_get_object(struct json_object *jso)
+struct lh_table *json_object_get_object(struct json_object *jso)
 {
-  if(!jso) return NULL;
-  switch(jso->o_type) {
-  case json_type_object:
-    return jso->o.c_object;
-  default:
-    return NULL;
-  }
+	if (!jso)
+		return NULL;
+	switch (jso->o_type) {
+	case json_type_object:
+		return jso->o.c_object;
+	default:
+		return NULL;
+	}
 }
 
-void json_object_object_add(struct json_object* jso, const char *key,
-			    struct json_object *val)
+void json_object_object_add(
+	struct json_object *jso, const char *key, struct json_object *val)
 {
-  lh_table_delete(jso->o.c_object, key);
-  lh_table_insert(jso->o.c_object, strdup(key), val);
+	lh_table_delete(jso->o.c_object, key);
+	lh_table_insert(jso->o.c_object, strdup(key), val);
 }
 
-struct json_object* json_object_object_get(struct json_object* jso, const char *key)
+struct json_object *
+json_object_object_get(struct json_object *jso, const char *key)
 {
-  return (struct json_object*) lh_table_lookup(jso->o.c_object, key);
+	return (struct json_object *)lh_table_lookup(jso->o.c_object, key);
 }
 
-void json_object_object_del(struct json_object* jso, const char *key)
+void json_object_object_del(struct json_object *jso, const char *key)
 {
-  lh_table_delete(jso->o.c_object, key);
+	lh_table_delete(jso->o.c_object, key);
 }
-
 
 /* json_object_boolean */
 
-static int json_object_boolean_to_json_string(struct json_object* jso,
-					      struct printbuf *pb)
+static int
+json_object_boolean_to_json_string(struct json_object *jso, struct printbuf *pb)
 {
-  if(jso->o.c_boolean) return sprintbuf(pb, "true");
-  else return sprintbuf(pb, "false");
+	if (jso->o.c_boolean)
+		return sprintbuf(pb, "true");
+	else
+		return sprintbuf(pb, "false");
 }
 
-struct json_object* json_object_new_boolean(boolean b)
+struct json_object *json_object_new_boolean(boolean b)
 {
-  struct json_object *jso = json_object_new(json_type_boolean);
-  if(!jso) return NULL;
-  jso->_to_json_string = &json_object_boolean_to_json_string;
-  jso->o.c_boolean = b;
-  return jso;
+	struct json_object *jso = json_object_new(json_type_boolean);
+	if (!jso)
+		return NULL;
+	jso->_to_json_string = &json_object_boolean_to_json_string;
+	jso->o.c_boolean = b;
+	return jso;
 }
 
 boolean json_object_get_boolean(struct json_object *jso)
 {
-  if(!jso) return FALSE;
-  switch(jso->o_type) {
-  case json_type_boolean:
-    return jso->o.c_boolean;
-  case json_type_int:
-    return (jso->o.c_int != 0);
-  case json_type_double:
-    return (jso->o.c_double != 0);
-  case json_type_string:
-    return (strlen(jso->o.c_string) != 0);
-  default:
-    return FALSE;
-  }
+	if (!jso)
+		return FALSE;
+	switch (jso->o_type) {
+	case json_type_boolean:
+		return jso->o.c_boolean;
+	case json_type_int:
+		return (jso->o.c_int != 0);
+	case json_type_double:
+		return (jso->o.c_double != 0);
+	case json_type_string:
+		return (strlen(jso->o.c_string) != 0);
+	default:
+		return FALSE;
+	}
 }
-
 
 /* json_object_int */
 
-static int json_object_int_to_json_string(struct json_object* jso,
-					  struct printbuf *pb)
+static int
+json_object_int_to_json_string(struct json_object *jso, struct printbuf *pb)
 {
-  return sprintbuf(pb, "%d", jso->o.c_int);
+	return sprintbuf(pb, "%d", jso->o.c_int);
 }
 
-struct json_object* json_object_new_int(int i)
+struct json_object *json_object_new_int(int i)
 {
-  struct json_object *jso = json_object_new(json_type_int);
-  if(!jso) return NULL;
-  jso->_to_json_string = &json_object_int_to_json_string;
-  jso->o.c_int = i;
-  return jso;
+	struct json_object *jso = json_object_new(json_type_int);
+	if (!jso)
+		return NULL;
+	jso->_to_json_string = &json_object_int_to_json_string;
+	jso->o.c_int = i;
+	return jso;
 }
 
 int json_object_get_int(struct json_object *jso)
 {
-  int cint;
+	int cint;
 
-  if(!jso) return 0;
-  switch(jso->o_type) {
-  case json_type_int:
-    return jso->o.c_int;
-  case json_type_double:
-    return (int)jso->o.c_double;
-  case json_type_boolean:
-    return jso->o.c_boolean;
-  case json_type_string:
-    if(sscanf(jso->o.c_string, "%d", &cint) == 1) return cint;
-  default:
-    return 0;
-  }
+	if (!jso)
+		return 0;
+	switch (jso->o_type) {
+	case json_type_int:
+		return jso->o.c_int;
+	case json_type_double:
+		return (int)jso->o.c_double;
+	case json_type_boolean:
+		return jso->o.c_boolean;
+	case json_type_string:
+		if (sscanf(jso->o.c_string, "%d", &cint) == 1)
+			return cint;
+	default:
+		return 0;
+	}
 }
-
 
 /* json_object_double */
 
-static int json_object_double_to_json_string(struct json_object* jso,
-					     struct printbuf *pb)
+static int
+json_object_double_to_json_string(struct json_object *jso, struct printbuf *pb)
 {
-  return sprintbuf(pb, "%lf", jso->o.c_double);
+	return sprintbuf(pb, "%lf", jso->o.c_double);
 }
 
-struct json_object* json_object_new_double(double d)
+struct json_object *json_object_new_double(double d)
 {
-  struct json_object *jso = json_object_new(json_type_double);
-  if(!jso) return NULL;
-  jso->_to_json_string = &json_object_double_to_json_string;
-  jso->o.c_double = d;
-  return jso;
+	struct json_object *jso = json_object_new(json_type_double);
+	if (!jso)
+		return NULL;
+	jso->_to_json_string = &json_object_double_to_json_string;
+	jso->o.c_double = d;
+	return jso;
 }
 
 double json_object_get_double(struct json_object *jso)
 {
-  double cdouble;
+	double cdouble;
 
-  if(!jso) return 0.0;
-  switch(jso->o_type) {
-  case json_type_double:
-    return jso->o.c_double;
-  case json_type_int:
-    return jso->o.c_int;
-  case json_type_boolean:
-    return jso->o.c_boolean;
-  case json_type_string:
-    if(sscanf(jso->o.c_string, "%lf", &cdouble) == 1) return cdouble;
-  default:
-    return 0.0;
-  }
+	if (!jso)
+		return 0.0;
+	switch (jso->o_type) {
+	case json_type_double:
+		return jso->o.c_double;
+	case json_type_int:
+		return jso->o.c_int;
+	case json_type_boolean:
+		return jso->o.c_boolean;
+	case json_type_string:
+		if (sscanf(jso->o.c_string, "%lf", &cdouble) == 1)
+			return cdouble;
+	default:
+		return 0.0;
+	}
 }
-
 
 /* json_object_string */
 
-static int json_object_string_to_json_string(struct json_object* jso,
-					     struct printbuf *pb)
+static int
+json_object_string_to_json_string(struct json_object *jso, struct printbuf *pb)
 {
-  sprintbuf(pb, "\"");
-  json_escape_str(pb, jso->o.c_string);
-  sprintbuf(pb, "\"");
-  return 0;
+	sprintbuf(pb, "\"");
+	json_escape_str(pb, jso->o.c_string);
+	sprintbuf(pb, "\"");
+	return 0;
 }
 
-static void json_object_string_delete(struct json_object* jso)
+static void json_object_string_delete(struct json_object *jso)
 {
-  free(jso->o.c_string);
-  json_object_generic_delete(jso);
+	free(jso->o.c_string);
+	json_object_generic_delete(jso);
 }
 
-struct json_object* json_object_new_string(const char *s)
+struct json_object *json_object_new_string(const char *s)
 {
-  struct json_object *jso = json_object_new(json_type_string);
-  if(!jso) return NULL;
-  jso->_delete = &json_object_string_delete;
-  jso->_to_json_string = &json_object_string_to_json_string;
-  jso->o.c_string = strdup(s);
-  return jso;
+	struct json_object *jso = json_object_new(json_type_string);
+	if (!jso)
+		return NULL;
+	jso->_delete = &json_object_string_delete;
+	jso->_to_json_string = &json_object_string_to_json_string;
+	jso->o.c_string = strdup(s);
+	return jso;
 }
 
-struct json_object* json_object_new_string_len(const char *s, int len)
+struct json_object *json_object_new_string_len(const char *s, int len)
 {
-  struct json_object *jso = json_object_new(json_type_string);
-  if(!jso) return NULL;
-  jso->_delete = &json_object_string_delete;
-  jso->_to_json_string = &json_object_string_to_json_string;
-  jso->o.c_string = strndup(s, len);
-  return jso;
+	struct json_object *jso = json_object_new(json_type_string);
+	if (!jso)
+		return NULL;
+	jso->_delete = &json_object_string_delete;
+	jso->_to_json_string = &json_object_string_to_json_string;
+	jso->o.c_string = strndup(s, len);
+	return jso;
 }
 
-const char* json_object_get_string(struct json_object *jso)
+const char *json_object_get_string(struct json_object *jso)
 {
-  if(!jso) return NULL;
-  switch(jso->o_type) {
-  case json_type_string:
-    return jso->o.c_string;
-  default:
-    return json_object_to_json_string(jso);
-  }
+	if (!jso)
+		return NULL;
+	switch (jso->o_type) {
+	case json_type_string:
+		return jso->o.c_string;
+	default:
+		return json_object_to_json_string(jso);
+	}
 }
-
 
 /* json_object_array */
 
-static int json_object_array_to_json_string(struct json_object* jso,
-					    struct printbuf *pb)
+static int
+json_object_array_to_json_string(struct json_object *jso, struct printbuf *pb)
 {
-  int i;
-  sprintbuf(pb, "[");
-  for(i=0; i < json_object_array_length(jso); i++) {
-	  struct json_object *val;
-	  if(i) { sprintbuf(pb, ", "); }
-	  else { sprintbuf(pb, " "); }
+	int i;
+	sprintbuf(pb, "[");
+	for (i = 0; i < json_object_array_length(jso); i++) {
+		struct json_object *val;
+		if (i) {
+			sprintbuf(pb, ", ");
+		} else {
+			sprintbuf(pb, " ");
+		}
 
-      val = json_object_array_get_idx(jso, i);
-	  if(val == NULL) { sprintbuf(pb, "null"); }
-	  else { val->_to_json_string(val, pb); }
-  }
-  return sprintbuf(pb, " ]");
+		val = json_object_array_get_idx(jso, i);
+		if (val == NULL) {
+			sprintbuf(pb, "null");
+		} else {
+			val->_to_json_string(val, pb);
+		}
+	}
+	return sprintbuf(pb, " ]");
 }
 
 static void json_object_array_entry_free(void *data)
 {
-  json_object_put((struct json_object*)data);
+	json_object_put((struct json_object *)data);
 }
 
-static void json_object_array_delete(struct json_object* jso)
+static void json_object_array_delete(struct json_object *jso)
 {
-  array_list_free(jso->o.c_array);
-  json_object_generic_delete(jso);
+	array_list_free(jso->o.c_array);
+	json_object_generic_delete(jso);
 }
 
-struct json_object* json_object_new_array(void)
+struct json_object *json_object_new_array(void)
 {
-  struct json_object *jso = json_object_new(json_type_array);
-  if(!jso) return NULL;
-  jso->_delete = &json_object_array_delete;
-  jso->_to_json_string = &json_object_array_to_json_string;
-  jso->o.c_array = array_list_new(&json_object_array_entry_free);
-  return jso;
+	struct json_object *jso = json_object_new(json_type_array);
+	if (!jso)
+		return NULL;
+	jso->_delete = &json_object_array_delete;
+	jso->_to_json_string = &json_object_array_to_json_string;
+	jso->o.c_array = array_list_new(&json_object_array_entry_free);
+	return jso;
 }
 
-struct array_list* json_object_get_array(struct json_object *jso)
+struct array_list *json_object_get_array(struct json_object *jso)
 {
-  if(!jso) return NULL;
-  switch(jso->o_type) {
-  case json_type_array:
-    return jso->o.c_array;
-  default:
-    return NULL;
-  }
+	if (!jso)
+		return NULL;
+	switch (jso->o_type) {
+	case json_type_array:
+		return jso->o.c_array;
+	default:
+		return NULL;
+	}
 }
 
 int json_object_array_length(struct json_object *jso)
 {
-  return array_list_length(jso->o.c_array);
+	return array_list_length(jso->o.c_array);
 }
 
-int json_object_array_add(struct json_object *jso,struct json_object *val)
+int json_object_array_add(struct json_object *jso, struct json_object *val)
 {
-  return array_list_add(jso->o.c_array, val);
+	return array_list_add(jso->o.c_array, val);
 }
 
-int json_object_array_put_idx(struct json_object *jso, int idx,
-			      struct json_object *val)
+int json_object_array_put_idx(
+	struct json_object *jso, int idx, struct json_object *val)
 {
-  return array_list_put_idx(jso->o.c_array, idx, val);
+	return array_list_put_idx(jso->o.c_array, idx, val);
 }
 
-struct json_object* json_object_array_get_idx(struct json_object *jso,
-					      int idx)
+struct json_object *json_object_array_get_idx(struct json_object *jso, int idx)
 {
-  return (struct json_object*)array_list_get_idx(jso->o.c_array, idx);
+	return (struct json_object *)array_list_get_idx(jso->o.c_array, idx);
 }
-

--- a/src/json-c/json_object.h
+++ b/src/json-c/json_object.h
@@ -40,13 +40,13 @@ typedef struct json_tokener json_tokener;
 /* supported object types */
 
 typedef enum json_type {
-  json_type_null,
-  json_type_boolean,
-  json_type_double,
-  json_type_int,
-  json_type_object,
-  json_type_array,
-  json_type_string
+	json_type_null,
+	json_type_boolean,
+	json_type_double,
+	json_type_int,
+	json_type_object,
+	json_type_array,
+	json_type_string
 } json_type;
 
 /* reference counting functions */
@@ -55,14 +55,13 @@ typedef enum json_type {
  * Increment the reference count of json_object
  * @param obj the json_object instance
  */
-extern struct json_object* json_object_get(struct json_object *obj);
+extern struct json_object *json_object_get(struct json_object *obj);
 
 /**
  * Decrement the reference count of json_object and free if it reaches zero
  * @param obj the json_object instance
  */
 extern void json_object_put(struct json_object *obj);
-
 
 /**
  * Check if the json_object is of a given type
@@ -90,26 +89,24 @@ extern int json_object_is_type(struct json_object *obj, enum json_type type);
  */
 extern enum json_type json_object_get_type(struct json_object *obj);
 
-
 /** Stringify object to json format
  * @param obj the json_object instance
  * @returns a string in JSON format
  */
-extern const char* json_object_to_json_string(struct json_object *obj);
-
+extern const char *json_object_to_json_string(struct json_object *obj);
 
 /* object type methods */
 
 /** Create a new empty object
  * @returns a json_object of type json_type_object
  */
-extern struct json_object* json_object_new_object(void);
+extern struct json_object *json_object_new_object(void);
 
 /** Get the hashtable of a json_object of type json_type_object
  * @param obj the json_object instance
  * @returns a linkhash
  */
-extern struct lh_table* json_object_get_object(struct json_object *obj);
+extern struct lh_table *json_object_get_object(struct json_object *obj);
 
 /** Add an object field to a json_object of type json_type_object
  *
@@ -121,16 +118,16 @@ extern struct lh_table* json_object_get_object(struct json_object *obj);
  * @param key the object field name (a private copy will be duplicated)
  * @param val a json_object or NULL member to associate with the given field
  */
-extern void json_object_object_add(struct json_object* obj, const char *key,
-				   struct json_object *val);
+extern void json_object_object_add(
+	struct json_object *obj, const char *key, struct json_object *val);
 
 /** Get the json_object associate with a given object field
  * @param obj the json_object instance
  * @param key the object field name
  * @returns the json_object associated with the given field name
  */
-extern struct json_object* json_object_object_get(struct json_object* obj,
-						  const char *key);
+extern struct json_object *
+json_object_object_get(struct json_object *obj, const char *key);
 
 /** Delete the given json_object field
  *
@@ -139,7 +136,7 @@ extern struct json_object* json_object_object_get(struct json_object* obj,
  * @param obj the json_object instance
  * @param key the object field name
  */
-extern void json_object_object_del(struct json_object* obj, const char *key);
+extern void json_object_object_del(struct json_object *obj, const char *key);
 
 /** Iterate through all keys and values of an object
  * @param obj the json_object instance
@@ -148,15 +145,31 @@ extern void json_object_object_del(struct json_object* obj, const char *key);
  */
 #if defined(__GNUC__) && !defined(__STRICT_ANSI__)
 
-# define json_object_object_foreach(obj,key,val) \
- char *key; struct json_object *val; \
- for(struct lh_entry *entry = json_object_get_object(obj)->head; ({ if(entry) { key = (char*)entry->k; val = (struct json_object*)entry->v; } ; entry; }); entry = entry->next )
+#define json_object_object_foreach(obj, key, val)                              \
+	char *key;                                                                 \
+	struct json_object *val;                                                   \
+	for (struct lh_entry *entry = json_object_get_object(obj)->head; ({        \
+			 if (entry) {                                                      \
+				 key = (char *)entry->k;                                       \
+				 val = (struct json_object *)entry->v;                         \
+			 };                                                                \
+			 entry;                                                            \
+		 });                                                                   \
+		 entry = entry->next)
 
 #else /* ANSI C or MSC */
 
-# define json_object_object_foreach(obj,key,val) \
- char *key; struct json_object *val; struct lh_entry *entry; \
- for(entry = json_object_get_object(obj)->head; (entry ? (key = (char*)entry->k, val = (struct json_object*)entry->v, entry) : 0); entry = entry->next)
+#define json_object_object_foreach(obj, key, val)                              \
+	char *key;                                                                 \
+	struct json_object *val;                                                   \
+	struct lh_entry *entry;                                                    \
+	for (entry = json_object_get_object(obj)->head;                            \
+		 (entry                                                                \
+			  ? (key = (char *)entry->k,                                       \
+				val = (struct json_object *)entry->v,                          \
+				entry)                                                         \
+			  : 0);                                                            \
+		 entry = entry->next)
 
 #endif /* defined(__GNUC__) && !defined(__STRICT_ANSI__) */
 
@@ -164,21 +177,27 @@ extern void json_object_object_del(struct json_object* obj, const char *key);
  * @param obj the json_object instance
  * @param iter the object iterator
  */
-#define json_object_object_foreachC(obj,iter) \
- for(iter.entry = json_object_get_object(obj)->head; (iter.entry ? (iter.key = (char*)iter.entry->k, iter.val = (struct json_object*)iter.entry->v, iter.entry) : 0); iter.entry = iter.entry->next)
+#define json_object_object_foreachC(obj, iter)                                 \
+	for (iter.entry = json_object_get_object(obj)->head;                       \
+		 (iter.entry                                                           \
+			  ? (iter.key = (char *)iter.entry->k,                             \
+				iter.val = (struct json_object *)iter.entry->v,                \
+				iter.entry)                                                    \
+			  : 0);                                                            \
+		 iter.entry = iter.entry->next)
 
 /* Array type methods */
 
 /** Create a new empty json_object of type json_type_array
  * @returns a json_object of type json_type_array
  */
-extern struct json_object* json_object_new_array(void);
+extern struct json_object *json_object_new_array(void);
 
 /** Get the arraylist of a json_object of type json_type_array
  * @param obj the json_object instance
  * @returns an arraylist
  */
-extern struct array_list* json_object_get_array(struct json_object *obj);
+extern struct array_list *json_object_get_array(struct json_object *obj);
 
 /** Get the length of a json_object of type json_type_array
  * @param obj the json_object instance
@@ -195,8 +214,8 @@ extern int json_object_array_length(struct json_object *obj);
  * @param obj the json_object instance
  * @param val the json_object to be added
  */
-extern int json_object_array_add(struct json_object *obj,
-				 struct json_object *val);
+extern int
+json_object_array_add(struct json_object *obj, struct json_object *val);
 
 /** Insert or replace an element at a specified index in an array (a json_object of type json_type_array)
  *
@@ -213,16 +232,16 @@ extern int json_object_array_add(struct json_object *obj,
  * @param idx the index to insert the element at
  * @param val the json_object to be added
  */
-extern int json_object_array_put_idx(struct json_object *obj, int idx,
-				     struct json_object *val);
+extern int json_object_array_put_idx(
+	struct json_object *obj, int idx, struct json_object *val);
 
 /** Get the element at specificed index of the array (a json_object of type json_type_array)
  * @param obj the json_object instance
  * @param idx the index to get the element at
  * @returns the json_object at the specified index (or NULL)
  */
-extern struct json_object* json_object_array_get_idx(struct json_object *obj,
-						     int idx);
+extern struct json_object *
+json_object_array_get_idx(struct json_object *obj, int idx);
 
 /* boolean type methods */
 
@@ -230,7 +249,7 @@ extern struct json_object* json_object_array_get_idx(struct json_object *obj,
  * @param b a boolean TRUE or FALSE (0 or 1)
  * @returns a json_object of type json_type_boolean
  */
-extern struct json_object* json_object_new_boolean(boolean b);
+extern struct json_object *json_object_new_boolean(boolean b);
 
 /** Get the boolean value of a json_object
  *
@@ -245,14 +264,13 @@ extern struct json_object* json_object_new_boolean(boolean b);
  */
 extern boolean json_object_get_boolean(struct json_object *obj);
 
-
 /* int type methods */
 
 /** Create a new empty json_object of type json_type_int
  * @param i the integer
  * @returns a json_object of type json_type_int
  */
-extern struct json_object* json_object_new_int(int i);
+extern struct json_object *json_object_new_int(int i);
 
 /** Get the int value of a json_object
  *
@@ -265,14 +283,13 @@ extern struct json_object* json_object_new_int(int i);
  */
 extern int json_object_get_int(struct json_object *obj);
 
-
 /* double type methods */
 
 /** Create a new empty json_object of type json_type_double
  * @param d the double
  * @returns a json_object of type json_type_double
  */
-extern struct json_object* json_object_new_double(double d);
+extern struct json_object *json_object_new_double(double d);
 
 /** Get the double value of a json_object
  *
@@ -285,7 +302,6 @@ extern struct json_object* json_object_new_double(double d);
  */
 extern double json_object_get_double(struct json_object *obj);
 
-
 /* string type methods */
 
 /** Create a new empty json_object of type json_type_string
@@ -295,9 +311,9 @@ extern double json_object_get_double(struct json_object *obj);
  * @param s the string
  * @returns a json_object of type json_type_string
  */
-extern struct json_object* json_object_new_string(const char *s);
+extern struct json_object *json_object_new_string(const char *s);
 
-extern struct json_object* json_object_new_string_len(const char *s, int len);
+extern struct json_object *json_object_new_string_len(const char *s, int len);
 
 /** Get the string value of a json_object
  *
@@ -310,7 +326,7 @@ extern struct json_object* json_object_new_string_len(const char *s, int len);
  * @param obj the json_object instance
  * @returns a string
  */
-extern const char* json_object_get_string(struct json_object *obj);
+extern const char *json_object_get_string(struct json_object *obj);
 
 #ifdef __cplusplus
 }

--- a/src/json-c/json_object_private.h
+++ b/src/json-c/json_object_private.h
@@ -16,30 +16,28 @@
 extern "C" {
 #endif
 
-typedef void (json_object_delete_fn)(struct json_object *o);
-typedef int (json_object_to_json_string_fn)(struct json_object *o,
-					    struct printbuf *pb);
+typedef void(json_object_delete_fn)(struct json_object *o);
+typedef int(json_object_to_json_string_fn)(
+	struct json_object *o, struct printbuf *pb);
 
-struct json_object
-{
-  enum json_type o_type;
-  json_object_delete_fn *_delete;
-  json_object_to_json_string_fn *_to_json_string;
-  int _ref_count;
-  struct printbuf *_pb;
-  union data {
-    boolean c_boolean;
-    double c_double;
-    int c_int;
-    struct lh_table *c_object;
-    struct array_list *c_array;
-    char *c_string;
-  } o;
+struct json_object {
+	enum json_type o_type;
+	json_object_delete_fn *_delete;
+	json_object_to_json_string_fn *_to_json_string;
+	int _ref_count;
+	struct printbuf *_pb;
+	union data {
+		boolean c_boolean;
+		double c_double;
+		int c_int;
+		struct lh_table *c_object;
+		struct array_list *c_array;
+		char *c_string;
+	} o;
 };
 
 /* CAW: added for ANSI C iteration correctness */
-struct json_object_iter
-{
+struct json_object_iter {
 	char *key;
 	struct json_object *val;
 	struct lh_entry *entry;

--- a/src/json-c/json_tokener.c
+++ b/src/json-c/json_tokener.c
@@ -173,7 +173,7 @@ char* strndup(const char* str, size_t n)
  *   For convenience of existing conditionals, returns the old value of c (0 on eof)
  *   Implicit inputs:  c var
  */
-#define ADVANCE_CHAR(str, tok) \
+#define ADVANCE_CHAR(str, tok, c) \
   ( ++(str), ((tok)->char_offset)++, c)
 
 /* End optimization macro defs */
@@ -193,10 +193,11 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
   redo_char:
     switch(state) {
 
+    char c2;
     case json_tokener_state_eatws:
       /* Advance until we change state */
-      while (isspace(c)) {
-	if ((!ADVANCE_CHAR(str, tok)) || (!POP_CHAR(c, tok)))
+      while (c2 = c, isspace(c)) {
+	if ((!ADVANCE_CHAR(str, tok, c2)) || (!POP_CHAR(c, tok)))
 	  goto out;
       }
       if(c == '/') {
@@ -307,7 +308,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
           /* Advance until we change state */
           const char *case_start = str;
           while(c != '*') {
-            if (!ADVANCE_CHAR(str, tok) || !POP_CHAR(c, tok)) {
+            if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
               printbuf_memappend_fast(tok->pb, case_start, str-case_start);
               goto out;
             } 
@@ -322,7 +323,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 	/* Advance until we change state */
 	const char *case_start = str;
 	while(c != '\n') {
-	  if (!ADVANCE_CHAR(str, tok) || !POP_CHAR(c, tok)) {
+	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
 	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
 	    goto out;
 	  }
@@ -360,7 +361,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 	    state = json_tokener_state_string_escape;
 	    break;
 	  }
-	  if (!ADVANCE_CHAR(str, tok) || !POP_CHAR(c, tok)) {
+	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
 	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
 	    goto out;
 	  }
@@ -430,7 +431,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 	      tok->err = json_tokener_error_parse_string;
 	      goto out;
 	      	  }
-	  if (!ADVANCE_CHAR(str, tok) || !POP_CHAR(c, tok))
+	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok))
 	    goto out;
 	}
       }
@@ -469,7 +470,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 	while(c && strchr(json_number_chars, c)) {
 	  ++case_len;
 	  if(c == '.' || c == 'e') tok->is_double = 1;
-	  if (!ADVANCE_CHAR(str, tok) || !POP_CHAR(c, tok)) {
+	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
 	    printbuf_memappend_fast(tok->pb, case_start, case_len);
 	    goto out;
 	  }
@@ -560,7 +561,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 	    state = json_tokener_state_string_escape;
 	    break;
 	  }
-	  if (!ADVANCE_CHAR(str, tok) || !POP_CHAR(c, tok)) {
+	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
 	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
 	    goto out;
 	  }
@@ -610,7 +611,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
       break;
 
     }
-    if (!ADVANCE_CHAR(str, tok))
+    if (!ADVANCE_CHAR(str, tok, c))
       goto out;
   } /* while(POP_CHAR) */
 

--- a/src/json-c/json_tokener.c
+++ b/src/json-c/json_tokener.c
@@ -28,115 +28,112 @@
 #include "json_object.h"
 #include "json_tokener.h"
 
-
 #if !HAVE_STRNCASECMP && defined(_MSC_VER)
-  /* MSC has the version as _strnicmp */
-# define strncasecmp _strnicmp
+/* MSC has the version as _strnicmp */
+#define strncasecmp _strnicmp
 #elif !HAVE_STRNCASECMP
-# error You do not have strncasecmp on your system.
+#error You do not have strncasecmp on your system.
 #endif /* HAVE_STRNCASECMP */
 
+static const char *json_null_str = "null";
+static const char *json_true_str = "true";
+static const char *json_false_str = "false";
 
-static const char* json_null_str = "null";
-static const char* json_true_str = "true";
-static const char* json_false_str = "false";
-
-const char* json_tokener_errors[] = {
-  "success",
-  "continue",
-  "nesting to deep",
-  "unexpected end of data",
-  "unexpected character",
-  "null expected",
-  "boolean expected",
-  "number expected",
-  "array value separator ',' expected",
-  "quoted object property name expected",
-  "object property name separator ':' expected",
-  "object value separator ',' expected",
-  "invalid string sequence",
-  "expected comment",
+const char *json_tokener_errors[] = {
+	"success",
+	"continue",
+	"nesting to deep",
+	"unexpected end of data",
+	"unexpected character",
+	"null expected",
+	"boolean expected",
+	"number expected",
+	"array value separator ',' expected",
+	"quoted object property name expected",
+	"object property name separator ':' expected",
+	"object value separator ',' expected",
+	"invalid string sequence",
+	"expected comment",
 };
 
-
-struct json_tokener* json_tokener_new(void)
+struct json_tokener *json_tokener_new(void)
 {
-  struct json_tokener *tok;
+	struct json_tokener *tok;
 
-  tok = (struct json_tokener*)calloc(1, sizeof(struct json_tokener));
-  if (!tok) return NULL;
-  tok->pb = printbuf_new();
-  json_tokener_reset(tok);
-  return tok;
+	tok = (struct json_tokener *)calloc(1, sizeof(struct json_tokener));
+	if (!tok)
+		return NULL;
+	tok->pb = printbuf_new();
+	json_tokener_reset(tok);
+	return tok;
 }
 
 void json_tokener_free(struct json_tokener *tok)
 {
-  json_tokener_reset(tok);
-  if(tok) printbuf_free(tok->pb);
-  free(tok);
+	json_tokener_reset(tok);
+	if (tok)
+		printbuf_free(tok->pb);
+	free(tok);
 }
 
 static void json_tokener_reset_level(struct json_tokener *tok, int depth)
 {
-  tok->stack[depth].state = json_tokener_state_eatws;
-  tok->stack[depth].saved_state = json_tokener_state_start;
-  json_object_put(tok->stack[depth].current);
-  tok->stack[depth].current = NULL;
-  free(tok->stack[depth].obj_field_name);
-  tok->stack[depth].obj_field_name = NULL;
+	tok->stack[depth].state = json_tokener_state_eatws;
+	tok->stack[depth].saved_state = json_tokener_state_start;
+	json_object_put(tok->stack[depth].current);
+	tok->stack[depth].current = NULL;
+	free(tok->stack[depth].obj_field_name);
+	tok->stack[depth].obj_field_name = NULL;
 }
 
 void json_tokener_reset(struct json_tokener *tok)
 {
-  int i;
-  if (!tok)
-    return;
+	int i;
+	if (!tok)
+		return;
 
-  for(i = tok->depth; i >= 0; i--)
-    json_tokener_reset_level(tok, i);
-  tok->depth = 0;
-  tok->err = json_tokener_success;
+	for (i = tok->depth; i >= 0; i--)
+		json_tokener_reset_level(tok, i);
+	tok->depth = 0;
+	tok->err = json_tokener_success;
 }
 
-struct json_object* json_tokener_parse(const char *str)
+struct json_object *json_tokener_parse(const char *str)
 {
-  struct json_tokener* tok;
-  struct json_object* obj;
+	struct json_tokener *tok;
+	struct json_object *obj;
 
-  tok = json_tokener_new();
-  obj = json_tokener_parse_ex(tok, str, -1);
-  if(tok->err != json_tokener_success)
-    obj = (struct json_object*)error_ptr(-tok->err);
-  json_tokener_free(tok);
-  return obj;
+	tok = json_tokener_new();
+	obj = json_tokener_parse_ex(tok, str, -1);
+	if (tok->err != json_tokener_success)
+		obj = (struct json_object *)error_ptr(-tok->err);
+	json_tokener_free(tok);
+	return obj;
 }
-
 
 #if !HAVE_STRNDUP
 /* CAW: compliant version of strndup() */
-char* strndup(const char* str, size_t n)
+char *strndup(const char *str, size_t n)
 {
-  if(str) {
-    size_t len = strlen(str);
-    size_t nn = json_min(len,n);
-    char* s = (char*)malloc(sizeof(char) * (nn + 1));
+	if (str) {
+		size_t len = strlen(str);
+		size_t nn = json_min(len, n);
+		char *s = (char *)malloc(sizeof(char) * (nn + 1));
 
-    if(s) {
-      memcpy(s, str, nn);
-      s[nn] = '\0';
-    }
+		if (s) {
+			memcpy(s, str, nn);
+			s[nn] = '\0';
+		}
 
-    return s;
-  }
+		return s;
+	}
 
-  return NULL;
+	return NULL;
 }
 #endif
 
-
-#define state  tok->stack[tok->depth].state
-#define saved_state  tok->stack[tok->depth].saved_state
+#define state tok->stack[tok->depth].state
+#define saved_state tok->stack[tok->depth].saved_state
 #define current tok->stack[tok->depth].current
 #define obj_field_name tok->stack[tok->depth].obj_field_name
 
@@ -158,472 +155,512 @@ char* strndup(const char* str, size_t n)
  *   Returns 1 on success, sets tok->err and returns 0 if no more chars.
  *   Implicit inputs:  str, len vars
  */
-#define POP_CHAR(dest, tok)                                                  \
-  (((tok)->char_offset == len) ?                                          \
-   (((tok)->depth == 0 && state == json_tokener_state_eatws && saved_state == json_tokener_state_finish) ? \
-    (((tok)->err = json_tokener_success), 0)                              \
-    :                                                                   \
-    (((tok)->err = json_tokener_continue), 0)                             \
-    ) :                                                                 \
-   (((dest) = *str), 1)                                                 \
-   )
- 
+#define POP_CHAR(dest, tok)                                                    \
+	(((tok)->char_offset == len)                                               \
+		 ? (((tok)->depth == 0 && state == json_tokener_state_eatws            \
+			 && saved_state == json_tokener_state_finish)                      \
+				? (((tok)->err = json_tokener_success), 0)                     \
+				: (((tok)->err = json_tokener_continue), 0))                   \
+		 : (((dest) = *str), 1))
+
 /* ADVANCE_CHAR() macro:
  *   Incrementes str & tok->char_offset.
  *   For convenience of existing conditionals, returns the old value of c (0 on eof)
  *   Implicit inputs:  c var
  */
-#define ADVANCE_CHAR(str, tok, c) \
-  ( ++(str), ((tok)->char_offset)++, c)
+#define ADVANCE_CHAR(str, tok, c) (++(str), ((tok)->char_offset)++, c)
 
 /* End optimization macro defs */
 
-
-struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
-					  const char *str, int len)
+struct json_object *
+json_tokener_parse_ex(struct json_tokener *tok, const char *str, int len)
 {
-  struct json_object *obj = NULL;
-  char c = '\1';
+	struct json_object *obj = NULL;
+	char c = '\1';
 
-  tok->char_offset = 0;
-  tok->err = json_tokener_success;
+	tok->char_offset = 0;
+	tok->err = json_tokener_success;
 
-  while (POP_CHAR(c, tok)) {
+	while (POP_CHAR(c, tok)) {
+	redo_char:
+		switch (state) {
+			char c2;
+		case json_tokener_state_eatws:
+			/* Advance until we change state */
+			while (c2 = c, isspace(c)) {
+				if ((!ADVANCE_CHAR(str, tok, c2)) || (!POP_CHAR(c, tok)))
+					goto out;
+			}
+			if (c == '/') {
+				printbuf_reset(tok->pb);
+				printbuf_memappend_fast(tok->pb, &c, 1);
+				state = json_tokener_state_comment_start;
+			} else {
+				state = saved_state;
+				goto redo_char;
+			}
+			break;
 
-  redo_char:
-    switch(state) {
-
-    char c2;
-    case json_tokener_state_eatws:
-      /* Advance until we change state */
-      while (c2 = c, isspace(c)) {
-	if ((!ADVANCE_CHAR(str, tok, c2)) || (!POP_CHAR(c, tok)))
-	  goto out;
-      }
-      if(c == '/') {
-	printbuf_reset(tok->pb);
-	printbuf_memappend_fast(tok->pb, &c, 1);
-	state = json_tokener_state_comment_start;
-      } else {
-	state = saved_state;
-	goto redo_char;
-      }
-      break;
-
-    case json_tokener_state_start:
-      switch(c) {
-      case '{':
-	state = json_tokener_state_eatws;
-	saved_state = json_tokener_state_object_field_start;
-	current = json_object_new_object();
-	break;
-      case '[':
-	state = json_tokener_state_eatws;
-	saved_state = json_tokener_state_array;
-	current = json_object_new_array();
-	break;
-      case 'N':
-      case 'n':
-	state = json_tokener_state_null;
-	printbuf_reset(tok->pb);
-	tok->st_pos = 0;
-	goto redo_char;
-      case '"':
-      case '\'':
-	state = json_tokener_state_string;
-	printbuf_reset(tok->pb);
-	tok->quote_char = c;
-	break;
-      case 'T':
-      case 't':
-      case 'F':
-      case 'f':
-	state = json_tokener_state_boolean;
-	printbuf_reset(tok->pb);
-	tok->st_pos = 0;
-	goto redo_char;
+		case json_tokener_state_start:
+			switch (c) {
+			case '{':
+				state = json_tokener_state_eatws;
+				saved_state = json_tokener_state_object_field_start;
+				current = json_object_new_object();
+				break;
+			case '[':
+				state = json_tokener_state_eatws;
+				saved_state = json_tokener_state_array;
+				current = json_object_new_array();
+				break;
+			case 'N':
+			case 'n':
+				state = json_tokener_state_null;
+				printbuf_reset(tok->pb);
+				tok->st_pos = 0;
+				goto redo_char;
+			case '"':
+			case '\'':
+				state = json_tokener_state_string;
+				printbuf_reset(tok->pb);
+				tok->quote_char = c;
+				break;
+			case 'T':
+			case 't':
+			case 'F':
+			case 'f':
+				state = json_tokener_state_boolean;
+				printbuf_reset(tok->pb);
+				tok->st_pos = 0;
+				goto redo_char;
 #if defined(__GNUC__)
-	  case '0' ... '9':
+			case '0' ... '9':
 #else
-	  case '0':
-      case '1':
-      case '2':
-      case '3':
-      case '4':
-      case '5':
-      case '6':
-      case '7':
-      case '8':
-      case '9':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
 #endif
-      case '-':
-	state = json_tokener_state_number;
-	printbuf_reset(tok->pb);
-	tok->is_double = 0;
-	goto redo_char;
-      default:
-	tok->err = json_tokener_error_parse_unexpected;
-	goto out;
-      }
-      break;
+			case '-':
+				state = json_tokener_state_number;
+				printbuf_reset(tok->pb);
+				tok->is_double = 0;
+				goto redo_char;
+			default:
+				tok->err = json_tokener_error_parse_unexpected;
+				goto out;
+			}
+			break;
 
-    case json_tokener_state_finish:
-      if(tok->depth == 0) goto out;
-      obj = json_object_get(current);
-      json_tokener_reset_level(tok, tok->depth);
-      tok->depth--;
-      goto redo_char;
+		case json_tokener_state_finish:
+			if (tok->depth == 0)
+				goto out;
+			obj = json_object_get(current);
+			json_tokener_reset_level(tok, tok->depth);
+			tok->depth--;
+			goto redo_char;
 
-    case json_tokener_state_null:
-      printbuf_memappend_fast(tok->pb, &c, 1);
-      if(strncasecmp(json_null_str, tok->pb->buf,
-		     json_min(tok->st_pos+1, strlen(json_null_str))) == 0) {
-	if(tok->st_pos == strlen(json_null_str)) {
-	  current = NULL;
-	  saved_state = json_tokener_state_finish;
-	  state = json_tokener_state_eatws;
-	  goto redo_char;
-	}
-      } else {
-	tok->err = json_tokener_error_parse_null;
-	goto out;
-      }
-      tok->st_pos++;
-      break;
+		case json_tokener_state_null:
+			printbuf_memappend_fast(tok->pb, &c, 1);
+			if (strncasecmp(
+					json_null_str,
+					tok->pb->buf,
+					json_min(tok->st_pos + 1, strlen(json_null_str)))
+				== 0) {
+				if (tok->st_pos == strlen(json_null_str)) {
+					current = NULL;
+					saved_state = json_tokener_state_finish;
+					state = json_tokener_state_eatws;
+					goto redo_char;
+				}
+			} else {
+				tok->err = json_tokener_error_parse_null;
+				goto out;
+			}
+			tok->st_pos++;
+			break;
 
-    case json_tokener_state_comment_start:
-      if(c == '*') {
-	state = json_tokener_state_comment;
-      } else if(c == '/') {
-	state = json_tokener_state_comment_eol;
-      } else {
-	tok->err = json_tokener_error_parse_comment;
-	goto out;
-      }
-      printbuf_memappend_fast(tok->pb, &c, 1);
-      break;
+		case json_tokener_state_comment_start:
+			if (c == '*') {
+				state = json_tokener_state_comment;
+			} else if (c == '/') {
+				state = json_tokener_state_comment_eol;
+			} else {
+				tok->err = json_tokener_error_parse_comment;
+				goto out;
+			}
+			printbuf_memappend_fast(tok->pb, &c, 1);
+			break;
 
-    case json_tokener_state_comment:
-              {
-          /* Advance until we change state */
-          const char *case_start = str;
-          while(c != '*') {
-            if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
-              printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-              goto out;
-            } 
-          }
-          printbuf_memappend_fast(tok->pb, case_start, 1+str-case_start);
-          state = json_tokener_state_comment_end;
-        }
-            break;
+		case json_tokener_state_comment: {
+			/* Advance until we change state */
+			const char *case_start = str;
+			while (c != '*') {
+				if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
+					printbuf_memappend_fast(
+						tok->pb,
+						case_start,
+						str - case_start);
+					goto out;
+				}
+			}
+			printbuf_memappend_fast(tok->pb, case_start, 1 + str - case_start);
+			state = json_tokener_state_comment_end;
+		} break;
 
-    case json_tokener_state_comment_eol:
-      {
-	/* Advance until we change state */
-	const char *case_start = str;
-	while(c != '\n') {
-	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
-	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-	    goto out;
-	  }
-	}
-	printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-	MC_DEBUG("json_tokener_comment: %s\n", tok->pb->buf);
-	state = json_tokener_state_eatws;
-      }
-      break;
+		case json_tokener_state_comment_eol: {
+			/* Advance until we change state */
+			const char *case_start = str;
+			while (c != '\n') {
+				if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
+					printbuf_memappend_fast(
+						tok->pb,
+						case_start,
+						str - case_start);
+					goto out;
+				}
+			}
+			printbuf_memappend_fast(tok->pb, case_start, str - case_start);
+			MC_DEBUG("json_tokener_comment: %s\n", tok->pb->buf);
+			state = json_tokener_state_eatws;
+		} break;
 
-    case json_tokener_state_comment_end:
-      printbuf_memappend_fast(tok->pb, &c, 1);
-      if(c == '/') {
-	MC_DEBUG("json_tokener_comment: %s\n", tok->pb->buf);
-	state = json_tokener_state_eatws;
-      } else {
-	state = json_tokener_state_comment;
-      }
-      break;
+		case json_tokener_state_comment_end:
+			printbuf_memappend_fast(tok->pb, &c, 1);
+			if (c == '/') {
+				MC_DEBUG("json_tokener_comment: %s\n", tok->pb->buf);
+				state = json_tokener_state_eatws;
+			} else {
+				state = json_tokener_state_comment;
+			}
+			break;
 
-    case json_tokener_state_string:
-      {
-	/* Advance until we change state */
-	const char *case_start = str;
-	while(1) {
-	  if(c == tok->quote_char) {
-	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-	    current = json_object_new_string(tok->pb->buf);
-	    saved_state = json_tokener_state_finish;
-	    state = json_tokener_state_eatws;
-	    break;
-	  } else if(c == '\\') {
-	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-	    saved_state = json_tokener_state_string;
-	    state = json_tokener_state_string_escape;
-	    break;
-	  }
-	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
-	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-	    goto out;
-	  }
-	}
-      }
-      break;
+		case json_tokener_state_string: {
+			/* Advance until we change state */
+			const char *case_start = str;
+			while (1) {
+				if (c == tok->quote_char) {
+					printbuf_memappend_fast(
+						tok->pb,
+						case_start,
+						str - case_start);
+					current = json_object_new_string(tok->pb->buf);
+					saved_state = json_tokener_state_finish;
+					state = json_tokener_state_eatws;
+					break;
+				} else if (c == '\\') {
+					printbuf_memappend_fast(
+						tok->pb,
+						case_start,
+						str - case_start);
+					saved_state = json_tokener_state_string;
+					state = json_tokener_state_string_escape;
+					break;
+				}
+				if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
+					printbuf_memappend_fast(
+						tok->pb,
+						case_start,
+						str - case_start);
+					goto out;
+				}
+			}
+		} break;
 
-    case json_tokener_state_string_escape:
-      switch(c) {
-      case '"':
-      case '\\':
-      case '/':
-	printbuf_memappend_fast(tok->pb, &c, 1);
-	state = saved_state;
-	break;
-      case 'b':
-      case 'n':
-      case 'r':
-      case 't':
-	if(c == 'b') printbuf_memappend_fast(tok->pb, "\b", 1);
-	else if(c == 'n') printbuf_memappend_fast(tok->pb, "\n", 1);
-	else if(c == 'r') printbuf_memappend_fast(tok->pb, "\r", 1);
-	else if(c == 't') printbuf_memappend_fast(tok->pb, "\t", 1);
-	state = saved_state;
-	break;
-      case 'u':
-	tok->ucs_char = 0;
-	tok->st_pos = 0;
-	state = json_tokener_state_escape_unicode;
-	break;
-      default:
-	tok->err = json_tokener_error_parse_string;
-	goto out;
-      }
-      break;
+		case json_tokener_state_string_escape:
+			switch (c) {
+			case '"':
+			case '\\':
+			case '/':
+				printbuf_memappend_fast(tok->pb, &c, 1);
+				state = saved_state;
+				break;
+			case 'b':
+			case 'n':
+			case 'r':
+			case 't':
+				if (c == 'b')
+					printbuf_memappend_fast(tok->pb, "\b", 1);
+				else if (c == 'n')
+					printbuf_memappend_fast(tok->pb, "\n", 1);
+				else if (c == 'r')
+					printbuf_memappend_fast(tok->pb, "\r", 1);
+				else if (c == 't')
+					printbuf_memappend_fast(tok->pb, "\t", 1);
+				state = saved_state;
+				break;
+			case 'u':
+				tok->ucs_char = 0;
+				tok->st_pos = 0;
+				state = json_tokener_state_escape_unicode;
+				break;
+			default:
+				tok->err = json_tokener_error_parse_string;
+				goto out;
+			}
+			break;
 
-    case json_tokener_state_escape_unicode:
-            /* Note that the following code is inefficient for handling large
+		case json_tokener_state_escape_unicode:
+			/* Note that the following code is inefficient for handling large
        * chunks of extended chars, calling printbuf_memappend() once
        * for each multi-byte character of input.
        * This is a good area for future optimization.
        */
-	{
-	  /* Advance until we change state */
-	  while(1) {
-	    if(strchr(json_hex_chars, c)) {
-	      tok->ucs_char += ((unsigned int)hexdigit(c) << ((3-tok->st_pos++)*4));
-	      if(tok->st_pos == 4) {
-		unsigned char utf_out[3];
-		if (tok->ucs_char < 0x80) {
-		  utf_out[0] = tok->ucs_char;
-		  printbuf_memappend_fast(tok->pb, (char*)utf_out, 1);
-		} else if (tok->ucs_char < 0x800) {
-		  utf_out[0] = 0xc0 | (tok->ucs_char >> 6);
-		  utf_out[1] = 0x80 | (tok->ucs_char & 0x3f);
-		  printbuf_memappend_fast(tok->pb, (char*)utf_out, 2);
-		} else {
-		  utf_out[0] = 0xe0 | (tok->ucs_char >> 12);
-		  utf_out[1] = 0x80 | ((tok->ucs_char >> 6) & 0x3f);
-		  utf_out[2] = 0x80 | (tok->ucs_char & 0x3f);
-		  printbuf_memappend_fast(tok->pb, (char*)utf_out, 3);
+			{
+				/* Advance until we change state */
+				while (1) {
+					if (strchr(json_hex_chars, c)) {
+						tok->ucs_char +=
+							((unsigned int)hexdigit(c)
+							 << ((3 - tok->st_pos++) * 4));
+						if (tok->st_pos == 4) {
+							unsigned char utf_out[3];
+							if (tok->ucs_char < 0x80) {
+								utf_out[0] = tok->ucs_char;
+								printbuf_memappend_fast(
+									tok->pb,
+									(char *)utf_out,
+									1);
+							} else if (tok->ucs_char < 0x800) {
+								utf_out[0] = 0xc0 | (tok->ucs_char >> 6);
+								utf_out[1] = 0x80 | (tok->ucs_char & 0x3f);
+								printbuf_memappend_fast(
+									tok->pb,
+									(char *)utf_out,
+									2);
+							} else {
+								utf_out[0] = 0xe0 | (tok->ucs_char >> 12);
+								utf_out[1] =
+									0x80 | ((tok->ucs_char >> 6) & 0x3f);
+								utf_out[2] = 0x80 | (tok->ucs_char & 0x3f);
+								printbuf_memappend_fast(
+									tok->pb,
+									(char *)utf_out,
+									3);
+							}
+							state = saved_state;
+							break;
+						}
+					} else {
+						tok->err = json_tokener_error_parse_string;
+						goto out;
+					}
+					if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok))
+						goto out;
+				}
+			}
+			break;
+
+		case json_tokener_state_boolean:
+			printbuf_memappend_fast(tok->pb, &c, 1);
+			if (strncasecmp(
+					json_true_str,
+					tok->pb->buf,
+					json_min(tok->st_pos + 1, strlen(json_true_str)))
+				== 0) {
+				if (tok->st_pos == strlen(json_true_str)) {
+					current = json_object_new_boolean(1);
+					saved_state = json_tokener_state_finish;
+					state = json_tokener_state_eatws;
+					goto redo_char;
+				}
+			} else if (
+				strncasecmp(
+					json_false_str,
+					tok->pb->buf,
+					json_min(tok->st_pos + 1, strlen(json_false_str)))
+				== 0) {
+				if (tok->st_pos == strlen(json_false_str)) {
+					current = json_object_new_boolean(0);
+					saved_state = json_tokener_state_finish;
+					state = json_tokener_state_eatws;
+					goto redo_char;
+				}
+			} else {
+				tok->err = json_tokener_error_parse_boolean;
+				goto out;
+			}
+			tok->st_pos++;
+			break;
+
+		case json_tokener_state_number: {
+			/* Advance until we change state */
+			const char *case_start = str;
+			int case_len = 0;
+			while (c && strchr(json_number_chars, c)) {
+				++case_len;
+				if (c == '.' || c == 'e')
+					tok->is_double = 1;
+				if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
+					printbuf_memappend_fast(tok->pb, case_start, case_len);
+					goto out;
+				}
+			}
+			if (case_len > 0)
+				printbuf_memappend_fast(tok->pb, case_start, case_len);
 		}
-		state = saved_state;
-		break;
-	      }
-	    } else {
-	      tok->err = json_tokener_error_parse_string;
-	      goto out;
-	      	  }
-	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok))
-	    goto out;
+			{
+				int numi;
+				double numd;
+				if (!tok->is_double && sscanf(tok->pb->buf, "%d", &numi) == 1) {
+					current = json_object_new_int(numi);
+				} else if (
+					tok->is_double && sscanf(tok->pb->buf, "%lf", &numd) == 1) {
+					current = json_object_new_double(numd);
+				} else {
+					tok->err = json_tokener_error_parse_number;
+					goto out;
+				}
+				saved_state = json_tokener_state_finish;
+				state = json_tokener_state_eatws;
+				goto redo_char;
+			}
+			break;
+
+		case json_tokener_state_array:
+			if (c == ']') {
+				saved_state = json_tokener_state_finish;
+				state = json_tokener_state_eatws;
+			} else {
+				if (tok->depth >= JSON_TOKENER_MAX_DEPTH - 1) {
+					tok->err = json_tokener_error_depth;
+					goto out;
+				}
+				state = json_tokener_state_array_add;
+				tok->depth++;
+				json_tokener_reset_level(tok, tok->depth);
+				goto redo_char;
+			}
+			break;
+
+		case json_tokener_state_array_add:
+			json_object_array_add(current, obj);
+			saved_state = json_tokener_state_array_sep;
+			state = json_tokener_state_eatws;
+			goto redo_char;
+
+		case json_tokener_state_array_sep:
+			if (c == ']') {
+				saved_state = json_tokener_state_finish;
+				state = json_tokener_state_eatws;
+			} else if (c == ',') {
+				saved_state = json_tokener_state_array;
+				state = json_tokener_state_eatws;
+			} else {
+				tok->err = json_tokener_error_parse_array;
+				goto out;
+			}
+			break;
+
+		case json_tokener_state_object_field_start:
+			if (c == '}') {
+				saved_state = json_tokener_state_finish;
+				state = json_tokener_state_eatws;
+			} else if (c == '"' || c == '\'') {
+				tok->quote_char = c;
+				printbuf_reset(tok->pb);
+				state = json_tokener_state_object_field;
+			} else {
+				tok->err = json_tokener_error_parse_object_key_name;
+				goto out;
+			}
+			break;
+
+		case json_tokener_state_object_field: {
+			/* Advance until we change state */
+			const char *case_start = str;
+			while (1) {
+				if (c == tok->quote_char) {
+					printbuf_memappend_fast(
+						tok->pb,
+						case_start,
+						str - case_start);
+					obj_field_name = strdup(tok->pb->buf);
+					saved_state = json_tokener_state_object_field_end;
+					state = json_tokener_state_eatws;
+					break;
+				} else if (c == '\\') {
+					printbuf_memappend_fast(
+						tok->pb,
+						case_start,
+						str - case_start);
+					saved_state = json_tokener_state_object_field;
+					state = json_tokener_state_string_escape;
+					break;
+				}
+				if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
+					printbuf_memappend_fast(
+						tok->pb,
+						case_start,
+						str - case_start);
+					goto out;
+				}
+			}
+		} break;
+
+		case json_tokener_state_object_field_end:
+			if (c == ':') {
+				saved_state = json_tokener_state_object_value;
+				state = json_tokener_state_eatws;
+			} else {
+				tok->err = json_tokener_error_parse_object_key_sep;
+				goto out;
+			}
+			break;
+
+		case json_tokener_state_object_value:
+			if (tok->depth >= JSON_TOKENER_MAX_DEPTH - 1) {
+				tok->err = json_tokener_error_depth;
+				goto out;
+			}
+			state = json_tokener_state_object_value_add;
+			tok->depth++;
+			json_tokener_reset_level(tok, tok->depth);
+			goto redo_char;
+
+		case json_tokener_state_object_value_add:
+			json_object_object_add(current, obj_field_name, obj);
+			free(obj_field_name);
+			obj_field_name = NULL;
+			saved_state = json_tokener_state_object_sep;
+			state = json_tokener_state_eatws;
+			goto redo_char;
+
+		case json_tokener_state_object_sep:
+			if (c == '}') {
+				saved_state = json_tokener_state_finish;
+				state = json_tokener_state_eatws;
+			} else if (c == ',') {
+				saved_state = json_tokener_state_object_field_start;
+				state = json_tokener_state_eatws;
+			} else {
+				tok->err = json_tokener_error_parse_object_value_sep;
+				goto out;
+			}
+			break;
+		}
+		if (!ADVANCE_CHAR(str, tok, c))
+			goto out;
+	} /* while(POP_CHAR) */
+
+out:
+	if (!c) { /* We hit an eof char (0) */
+		if (state != json_tokener_state_finish
+			&& saved_state != json_tokener_state_finish)
+			tok->err = json_tokener_error_parse_eof;
 	}
-      }
-      break;
 
-    case json_tokener_state_boolean:
-      printbuf_memappend_fast(tok->pb, &c, 1);
-      if(strncasecmp(json_true_str, tok->pb->buf,
-		     json_min(tok->st_pos+1, strlen(json_true_str))) == 0) {
-	if(tok->st_pos == strlen(json_true_str)) {
-	  current = json_object_new_boolean(1);
-	  saved_state = json_tokener_state_finish;
-	  state = json_tokener_state_eatws;
-	  goto redo_char;
-	}
-      } else if(strncasecmp(json_false_str, tok->pb->buf,
-			    json_min(tok->st_pos+1, strlen(json_false_str))) == 0) {
-	if(tok->st_pos == strlen(json_false_str)) {
-	  current = json_object_new_boolean(0);
-	  saved_state = json_tokener_state_finish;
-	  state = json_tokener_state_eatws;
-	  goto redo_char;
-	}
-      } else {
-	tok->err = json_tokener_error_parse_boolean;
-	goto out;
-      }
-      tok->st_pos++;
-      break;
-
-    case json_tokener_state_number:
-      {
-	/* Advance until we change state */
-	const char *case_start = str;
-	int case_len=0;
-	while(c && strchr(json_number_chars, c)) {
-	  ++case_len;
-	  if(c == '.' || c == 'e') tok->is_double = 1;
-	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
-	    printbuf_memappend_fast(tok->pb, case_start, case_len);
-	    goto out;
-	  }
-	}
-        if (case_len>0)
-          printbuf_memappend_fast(tok->pb, case_start, case_len);
-      }
-      {
-        int numi;
-        double numd;
-        if(!tok->is_double && sscanf(tok->pb->buf, "%d", &numi) == 1) {
-          current = json_object_new_int(numi);
-        } else if(tok->is_double && sscanf(tok->pb->buf, "%lf", &numd) == 1) {
-          current = json_object_new_double(numd);
-        } else {
-          tok->err = json_tokener_error_parse_number;
-          goto out;
-        }
-        saved_state = json_tokener_state_finish;
-        state = json_tokener_state_eatws;
-        goto redo_char;
-      }
-      break;
-
-    case json_tokener_state_array:
-      if(c == ']') {
-	saved_state = json_tokener_state_finish;
-	state = json_tokener_state_eatws;
-      } else {
-	if(tok->depth >= JSON_TOKENER_MAX_DEPTH-1) {
-	  tok->err = json_tokener_error_depth;
-	  goto out;
-	}
-	state = json_tokener_state_array_add;
-	tok->depth++;
-	json_tokener_reset_level(tok, tok->depth);
-	goto redo_char;
-      }
-      break;
-
-    case json_tokener_state_array_add:
-      json_object_array_add(current, obj);
-      saved_state = json_tokener_state_array_sep;
-      state = json_tokener_state_eatws;
-      goto redo_char;
-
-    case json_tokener_state_array_sep:
-      if(c == ']') {
-	saved_state = json_tokener_state_finish;
-	state = json_tokener_state_eatws;
-      } else if(c == ',') {
-	saved_state = json_tokener_state_array;
-	state = json_tokener_state_eatws;
-      } else {
-	tok->err = json_tokener_error_parse_array;
-	goto out;
-      }
-      break;
-
-    case json_tokener_state_object_field_start:
-      if(c == '}') {
-	saved_state = json_tokener_state_finish;
-	state = json_tokener_state_eatws;
-      } else if (c == '"' || c == '\'') {
-	tok->quote_char = c;
-	printbuf_reset(tok->pb);
-	state = json_tokener_state_object_field;
-      } else {
-	tok->err = json_tokener_error_parse_object_key_name;
-	goto out;
-      }
-      break;
-
-    case json_tokener_state_object_field:
-      {
-	/* Advance until we change state */
-	const char *case_start = str;
-	while(1) {
-	  if(c == tok->quote_char) {
-	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-	    obj_field_name = strdup(tok->pb->buf);
-	    saved_state = json_tokener_state_object_field_end;
-	    state = json_tokener_state_eatws;
-	    break;
-	  } else if(c == '\\') {
-	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-	    saved_state = json_tokener_state_object_field;
-	    state = json_tokener_state_string_escape;
-	    break;
-	  }
-	  if (!ADVANCE_CHAR(str, tok, c) || !POP_CHAR(c, tok)) {
-	    printbuf_memappend_fast(tok->pb, case_start, str-case_start);
-	    goto out;
-	  }
-	}
-      }
-      break;
-
-    case json_tokener_state_object_field_end:
-      if(c == ':') {
-	saved_state = json_tokener_state_object_value;
-	state = json_tokener_state_eatws;
-      } else {
-	tok->err = json_tokener_error_parse_object_key_sep;
-	goto out;
-      }
-      break;
-
-    case json_tokener_state_object_value:
-      if(tok->depth >= JSON_TOKENER_MAX_DEPTH-1) {
-	tok->err = json_tokener_error_depth;
-	goto out;
-      }
-      state = json_tokener_state_object_value_add;
-      tok->depth++;
-      json_tokener_reset_level(tok, tok->depth);
-      goto redo_char;
-
-    case json_tokener_state_object_value_add:
-      json_object_object_add(current, obj_field_name, obj);
-      free(obj_field_name);
-      obj_field_name = NULL;
-      saved_state = json_tokener_state_object_sep;
-      state = json_tokener_state_eatws;
-      goto redo_char;
-
-    case json_tokener_state_object_sep:
-      if(c == '}') {
-	saved_state = json_tokener_state_finish;
-	state = json_tokener_state_eatws;
-      } else if(c == ',') {
-	saved_state = json_tokener_state_object_field_start;
-	state = json_tokener_state_eatws;
-      } else {
-	tok->err = json_tokener_error_parse_object_value_sep;
-	goto out;
-      }
-      break;
-
-    }
-    if (!ADVANCE_CHAR(str, tok, c))
-      goto out;
-  } /* while(POP_CHAR) */
-
- out:
-  if (!c) { /* We hit an eof char (0) */
-    if(state != json_tokener_state_finish &&
-       saved_state != json_tokener_state_finish)
-      tok->err = json_tokener_error_parse_eof;
-  }
-
-  if(tok->err == json_tokener_success) return json_object_get(current);
-  MC_DEBUG("json_tokener_parse_ex: error %s at offset %d\n",
-	   json_tokener_errors[tok->err], tok->char_offset);
-  return NULL;
+	if (tok->err == json_tokener_success)
+		return json_object_get(current);
+	MC_DEBUG(
+		"json_tokener_parse_ex: error %s at offset %d\n",
+		json_tokener_errors[tok->err],
+		tok->char_offset);
+	return NULL;
 }

--- a/src/json-c/json_tokener.h
+++ b/src/json-c/json_tokener.h
@@ -20,76 +20,74 @@ extern "C" {
 #endif
 
 enum json_tokener_error {
-  json_tokener_success,
-  json_tokener_continue,
-  json_tokener_error_depth,
-  json_tokener_error_parse_eof,
-  json_tokener_error_parse_unexpected,
-  json_tokener_error_parse_null,
-  json_tokener_error_parse_boolean,
-  json_tokener_error_parse_number,
-  json_tokener_error_parse_array,
-  json_tokener_error_parse_object_key_name,
-  json_tokener_error_parse_object_key_sep,
-  json_tokener_error_parse_object_value_sep,
-  json_tokener_error_parse_string,
-  json_tokener_error_parse_comment
+	json_tokener_success,
+	json_tokener_continue,
+	json_tokener_error_depth,
+	json_tokener_error_parse_eof,
+	json_tokener_error_parse_unexpected,
+	json_tokener_error_parse_null,
+	json_tokener_error_parse_boolean,
+	json_tokener_error_parse_number,
+	json_tokener_error_parse_array,
+	json_tokener_error_parse_object_key_name,
+	json_tokener_error_parse_object_key_sep,
+	json_tokener_error_parse_object_value_sep,
+	json_tokener_error_parse_string,
+	json_tokener_error_parse_comment
 };
 
 enum json_tokener_state {
-  json_tokener_state_eatws,
-  json_tokener_state_start,
-  json_tokener_state_finish,
-  json_tokener_state_null,
-  json_tokener_state_comment_start,
-  json_tokener_state_comment,
-  json_tokener_state_comment_eol,
-  json_tokener_state_comment_end,
-  json_tokener_state_string,
-  json_tokener_state_string_escape,
-  json_tokener_state_escape_unicode,
-  json_tokener_state_boolean,
-  json_tokener_state_number,
-  json_tokener_state_array,
-  json_tokener_state_array_add,
-  json_tokener_state_array_sep,
-  json_tokener_state_object_field_start,
-  json_tokener_state_object_field,
-  json_tokener_state_object_field_end,
-  json_tokener_state_object_value,
-  json_tokener_state_object_value_add,
-  json_tokener_state_object_sep
+	json_tokener_state_eatws,
+	json_tokener_state_start,
+	json_tokener_state_finish,
+	json_tokener_state_null,
+	json_tokener_state_comment_start,
+	json_tokener_state_comment,
+	json_tokener_state_comment_eol,
+	json_tokener_state_comment_end,
+	json_tokener_state_string,
+	json_tokener_state_string_escape,
+	json_tokener_state_escape_unicode,
+	json_tokener_state_boolean,
+	json_tokener_state_number,
+	json_tokener_state_array,
+	json_tokener_state_array_add,
+	json_tokener_state_array_sep,
+	json_tokener_state_object_field_start,
+	json_tokener_state_object_field,
+	json_tokener_state_object_field_end,
+	json_tokener_state_object_value,
+	json_tokener_state_object_value_add,
+	json_tokener_state_object_sep
 };
 
-struct json_tokener_srec
-{
-  enum json_tokener_state state, saved_state;
-  struct json_object *obj;
-  struct json_object *current;
-  char *obj_field_name;
+struct json_tokener_srec {
+	enum json_tokener_state state, saved_state;
+	struct json_object *obj;
+	struct json_object *current;
+	char *obj_field_name;
 };
 
 #define JSON_TOKENER_MAX_DEPTH 32
 
-struct json_tokener
-{
-  char *str;
-  struct printbuf *pb;
-  int depth, is_double, st_pos, char_offset;
-  ptrdiff_t err;
-  unsigned int ucs_char;
-  char quote_char;
-  struct json_tokener_srec stack[JSON_TOKENER_MAX_DEPTH];
+struct json_tokener {
+	char *str;
+	struct printbuf *pb;
+	int depth, is_double, st_pos, char_offset;
+	ptrdiff_t err;
+	unsigned int ucs_char;
+	char quote_char;
+	struct json_tokener_srec stack[JSON_TOKENER_MAX_DEPTH];
 };
 
-extern const char* json_tokener_errors[];
+extern const char *json_tokener_errors[];
 
-extern struct json_tokener* json_tokener_new(void);
+extern struct json_tokener *json_tokener_new(void);
 extern void json_tokener_free(struct json_tokener *tok);
 extern void json_tokener_reset(struct json_tokener *tok);
-extern struct json_object* json_tokener_parse(const char *str);
-extern struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
-						 const char *str, int len);
+extern struct json_object *json_tokener_parse(const char *str);
+extern struct json_object *
+json_tokener_parse_ex(struct json_tokener *tok, const char *str, int len);
 
 #ifdef __cplusplus
 }

--- a/src/json-c/json_util.c
+++ b/src/json-c/json_util.c
@@ -31,19 +31,18 @@
 #endif /* HAVE_FCNTL_H */
 
 #if HAVE_UNISTD_H
-# include <unistd.h>
+#include <unistd.h>
 #endif /* HAVE_UNISTD_H */
 
 #ifdef WIN32
-# define WIN32_LEAN_AND_MEAN
-# include <windows.h>
-# include <io.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <io.h>
 #endif /* defined(WIN32) */
 
 #if !HAVE_OPEN && defined(WIN32)
-# define open _open
+#define open _open
 #endif
-
 
 #include "bits.h"
 #include "debug.h"
@@ -52,71 +51,82 @@
 #include "json_tokener.h"
 #include "json_util.h"
 
-struct json_object* json_object_from_file(char *filename)
+struct json_object *json_object_from_file(char *filename)
 {
-  struct printbuf *pb;
-  struct json_object *obj;
-  char buf[JSON_FILE_BUF_SIZE];
-  int fd, ret;
+	struct printbuf *pb;
+	struct json_object *obj;
+	char buf[JSON_FILE_BUF_SIZE];
+	int fd, ret;
 
-  if((fd = open(filename, O_RDONLY)) < 0) {
-    MC_ERROR("json_object_from_file: error reading file %s: %s\n",
-	     filename, strerror(errno));
-    return (struct json_object*)error_ptr(-1);
-  }
-  if(!(pb = printbuf_new())) {
-    MC_ERROR("json_object_from_file: printbuf_new failed\n");
-    return (struct json_object*)error_ptr(-1);
-  }
-  while((ret = read(fd, buf, JSON_FILE_BUF_SIZE)) > 0) {
-    printbuf_memappend(pb, buf, ret);
-  }
-  close(fd);
-  if(ret < 0) {
-    MC_ABORT("json_object_from_file: error reading file %s: %s\n",
-	     filename, strerror(errno));
-    printbuf_free(pb);
-    return (struct json_object*)error_ptr(-1);
-  }
-  obj = json_tokener_parse(pb->buf);
-  printbuf_free(pb);
-  return obj;
+	if ((fd = open(filename, O_RDONLY)) < 0) {
+		MC_ERROR(
+			"json_object_from_file: error reading file %s: %s\n",
+			filename,
+			strerror(errno));
+		return (struct json_object *)error_ptr(-1);
+	}
+	if (!(pb = printbuf_new())) {
+		MC_ERROR("json_object_from_file: printbuf_new failed\n");
+		return (struct json_object *)error_ptr(-1);
+	}
+	while ((ret = read(fd, buf, JSON_FILE_BUF_SIZE)) > 0) {
+		printbuf_memappend(pb, buf, ret);
+	}
+	close(fd);
+	if (ret < 0) {
+		MC_ABORT(
+			"json_object_from_file: error reading file %s: %s\n",
+			filename,
+			strerror(errno));
+		printbuf_free(pb);
+		return (struct json_object *)error_ptr(-1);
+	}
+	obj = json_tokener_parse(pb->buf);
+	printbuf_free(pb);
+	return obj;
 }
 
 int json_object_to_file(char *filename, struct json_object *obj)
 {
-  const char *json_str;
-  int fd, ret;
-  unsigned int wpos, wsize;
+	const char *json_str;
+	int fd, ret;
+	unsigned int wpos, wsize;
 
-  if(!obj) {
-    MC_ERROR("json_object_to_file: object is null\n");
-    return -1;
-  }
+	if (!obj) {
+		MC_ERROR("json_object_to_file: object is null\n");
+		return -1;
+	}
 
-  if((fd = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0644)) < 0) {
-    MC_ERROR("json_object_to_file: error opening file %s: %s\n",
-	     filename, strerror(errno));
-    return -1;
-  }
+	if ((fd = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0644)) < 0) {
+		MC_ERROR(
+			"json_object_to_file: error opening file %s: %s\n",
+			filename,
+			strerror(errno));
+		return -1;
+	}
 
-  if(!(json_str = json_object_to_json_string(obj))) { return -1; }
+	if (!(json_str = json_object_to_json_string(obj))) {
+		return -1;
+	}
 
+	wsize =
+		(unsigned int)(strlen(json_str)
+					   & UINT_MAX); /* CAW: probably unnecessary, but the most 64bit safe */
+	wpos = 0;
+	while (wpos < wsize) {
+		if ((ret = write(fd, json_str + wpos, wsize - wpos)) < 0) {
+			close(fd);
+			MC_ERROR(
+				"json_object_to_file: error writing file %s: %s\n",
+				filename,
+				strerror(errno));
+			return -1;
+		}
 
-  wsize = (unsigned int)(strlen(json_str) & UINT_MAX); /* CAW: probably unnecessary, but the most 64bit safe */
-  wpos = 0;
-  while(wpos < wsize) {
-    if((ret = write(fd, json_str + wpos, wsize-wpos)) < 0) {
-      close(fd);
-      MC_ERROR("json_object_to_file: error writing file %s: %s\n",
-	     filename, strerror(errno));
-      return -1;
-    }
+		/* because of the above check for ret < 0, we can safely cast and add */
+		wpos += (unsigned int)ret;
+	}
 
-	/* because of the above check for ret < 0, we can safely cast and add */
-    wpos += (unsigned int)ret;
-  }
-
-  close(fd);
-  return 0;
+	close(fd);
+	return 0;
 }

--- a/src/json-c/json_util.h
+++ b/src/json-c/json_util.h
@@ -21,7 +21,7 @@ extern "C" {
 #define JSON_FILE_BUF_SIZE 4096
 
 /* utility functions */
-extern struct json_object* json_object_from_file(char *filename);
+extern struct json_object *json_object_from_file(char *filename);
 extern int json_object_to_file(char *filename, struct json_object *obj);
 
 #ifdef __cplusplus

--- a/src/json-c/linkhash.c
+++ b/src/json-c/linkhash.c
@@ -41,48 +41,51 @@ int lh_ptr_equal(const void *k1, const void *k2)
 unsigned long lh_char_hash(const void *k)
 {
 	unsigned int h = 0;
-	const char* data = (const char*)k;
- 
-	while( *data!=0 ) h = h*129 + (unsigned int)(*data++) + LH_PRIME;
+	const char *data = (const char *)k;
+
+	while (*data != 0)
+		h = h * 129 + (unsigned int)(*data++) + LH_PRIME;
 
 	return h;
 }
 
 int lh_char_equal(const void *k1, const void *k2)
 {
-	return (strcmp((const char*)k1, (const char*)k2) == 0);
+	return (strcmp((const char *)k1, (const char *)k2) == 0);
 }
 
-struct lh_table* lh_table_new(int size, const char *name,
-			      lh_entry_free_fn *free_fn,
-			      lh_hash_fn *hash_fn,
-			      lh_equal_fn *equal_fn)
+struct lh_table *lh_table_new(
+	int size, const char *name, lh_entry_free_fn *free_fn, lh_hash_fn *hash_fn,
+	lh_equal_fn *equal_fn)
 {
 	int i;
 	struct lh_table *t;
 
-	t = (struct lh_table*)calloc(1, sizeof(struct lh_table));
-	if(!t) lh_abort("lh_table_new: calloc failed\n");
+	t = (struct lh_table *)calloc(1, sizeof(struct lh_table));
+	if (!t)
+		lh_abort("lh_table_new: calloc failed\n");
 	t->count = 0;
 	t->size = size;
 	t->name = name;
-	t->table = (struct lh_entry*)calloc(size, sizeof(struct lh_entry));
-	if(!t->table) lh_abort("lh_table_new: calloc failed\n");
+	t->table = (struct lh_entry *)calloc(size, sizeof(struct lh_entry));
+	if (!t->table)
+		lh_abort("lh_table_new: calloc failed\n");
 	t->free_fn = free_fn;
 	t->hash_fn = hash_fn;
 	t->equal_fn = equal_fn;
-	for(i = 0; i < size; i++) t->table[i].k = LH_EMPTY;
+	for (i = 0; i < size; i++)
+		t->table[i].k = LH_EMPTY;
 	return t;
 }
 
-struct lh_table* lh_kchar_table_new(int size, const char *name,
-				    lh_entry_free_fn *free_fn)
+struct lh_table *
+lh_kchar_table_new(int size, const char *name, lh_entry_free_fn *free_fn)
 {
 	return lh_table_new(size, name, free_fn, lh_char_hash, lh_char_equal);
 }
 
-struct lh_table* lh_kptr_table_new(int size, const char *name,
-				   lh_entry_free_fn *free_fn)
+struct lh_table *
+lh_kptr_table_new(int size, const char *name, lh_entry_free_fn *free_fn)
 {
 	return lh_table_new(size, name, free_fn, lh_ptr_hash, lh_ptr_equal);
 }
@@ -94,7 +97,7 @@ void lh_table_resize(struct lh_table *t, int new_size)
 
 	new_t = lh_table_new(new_size, t->name, NULL, t->hash_fn, t->equal_fn);
 	ent = t->head;
-	while(ent) {
+	while (ent) {
 		lh_table_insert(new_t, ent->k, ent->v);
 		ent = ent->next;
 	}
@@ -110,8 +113,8 @@ void lh_table_resize(struct lh_table *t, int new_size)
 void lh_table_free(struct lh_table *t)
 {
 	struct lh_entry *c;
-	for(c = t->head; c != NULL; c = c->next) {
-		if(t->free_fn) {
+	for (c = t->head; c != NULL; c = c->next) {
+		if (t->free_fn) {
 			t->free_fn(c);
 		}
 	}
@@ -119,28 +122,30 @@ void lh_table_free(struct lh_table *t)
 	free(t);
 }
 
-
 int lh_table_insert(struct lh_table *t, void *k, const void *v)
 {
 	unsigned long h, n;
 
 	t->inserts++;
-	if(t->count > t->size * 0.66) lh_table_resize(t, t->size * 2);
+	if (t->count > t->size * 0.66)
+		lh_table_resize(t, t->size * 2);
 
 	h = t->hash_fn(k);
 	n = h % t->size;
 
-	while( 1 ) {
-		if(t->table[n].k == LH_EMPTY || t->table[n].k == LH_FREED) break;
+	while (1) {
+		if (t->table[n].k == LH_EMPTY || t->table[n].k == LH_FREED)
+			break;
 		t->collisions++;
-		if(++n == t->size) n = 0;
+		if (++n == t->size)
+			n = 0;
 	}
 
 	t->table[n].k = k;
 	t->table[n].v = v;
 	t->count++;
 
-	if(t->head == NULL) {
+	if (t->head == NULL) {
 		t->head = t->tail = &t->table[n];
 		t->table[n].next = t->table[n].prev = NULL;
 	} else {
@@ -153,44 +158,50 @@ int lh_table_insert(struct lh_table *t, void *k, const void *v)
 	return 0;
 }
 
-
-struct lh_entry* lh_table_lookup_entry(struct lh_table *t, const void *k)
+struct lh_entry *lh_table_lookup_entry(struct lh_table *t, const void *k)
 {
 	unsigned long h = t->hash_fn(k);
 	unsigned long n = h % t->size;
 
 	t->lookups++;
-	while( 1 ) {
-		if(t->table[n].k == LH_EMPTY) return NULL;
-		if(t->table[n].k != LH_FREED &&
-		   t->equal_fn(t->table[n].k, k)) return &t->table[n];
-		if(++n == t->size) n = 0;
+	while (1) {
+		if (t->table[n].k == LH_EMPTY)
+			return NULL;
+		if (t->table[n].k != LH_FREED && t->equal_fn(t->table[n].k, k))
+			return &t->table[n];
+		if (++n == t->size)
+			n = 0;
 	}
 	return NULL;
 }
 
-
-const void* lh_table_lookup(struct lh_table *t, const void *k)
+const void *lh_table_lookup(struct lh_table *t, const void *k)
 {
 	struct lh_entry *e = lh_table_lookup_entry(t, k);
-	if(e) return e->v;
+	if (e)
+		return e->v;
 	return NULL;
 }
 
-
 int lh_table_delete_entry(struct lh_table *t, struct lh_entry *e)
 {
-	ptrdiff_t n = (ptrdiff_t)(e - t->table); /* CAW: fixed to be 64bit nice, still need the crazy negative case... */
+	ptrdiff_t n =
+		(ptrdiff_t)(e
+					- t->table); /* CAW: fixed to be 64bit nice, still need the crazy negative case... */
 
 	/* CAW: this is bad, really bad, maybe stack goes other direction on this machine... */
-	if(n < 0) { return -2; }
+	if (n < 0) {
+		return -2;
+	}
 
-	if(t->table[n].k == LH_EMPTY || t->table[n].k == LH_FREED) return -1;
+	if (t->table[n].k == LH_EMPTY || t->table[n].k == LH_FREED)
+		return -1;
 	t->count--;
-	if(t->free_fn) t->free_fn(e);
+	if (t->free_fn)
+		t->free_fn(e);
 	t->table[n].v = NULL;
 	t->table[n].k = LH_FREED;
-	if(t->tail == &t->table[n] && t->head == &t->table[n]) {
+	if (t->tail == &t->table[n] && t->head == &t->table[n]) {
 		t->head = t->tail = NULL;
 	} else if (t->head == &t->table[n]) {
 		t->head->next->prev = NULL;
@@ -206,11 +217,10 @@ int lh_table_delete_entry(struct lh_table *t, struct lh_entry *e)
 	return 0;
 }
 
-
 int lh_table_delete(struct lh_table *t, const void *k)
 {
 	struct lh_entry *e = lh_table_lookup_entry(t, k);
-	if(!e) return -1;
+	if (!e)
+		return -1;
 	return lh_table_delete_entry(t, e);
 }
-

--- a/src/json-c/linkhash.h
+++ b/src/json-c/linkhash.h
@@ -8,7 +8,7 @@
  * it under the terms of the MIT license. See COPYING for details.
  *
  */
- 
+
 #ifndef _linkhash_h_
 #define _linkhash_h_
 
@@ -24,27 +24,27 @@ extern "C" {
 /**
  * sentinel pointer value for empty slots
  */
-#define LH_EMPTY (void*)-1
+#define LH_EMPTY (void *)-1
 
 /**
  * sentinel pointer value for freed slots
  */
-#define LH_FREED (void*)-2
+#define LH_FREED (void *)-2
 
 struct lh_entry;
 
 /**
  * callback function prototypes
  */
-typedef void (lh_entry_free_fn) (struct lh_entry *e);
+typedef void(lh_entry_free_fn)(struct lh_entry *e);
 /**
  * callback function prototypes
  */
-typedef unsigned long (lh_hash_fn) (const void *k);
+typedef unsigned long(lh_hash_fn)(const void *k);
 /**
  * callback function prototypes
  */
-typedef int (lh_equal_fn) (const void *k1, const void *k2);
+typedef int(lh_equal_fn)(const void *k1, const void *k2);
 
 /**
  * An entry in the hash table
@@ -67,7 +67,6 @@ struct lh_entry {
 	 */
 	struct lh_entry *prev;
 };
-
 
 /**
  * The hash table structure.
@@ -132,7 +131,6 @@ struct lh_table {
 	lh_equal_fn *equal_fn;
 };
 
-
 /**
  * Pre-defined hash and equality functions
  */
@@ -142,20 +140,17 @@ extern int lh_ptr_equal(const void *k1, const void *k2);
 extern unsigned long lh_char_hash(const void *k);
 extern int lh_char_equal(const void *k1, const void *k2);
 
-
 /**
  * Convenience list iterator.
  */
-#define lh_foreach(table, entry) \
-for(entry = table->head; entry; entry = entry->next)
+#define lh_foreach(table, entry)                                               \
+	for (entry = table->head; entry; entry = entry->next)
 
 /**
  * lh_foreach_safe allows calling of deletion routine while iterating.
  */
-#define lh_foreach_safe(table, entry, tmp) \
-for(entry = table->head; entry && ((tmp = entry->next) || 1); entry = tmp)
-
-
+#define lh_foreach_safe(table, entry, tmp)                                     \
+	for (entry = table->head; entry && ((tmp = entry->next) || 1); entry = tmp)
 
 /**
  * Create a new linkhash table.
@@ -174,10 +169,9 @@ for(entry = table->head; entry && ((tmp = entry->next) || 1); entry = tmp)
  * and C strings respectively.
  * @return a pointer onto the linkhash table.
  */
-extern struct lh_table* lh_table_new(int size, const char *name,
-				     lh_entry_free_fn *free_fn,
-				     lh_hash_fn *hash_fn,
-				     lh_equal_fn *equal_fn);
+extern struct lh_table *lh_table_new(
+	int size, const char *name, lh_entry_free_fn *free_fn, lh_hash_fn *hash_fn,
+	lh_equal_fn *equal_fn);
 
 /**
  * Convenience function to create a new linkhash
@@ -187,9 +181,8 @@ extern struct lh_table* lh_table_new(int size, const char *name,
  * @param free_fn callback function used to free memory for entries.
  * @return a pointer onto the linkhash table.
  */
-extern struct lh_table* lh_kchar_table_new(int size, const char *name,
-					   lh_entry_free_fn *free_fn);
-
+extern struct lh_table *
+lh_kchar_table_new(int size, const char *name, lh_entry_free_fn *free_fn);
 
 /**
  * Convenience function to create a new linkhash
@@ -199,9 +192,8 @@ extern struct lh_table* lh_kchar_table_new(int size, const char *name,
  * @param free_fn callback function used to free memory for entries.
  * @return a pointer onto the linkhash table.
  */
-extern struct lh_table* lh_kptr_table_new(int size, const char *name,
-					  lh_entry_free_fn *free_fn);
-
+extern struct lh_table *
+lh_kptr_table_new(int size, const char *name, lh_entry_free_fn *free_fn);
 
 /**
  * Free a linkhash table.
@@ -211,7 +203,6 @@ extern struct lh_table* lh_kptr_table_new(int size, const char *name,
  */
 extern void lh_table_free(struct lh_table *t);
 
-
 /**
  * Insert a record into the table.
  * @param t the table to insert into.
@@ -220,14 +211,14 @@ extern void lh_table_free(struct lh_table *t);
  */
 extern int lh_table_insert(struct lh_table *t, void *k, const void *v);
 
-
 /**
  * Lookup a record into the table.
  * @param t the table to lookup
  * @param k a pointer to the key to lookup
  * @return a pointer to the record structure of the value or NULL if it does not exist.
  */
-extern struct lh_entry* lh_table_lookup_entry(struct lh_table *t, const void *k);
+extern struct lh_entry *
+lh_table_lookup_entry(struct lh_table *t, const void *k);
 
 /**
  * Lookup a record into the table
@@ -235,8 +226,7 @@ extern struct lh_entry* lh_table_lookup_entry(struct lh_table *t, const void *k)
  * @param k a pointer to the key to lookup
  * @return a pointer to the found value or NULL if it does not exist.
  */
-extern const void* lh_table_lookup(struct lh_table *t, const void *k);
-
+extern const void *lh_table_lookup(struct lh_table *t, const void *k);
 
 /**
  * Delete a record from the table.
@@ -249,7 +239,6 @@ extern const void* lh_table_lookup(struct lh_table *t, const void *k);
  */
 extern int lh_table_delete_entry(struct lh_table *t, struct lh_entry *e);
 
-
 /**
  * Delete a record from the table.
  * If a callback free function is provided then it is called for the
@@ -260,7 +249,6 @@ extern int lh_table_delete_entry(struct lh_table *t, struct lh_entry *e);
  * @return -1 if it was not found.
  */
 extern int lh_table_delete(struct lh_table *t, const void *k);
-
 
 void lh_abort(const char *msg, ...);
 void lh_table_resize(struct lh_table *t, int new_size);

--- a/src/json-c/printbuf.c
+++ b/src/json-c/printbuf.c
@@ -20,55 +20,60 @@
 #include <string.h>
 
 #if HAVE_STDARG_H
-# include <stdarg.h>
+#include <stdarg.h>
 #else /* !HAVE_STDARG_H */
-# error Not enough var arg support!
+#error Not enough var arg support!
 #endif /* HAVE_STDARG_H */
 
 #include "bits.h"
 #include "debug.h"
 #include "printbuf.h"
 
-struct printbuf* printbuf_new(void)
+struct printbuf *printbuf_new(void)
 {
-  struct printbuf *p;
+	struct printbuf *p;
 
-  p = (struct printbuf*)calloc(1, sizeof(struct printbuf));
-  if(!p) return NULL;
-  p->size = 32;
-  p->bpos = 0;
-  if(!(p->buf = (char*)malloc(p->size))) {
-    free(p);
-    return NULL;
-  }
-  return p;
+	p = (struct printbuf *)calloc(1, sizeof(struct printbuf));
+	if (!p)
+		return NULL;
+	p->size = 32;
+	p->bpos = 0;
+	if (!(p->buf = (char *)malloc(p->size))) {
+		free(p);
+		return NULL;
+	}
+	return p;
 }
-
 
 int printbuf_memappend(struct printbuf *p, const char *buf, int size)
 {
-  char *t;
-  if(p->size - p->bpos <= size) {
-    int new_size = json_max(p->size * 2, p->bpos + size + 8);
+	char *t;
+	if (p->size - p->bpos <= size) {
+		int new_size = json_max(p->size * 2, p->bpos + size + 8);
 #ifdef PRINTBUF_DEBUG
-    MC_DEBUG("printbuf_memappend: realloc "
-	     "bpos=%d wrsize=%d old_size=%d new_size=%d\n",
-	     p->bpos, size, p->size, new_size);
+		MC_DEBUG(
+			"printbuf_memappend: realloc "
+			"bpos=%d wrsize=%d old_size=%d new_size=%d\n",
+			p->bpos,
+			size,
+			p->size,
+			new_size);
 #endif /* PRINTBUF_DEBUG */
-    if(!(t = (char*)realloc(p->buf, new_size))) return -1;
-    p->size = new_size;
-    p->buf = t;
-  }
-  memcpy(p->buf + p->bpos, buf, size);
-  p->bpos += size;
-  p->buf[p->bpos]= '\0';
-  return size;
+		if (!(t = (char *)realloc(p->buf, new_size)))
+			return -1;
+		p->size = new_size;
+		p->buf = t;
+	}
+	memcpy(p->buf + p->bpos, buf, size);
+	p->bpos += size;
+	p->buf[p->bpos] = '\0';
+	return size;
 }
 
 #if !HAVE_VSNPRINTF && defined(WIN32)
-# define vsnprintf _vsnprintf
+#define vsnprintf _vsnprintf
 #elif !HAVE_VSNPRINTF /* !HAVE_VSNPRINTF */
-# error Need vsnprintf!
+#error Need vsnprintf!
 #endif /* !HAVE_VSNPRINTF && defined(WIN32) */
 
 #if !HAVE_VASPRINTF
@@ -81,22 +86,27 @@ static int vasprintf(char **buf, const char *fmt, va_list ap)
 	int chars;
 	char *b;
 
-	if(!buf) { return -1; }
+	if (!buf) {
+		return -1;
+	}
 
 #ifdef WIN32
-	chars = _vscprintf(fmt, ap)+1;
+	chars = _vscprintf(fmt, ap) + 1;
 #else /* !defined(WIN32) */
 	/* CAW: RAWR! We have to hope to god here that vsnprintf doesn't overwrite
 	   our buffer like on some 64bit sun systems.... but hey, its time to move on */
-	chars = vsnprintf(&_T_emptybuffer, 0, fmt, ap)+1;
-	if(chars < 0) { chars *= -1; } /* CAW: old glibc versions have this problem */
+	chars = vsnprintf(&_T_emptybuffer, 0, fmt, ap) + 1;
+	if (chars < 0) {
+		chars *= -1;
+	} /* CAW: old glibc versions have this problem */
 #endif /* defined(WIN32) */
 
-	b = (char*)malloc(sizeof(char)*chars);
-	if(!b) { return -1; }
+	b = (char *)malloc(sizeof(char) * chars);
+	if (!b) {
+		return -1;
+	}
 
-	if((chars = vsprintf(b, fmt, ap)) < 0)
-	{
+	if ((chars = vsprintf(b, fmt, ap)) < 0) {
 		free(b);
 	} else {
 		*buf = b;
@@ -108,42 +118,45 @@ static int vasprintf(char **buf, const char *fmt, va_list ap)
 
 int sprintbuf(struct printbuf *p, const char *msg, ...)
 {
-  va_list ap;
-  char *t;
-  int size;
-  char buf[128];
+	va_list ap;
+	char *t;
+	int size;
+	char buf[128];
 
-  /* user stack buffer first */
-  va_start(ap, msg);
-  size = vsnprintf(buf, 128, msg, ap);
-  va_end(ap);
-  /* if string is greater than stack buffer, then use dynamic string
+	/* user stack buffer first */
+	va_start(ap, msg);
+	size = vsnprintf(buf, 128, msg, ap);
+	va_end(ap);
+	/* if string is greater than stack buffer, then use dynamic string
      with vasprintf.  Note: some implementation of vsnprintf return -1
      if output is truncated whereas some return the number of bytes that
      would have been written - this code handles both cases. */
-  if(size == -1 || size > 127) {
-    va_start(ap, msg);
-    if((size = vasprintf(&t, msg, ap)) == -1) { va_end(ap); return -1; }
-    va_end(ap);
-    printbuf_memappend(p, t, size);
-    free(t);
-    return size;
-  } else {
-    printbuf_memappend(p, buf, size);
-    return size;
-  }
+	if (size == -1 || size > 127) {
+		va_start(ap, msg);
+		if ((size = vasprintf(&t, msg, ap)) == -1) {
+			va_end(ap);
+			return -1;
+		}
+		va_end(ap);
+		printbuf_memappend(p, t, size);
+		free(t);
+		return size;
+	} else {
+		printbuf_memappend(p, buf, size);
+		return size;
+	}
 }
 
 void printbuf_reset(struct printbuf *p)
 {
-  p->buf[0] = '\0';
-  p->bpos = 0;
+	p->buf[0] = '\0';
+	p->bpos = 0;
 }
 
 void printbuf_free(struct printbuf *p)
 {
-  if(p) {
-    free(p->buf);
-    free(p);
-  }
+	if (p) {
+		free(p->buf);
+		free(p);
+	}
 }

--- a/src/json-c/printbuf.h
+++ b/src/json-c/printbuf.h
@@ -23,39 +23,36 @@ extern "C" {
 #undef PRINTBUF_DEBUG
 
 struct printbuf {
-  char *buf;
-  int bpos;
-  int size;
+	char *buf;
+	int bpos;
+	int size;
 };
 
-extern struct printbuf*
-printbuf_new(void);
+extern struct printbuf *printbuf_new(void);
 
 /* As an optimization, printbuf_memappend is defined as a macro that
  * handles copying data if the buffer is large enough; otherwise it
  * invokes printbuf_memappend_real() which performs the heavy lifting
  * of realloc()ing the buffer and copying data.
  */
-extern int
-printbuf_memappend(struct printbuf *p, const char *buf, int size);
+extern int printbuf_memappend(struct printbuf *p, const char *buf, int size);
 
-#define printbuf_memappend_fast(p, bufptr, bufsize)          \
-do {                                                         \
-  if ((p->size - p->bpos) > bufsize) {                       \
-    memcpy(p->buf + p->bpos, (bufptr), bufsize);             \
-    p->bpos += bufsize;                                      \
-    p->buf[p->bpos]= '\0';                                   \
-  } else {  printbuf_memappend(p, (bufptr), bufsize); }      \
-} while (0)
+#define printbuf_memappend_fast(p, bufptr, bufsize)                            \
+	do {                                                                       \
+		if ((p->size - p->bpos) > bufsize) {                                   \
+			memcpy(p->buf + p->bpos, (bufptr), bufsize);                       \
+			p->bpos += bufsize;                                                \
+			p->buf[p->bpos] = '\0';                                            \
+		} else {                                                               \
+			printbuf_memappend(p, (bufptr), bufsize);                          \
+		}                                                                      \
+	} while (0)
 
-extern int
-sprintbuf(struct printbuf *p, const char *msg, ...);
+extern int sprintbuf(struct printbuf *p, const char *msg, ...);
 
-extern void
-printbuf_reset(struct printbuf *p);
+extern void printbuf_reset(struct printbuf *p);
 
-extern void
-printbuf_free(struct printbuf *p);
+extern void printbuf_free(struct printbuf *p);
 
 #ifdef __cplusplus
 }

--- a/src/json-c/test1.c
+++ b/src/json-c/test1.c
@@ -7,158 +7,166 @@
 
 int main(int argc, char **argv)
 {
-  json_tokener *tok;
-  json_object *my_string, *my_int, *my_object, *my_array;
-  json_object *new_obj;
-  int i;
+	json_tokener *tok;
+	json_object *my_string, *my_int, *my_object, *my_array;
+	json_object *new_obj;
+	int i;
 
-  MC_SET_DEBUG(1);
+	MC_SET_DEBUG(1);
 
-  my_string = json_object_new_string("\t");
-  printf("my_string=%s\n", json_object_get_string(my_string));
-  printf("my_string.to_string()=%s\n", json_object_to_json_string(my_string));
-  json_object_put(my_string);
+	my_string = json_object_new_string("\t");
+	printf("my_string=%s\n", json_object_get_string(my_string));
+	printf("my_string.to_string()=%s\n", json_object_to_json_string(my_string));
+	json_object_put(my_string);
 
-  my_string = json_object_new_string("\\");
-  printf("my_string=%s\n", json_object_get_string(my_string));
-  printf("my_string.to_string()=%s\n", json_object_to_json_string(my_string));
-  json_object_put(my_string);
+	my_string = json_object_new_string("\\");
+	printf("my_string=%s\n", json_object_get_string(my_string));
+	printf("my_string.to_string()=%s\n", json_object_to_json_string(my_string));
+	json_object_put(my_string);
 
-  my_string = json_object_new_string("foo");
-  printf("my_string=%s\n", json_object_get_string(my_string));
-  printf("my_string.to_string()=%s\n", json_object_to_json_string(my_string));
+	my_string = json_object_new_string("foo");
+	printf("my_string=%s\n", json_object_get_string(my_string));
+	printf("my_string.to_string()=%s\n", json_object_to_json_string(my_string));
 
-  my_int = json_object_new_int(9);
-  printf("my_int=%d\n", json_object_get_int(my_int));
-  printf("my_int.to_string()=%s\n", json_object_to_json_string(my_int));
+	my_int = json_object_new_int(9);
+	printf("my_int=%d\n", json_object_get_int(my_int));
+	printf("my_int.to_string()=%s\n", json_object_to_json_string(my_int));
 
-  my_array = json_object_new_array();
-  json_object_array_add(my_array, json_object_new_int(1));
-  json_object_array_add(my_array, json_object_new_int(2));
-  json_object_array_add(my_array, json_object_new_int(3));
-  json_object_array_put_idx(my_array, 4, json_object_new_int(5));
-  printf("my_array=\n");
-  for(i=0; i < json_object_array_length(my_array); i++) {
-    json_object *obj = json_object_array_get_idx(my_array, i);
-    printf("\t[%d]=%s\n", i, json_object_to_json_string(obj));
-  }
-  printf("my_array.to_string()=%s\n", json_object_to_json_string(my_array));    
+	my_array = json_object_new_array();
+	json_object_array_add(my_array, json_object_new_int(1));
+	json_object_array_add(my_array, json_object_new_int(2));
+	json_object_array_add(my_array, json_object_new_int(3));
+	json_object_array_put_idx(my_array, 4, json_object_new_int(5));
+	printf("my_array=\n");
+	for (i = 0; i < json_object_array_length(my_array); i++) {
+		json_object *obj = json_object_array_get_idx(my_array, i);
+		printf("\t[%d]=%s\n", i, json_object_to_json_string(obj));
+	}
+	printf("my_array.to_string()=%s\n", json_object_to_json_string(my_array));
 
-  my_object = json_object_new_object();
-  json_object_object_add(my_object, "abc", json_object_new_int(12));
-  json_object_object_add(my_object, "foo", json_object_new_string("bar"));
-  json_object_object_add(my_object, "bool0", json_object_new_boolean(0));
-  json_object_object_add(my_object, "bool1", json_object_new_boolean(1));
-  json_object_object_add(my_object, "baz", json_object_new_string("bang"));
-  json_object_object_add(my_object, "baz", json_object_new_string("fark"));
-  json_object_object_del(my_object, "baz");
-  /*json_object_object_add(my_object, "arr", my_array);*/
-  printf("my_object=\n");
-  json_object_object_foreach(my_object, key, val) {
-    printf("\t%s: %s\n", key, json_object_to_json_string(val));
-  }
-  printf("my_object.to_string()=%s\n", json_object_to_json_string(my_object));
+	my_object = json_object_new_object();
+	json_object_object_add(my_object, "abc", json_object_new_int(12));
+	json_object_object_add(my_object, "foo", json_object_new_string("bar"));
+	json_object_object_add(my_object, "bool0", json_object_new_boolean(0));
+	json_object_object_add(my_object, "bool1", json_object_new_boolean(1));
+	json_object_object_add(my_object, "baz", json_object_new_string("bang"));
+	json_object_object_add(my_object, "baz", json_object_new_string("fark"));
+	json_object_object_del(my_object, "baz");
+	/*json_object_object_add(my_object, "arr", my_array);*/
+	printf("my_object=\n");
+	json_object_object_foreach(my_object, key, val)
+	{
+		printf("\t%s: %s\n", key, json_object_to_json_string(val));
+	}
+	printf("my_object.to_string()=%s\n", json_object_to_json_string(my_object));
 
-  new_obj = json_tokener_parse("\"\003\"");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("\"\003\"");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("/* hello */\"foo\"");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("/* hello */\"foo\"");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("// hello\n\"foo\"");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("// hello\n\"foo\"");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("\"\\u0041\\u0042\\u0043\"");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("\"\\u0041\\u0042\\u0043\"");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("null");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("null");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("True");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("True");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("12");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("12");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("12.3");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("12.3");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("[\"\\n\"]");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("[\"\\n\"]");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("[\"\\nabc\\n\"]");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("[\"\\nabc\\n\"]");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("[null]");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("[null]");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("[]");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("[]");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("[false]");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("[false]");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("[\"abc\",null,\"def\",12]");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("[\"abc\",null,\"def\",12]");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("{}");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("{}");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("{ \"foo\": \"bar\" }");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("{ \"foo\": \"bar\" }");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("{ \"foo\": \"bar\", \"baz\": null, \"bool0\": true }");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse(
+		"{ \"foo\": \"bar\", \"baz\": null, \"bool0\": true }");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("{ \"foo\": [null, \"foo\"] }");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse("{ \"foo\": [null, \"foo\"] }");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("{ \"abc\": 12, \"foo\": \"bar\", \"bool0\": false, \"bool1\": true, \"arr\": [ 1, 2, 3, null, 5 ] }");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse(
+		"{ \"abc\": 12, \"foo\": \"bar\", \"bool0\": false, \"bool1\": true, \"arr\": [ 1, 2, 3, null, 5 ] }");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  new_obj = json_tokener_parse("{ foo }");
-  if(is_error(new_obj)) printf("got error as expected\n");
+	new_obj = json_tokener_parse("{ foo }");
+	if (is_error(new_obj))
+		printf("got error as expected\n");
 
-  new_obj = json_tokener_parse("foo");
-  if(is_error(new_obj)) printf("got error as expected\n");
+	new_obj = json_tokener_parse("foo");
+	if (is_error(new_obj))
+		printf("got error as expected\n");
 
-  new_obj = json_tokener_parse("{ \"foo");
-  if(is_error(new_obj)) printf("got error as expected\n");
+	new_obj = json_tokener_parse("{ \"foo");
+	if (is_error(new_obj))
+		printf("got error as expected\n");
 
-  /* test incremental parsing */
-  tok = json_tokener_new();
-  new_obj = json_tokener_parse_ex(tok, "{ \"foo", 6);
-  if(is_error(new_obj)) printf("got error as expected\n");
-  new_obj = json_tokener_parse_ex(tok, "\": {\"bar", 8);
-  if(is_error(new_obj)) printf("got error as expected\n");
-  new_obj = json_tokener_parse_ex(tok, "\":13}}", 6);
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);  
-  json_tokener_free(tok);
+	/* test incremental parsing */
+	tok = json_tokener_new();
+	new_obj = json_tokener_parse_ex(tok, "{ \"foo", 6);
+	if (is_error(new_obj))
+		printf("got error as expected\n");
+	new_obj = json_tokener_parse_ex(tok, "\": {\"bar", 8);
+	if (is_error(new_obj))
+		printf("got error as expected\n");
+	new_obj = json_tokener_parse_ex(tok, "\":13}}", 6);
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
+	json_tokener_free(tok);
 
-  json_object_put(my_string);
-  json_object_put(my_int);
-  json_object_put(my_object);
-  //json_object_put(my_array);
+	json_object_put(my_string);
+	json_object_put(my_int);
+	json_object_put(my_object);
+	//json_object_put(my_array);
 
-  return 0;
+	return 0;
 }

--- a/src/json-c/test2.c
+++ b/src/json-c/test2.c
@@ -5,16 +5,16 @@
 
 #include "json.h"
 
-
 int main(int argc, char **argv)
 {
-  json_object *new_obj;
+	json_object *new_obj;
 
-  MC_SET_DEBUG(1);
+	MC_SET_DEBUG(1);
 
-  new_obj = json_tokener_parse("/* more difficult test case */ { \"glossary\": { \"title\": \"example glossary\", \"GlossDiv\": { \"title\": \"S\", \"GlossList\": [ { \"ID\": \"SGML\", \"SortAs\": \"SGML\", \"GlossTerm\": \"Standard Generalized Markup Language\", \"Acronym\": \"SGML\", \"Abbrev\": \"ISO 8879:1986\", \"GlossDef\": \"A meta-markup language, used to create markup languages such as DocBook.\", \"GlossSeeAlso\": [\"GML\", \"XML\", \"markup\"] } ] } } }");
-  printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
-  json_object_put(new_obj);
+	new_obj = json_tokener_parse(
+		"/* more difficult test case */ { \"glossary\": { \"title\": \"example glossary\", \"GlossDiv\": { \"title\": \"S\", \"GlossList\": [ { \"ID\": \"SGML\", \"SortAs\": \"SGML\", \"GlossTerm\": \"Standard Generalized Markup Language\", \"Acronym\": \"SGML\", \"Abbrev\": \"ISO 8879:1986\", \"GlossDef\": \"A meta-markup language, used to create markup languages such as DocBook.\", \"GlossSeeAlso\": [\"GML\", \"XML\", \"markup\"] } ] } } }");
+	printf("new_obj.to_string()=%s\n", json_object_to_json_string(new_obj));
+	json_object_put(new_obj);
 
-  return 0;
+	return 0;
 }


### PR DESCRIPTION
Definitely one of the fixes lol

![image](https://github.com/DarkRTA/rb3/assets/29052821/5f59f2f4-6f55-450b-9598-0d0ded3896f8)

I reformatted everything because the formatting was *atrocious* with the current editor config settings. json-c (the version used here, at least) is intended to have a tab size of 8, but it also uses a mix of spaces and tabs to achieve an effective indentation size of 2: tabs for each multiple of 8, spaces for the rest. Very weird hybrid.

I also can't get json_tokener to link for some reason, linker complains about `isspace` not being defined when linking `fn_8048D200` in `auto_03_80472568.o`. `isspace` is inline and is getting compiled into `json_tokener.o`, which I've verified is correct (it comes right after `json_tokener_parse_ex` in both the original binary and the compiled object), and it is not getting name mangled.