### PR TITLE
More decompctx adjustments

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -17,7 +17,10 @@
                     "${workspaceFolder}/src/**"
                 ],
                 "limitSymbolsToIncludedHeaders": true
-            }
+            },
+            "defines": [
+                "NDEBUG"
+            ]
         }
     ],
     "version": 4

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,6 +39,20 @@
         "kind": "build",
         "isDefault": true
       }
+    },
+    {
+      "label": "decompctx (current file)",
+      "type": "shell",
+      "command": "python",
+      "args": [
+        "decompctx.py",
+        "${relativeFile}"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "group": "none"
     }
   ]
 }

--- a/configure.py
+++ b/configure.py
@@ -152,8 +152,13 @@ cflags_includes = [
     "-i src",
 ]
 
+cflags_defines = [
+    "-d NDEBUG",
+]
+
 cflags_base = [
     *cflags_includes,
+    *cflags_defines,
     "-nodefaults",
     "-proc gekko",
     "-align powerpc",

--- a/decompctx.py
+++ b/decompctx.py
@@ -24,6 +24,46 @@ default_defines: dict[str, str] = {
     "__MWERKS__" : "0x4302",
 }
 
+passthrough_defines: list[str] = [
+    # C/C++-dependent
+    "__cplusplus",
+    "__STDC__",
+    "__STDC_VERSION__",
+
+    # __option
+    "__option",
+    "little_endian",
+    "wchar_type",
+    "exceptions",
+    "longlong",
+
+    # __declspec
+    "__declspec",
+    "section",
+    "dllexport",
+    "dllimport",
+    "noreturn",
+    "weak",
+
+    # __attribute__
+    "__attribute__",
+    "aligned",
+    "packed",
+    "unused",
+    "weak",
+    "never_inline",
+    "format",
+    "constructor",
+    "destructor",
+
+    # STLport
+    # Namespaces are excluded when __cplusplus is undefined, but because we
+    # pass it through, pcpp never executes the define for _STLP_HAS_NO_NAMESPACES
+    "_STLP_HAS_NO_NAMESPACES",
+    "_STLP_USE_NAMESPACES",
+    "_STLP_NO_NAMESPACES",
+]
+
 # Bring in defines from configure.py so we don't have to duplicate them here
 for flag in cflags_defines:
     parts = flag.strip("-d").lstrip().split("=")
@@ -61,6 +101,21 @@ class ContextPreprocessor(CmdPreprocessor):
             return curdir
 
         return super(ContextPreprocessor, self).on_include_not_found(is_malformed, is_system_include, curdir, includepath)
+
+    def on_unknown_macro_in_expr(self, ident):
+        if ident in passthrough_defines:
+            return None
+        return super(ContextPreprocessor, self).on_unknown_macro_in_expr(ident)
+
+    def on_unknown_macro_in_defined_expr(self, tok):
+        if tok.value in passthrough_defines:
+            return None
+        return super(ContextPreprocessor, self).on_unknown_macro_in_defined_expr(tok)
+
+    def on_unknown_macro_function_in_expr(self, ident):
+        if ident in passthrough_defines:
+            return None
+        return super(ContextPreprocessor, self).on_unknown_macro_function_in_expr(ident)
 #endregion
 
 #region Attribute Stripping

--- a/decompctx.py
+++ b/decompctx.py
@@ -11,7 +11,7 @@ from pcpp import CmdPreprocessor
 from contextlib import redirect_stdout
 
 # Note: requires being in the same directory as configure.py
-from configure import cflags_includes
+from configure import cflags_includes, cflags_defines
 
 #region Regex Patterns
 at_address_pattern = re.compile(r"(?:.*?)(?:[a-zA-Z_$][\w$]*\s*\*?\s[a-zA-Z_$][\w$]*)\s*((?:AT_ADDRESS|:)(?:\s*\(?\s*)(0x[0-9a-fA-F]+|[a-zA-Z_$][\w$]*)\)?);")
@@ -23,6 +23,18 @@ binary_literal_pattern = re.compile(r"\b(0b[01]+)\b")
 default_defines: dict[str, str] = {
     "__MWERKS__" : "0x4302",
 }
+
+# Bring in defines from configure.py so we don't have to duplicate them here
+for flag in cflags_defines:
+    parts = flag.strip("-d").lstrip().split("=")
+    partCount = len(parts)
+
+    symbol = parts[0]
+    value = "1"
+    if partCount > 1:
+        value = parts[1]
+
+    default_defines[symbol] = value
 
 src_dir = "src"
 include_dir = "include"

--- a/decompctx.py
+++ b/decompctx.py
@@ -20,6 +20,14 @@ binary_literal_pattern = re.compile(r"\b(0b[01]+)\b")
 #endregion
 
 #region Defaults
+default_arguments: list[str] = [
+    # Strip out left-over whitespace
+    "--compress",
+
+    # Put a newline before each line directive
+    "--line-directive", "\n#line"
+]
+
 default_defines: dict[str, str] = {
     "__MWERKS__" : "0x4302",
 }
@@ -257,6 +265,9 @@ def main():
     # Add the defines to the arguments
     for define in include_defines:
         preprocessor_arguments.extend(("-D", define))
+
+    # Add other default arguments
+    preprocessor_arguments.extend(default_arguments)
 
     # Add unknown arguments and pass them to pcpp
     pass_through_args = parsed_args[1]

--- a/src/std_native/assert.h
+++ b/src/std_native/assert.h
@@ -7,7 +7,11 @@ extern "C" {
 
 #include "PowerPC_EABI_Support/MSL_C/MSL_Common/assert_api.h"
 
+#ifdef NDEBUG
+#define assert(condition) ((void)0)
+#else
 #define assert(condition) ((condition) ? ((void)0) : __msl_assertion_failed(#condition, __FILE__, 0, __LINE__))
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
A couple growing pains from the new script lol, hopefully there's not much else that needs to be done.

Script adjustments:
- Fix `#include <file>` directives not resolving paths in the same directory as the including file
- Pass through a number of unknown defines to help prevent context being only C or C++ compatible
- Clean up file output a little bit by stripping blank lines and adding a newline before the added `#line` directives

Other changes:
- Add defines list to configure.py, and pull those in decompctx
- Fix `assert` macro not respecting `NDEBUG` define
- Add VS Code task for generating context for the current file