### PR TITLE
Fix json-c warnings and link json_tokener

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -322,7 +322,7 @@ config.libs = [
         "objects": [
             Object(Matching, "json-c/arraylist.c"),
             Object(Matching, "json-c/json_object.c"),
-            Object(NonMatching, "json-c/json_tokener.c"), # Matches but doesn't link
+            Object(Matching, "json-c/json_tokener.c"),
             Object(Matching, "json-c/linkhash.c"),
             Object(Matching, "json-c/printbuf.c")
         ]

--- a/src/json-c/debug.h
+++ b/src/json-c/debug.h
@@ -29,10 +29,10 @@ extern void mc_info(const char *msg, ...);
 #define MC_SET_DEBUG(x) mc_set_debug(x)
 #define MC_GET_DEBUG() mc_get_debug()
 #define MC_SET_SYSLOG(x) mc_set_syslog(x)
-#define MC_ABORT(x, ...) mc_abort(x, ##__VA_ARGS__)
-#define MC_DEBUG(x, ...) mc_debug(x, ##__VA_ARGS__)
-#define MC_ERROR(x, ...) mc_error(x, ##__VA_ARGS__)
-#define MC_INFO(x, ...) mc_info(x, ##__VA_ARGS__)
+#define MC_ABORT(x, ...) mc_abort(x, __VA_ARGS__)
+#define MC_DEBUG(x, ...) mc_debug(x, __VA_ARGS__)
+#define MC_ERROR(x, ...) mc_error(x, __VA_ARGS__)
+#define MC_INFO(x, ...) mc_info(x, __VA_ARGS__)
 #else
 #define MC_SET_DEBUG(x)                                                        \
 	if (0)                                                                     \
@@ -43,16 +43,16 @@ extern void mc_info(const char *msg, ...);
 	mc_set_syslog(x)
 #define MC_ABORT(x, ...)                                                       \
 	if (0)                                                                     \
-	mc_abort(x, ##__VA_ARGS__)
+	mc_abort(x, __VA_ARGS__)
 #define MC_DEBUG(x, ...)                                                       \
 	if (0)                                                                     \
-	mc_debug(x, ##__VA_ARGS__)
+	mc_debug(x, __VA_ARGS__)
 #define MC_ERROR(x, ...)                                                       \
 	if (0)                                                                     \
-	mc_error(x, ##__VA_ARGS__)
+	mc_error(x, __VA_ARGS__)
 #define MC_INFO(x, ...)                                                        \
 	if (0)                                                                     \
-	mc_info(x, ##__VA_ARGS__)
+	mc_info(x, __VA_ARGS__)
 #endif
 
 #ifdef __cplusplus

--- a/src/std/ctype.h
+++ b/src/std/ctype.h
@@ -9,59 +9,59 @@
 extern "C" {
 #endif
 
-static inline int isalnum(int c) {
+inline int isalnum(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_alnum);
 }
 
-static inline int isalpha(int c) {
+inline int isalpha(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_alpha);
 }
 
-static inline int isblank(int c) {
+inline int isblank(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_blank);
 }
 
-static inline int iscntrl(int c) {
+inline int iscntrl(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_cntrl);
 }
 
-static inline int isdigit(int c) {
+inline int isdigit(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_digit);
 }
 
-static inline int isgraph(int c) {
+inline int isgraph(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_graph);
 }
 
-static inline int islower(int c) {
+inline int islower(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_lower);
 }
 
-static inline int isprint(int c) {
+inline int isprint(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_print);
 }
 
-static inline int ispunct(int c) {
+inline int ispunct(int c) {
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_punct);
 }
 
-static inline int isspace(int c) { 
+inline int isspace(int c) { 
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_space); 
 }
 
-static inline int isupper(int c) { 
+inline int isupper(int c) { 
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_upper); 
 }
 
-static inline int isxdigit(int c) { 
+inline int isxdigit(int c) { 
     return (c < 0 || c >= 256) ? 0 : (int)(_current_locale.ctype_cmpt_ptr->ctype_map_ptr[c] & ctype_xdigit); 
 }
 
-static inline int tolower(int c) {
+inline int tolower(int c) {
     return (c < 0 || c >= 256) ? c : (int)(&_current_locale)->ctype_cmpt_ptr->lower_map_ptr[c];
 }
 
-static inline int toupper(int c) {
+inline int toupper(int c) {
     return (c < 0 || c >= 256) ? c : (int)(&_current_locale)->ctype_cmpt_ptr->upper_map_ptr[c];
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -13,7 +13,6 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int uint;
 typedef unsigned long u32;
-typedef unsigned long size_t;
 typedef unsigned long long u64;
 
 typedef volatile u8 vu8;


### PR DESCRIPTION
- Remove concat sequence in json-c debug macros to fix `invalid token pasting of ',' and 'tok'` warning
- Remove `size_t` from types.h to prevent re-definition warning, it's already defined by stddef.h
- Remove `static` from ctype.h's inline methods to fix linker errors