### PR TITLE
Better macro handling in context generator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "cwd": "${workspaceFolder}",
+      "args": [],
+      "console": "integratedTerminal",
+      "justMyCode": true
+    }
+  ]
+}

--- a/cflags_common.py
+++ b/cflags_common.py
@@ -1,0 +1,26 @@
+cflags_includes = [
+    "-i src/stlport/stlport",
+    "-i src/PowerPC_EABI_Support/MSL_C/MSL_Common",
+    "-i src/PowerPC_EABI_Support/MSL_C/MSL_Common_Embedded",
+    "-i src/PowerPC_EABI_Support/MSL_C/MSL_Common_Embedded/Math",
+    "-i src/PowerPC_EABI_Support/MetroTRK",
+    # "-i src/tainted/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include",
+    "-i src/bt/gki/common",
+    "-i src/bt/bta/include",
+    "-i src/bt/utils/include",
+    "-i src/bt/stack/l2cap",
+    "-i src/bt/stack/btm",
+    "-i src/bt/include",
+    "-i src/bt/stack/include",
+    "-i src/libogg/include",
+    "-i src/speex/include",
+    "-i src/speex",
+    "-i src/RVL_SDK",
+    "-i src/std_native",
+    "-i src/rb3",
+    "-i src",
+]
+
+cflags_defines = [
+    "-d NDEBUG",
+]

--- a/configure.py
+++ b/configure.py
@@ -24,6 +24,8 @@ from tools.project import (
     is_windows,
 )
 
+from cflags_common import cflags_includes, cflags_defines
+
 # Game versions
 DEFAULT_VERSION = 0
 VERSIONS = [
@@ -146,33 +148,6 @@ config.ldflags = [
 ]
 config.shift_jis = False
 config.progress_all = False
-
-cflags_includes = [
-    "-i src/stlport/stlport",
-    "-i src/PowerPC_EABI_Support/MSL_C/MSL_Common",
-    "-i src/PowerPC_EABI_Support/MSL_C/MSL_Common_Embedded",
-    "-i src/PowerPC_EABI_Support/MSL_C/MSL_Common_Embedded/Math",
-    "-i src/PowerPC_EABI_Support/MetroTRK",
-    # "-i src/tainted/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include",
-    "-i src/bt/gki/common",
-    "-i src/bt/bta/include",
-    "-i src/bt/utils/include",
-    "-i src/bt/stack/l2cap",
-    "-i src/bt/stack/btm",
-    "-i src/bt/include",
-    "-i src/bt/stack/include",
-    "-i src/libogg/include",
-    "-i src/speex/include",
-    "-i src/speex",
-    "-i src/RVL_SDK",
-    "-i src/std_native",
-    "-i src/rb3",
-    "-i src",
-]
-
-cflags_defines = [
-    "-d NDEBUG",
-]
 
 cflags_base = [
     *cflags_includes,
@@ -577,16 +552,12 @@ config.libs = [
     },
 ]
 
-def main():
-    if args.mode == "configure":
-        # Write build.ninja and objdiff.json
-        generate_build(config)
-    elif args.mode == "progress":
-        # Print progress and write progress.json
-        config.progress_each_module = args.verbose
-        calculate_progress(config)
-    else:
-        sys.exit("Unknown mode: " + args.mode)
-
-if __name__ == "__main__":
-    main()
+if args.mode == "configure":
+    # Write build.ninja and objdiff.json
+    generate_build(config)
+elif args.mode == "progress":
+    # Print progress and write progress.json
+    config.progress_each_module = args.verbose
+    calculate_progress(config)
+else:
+    sys.exit("Unknown mode: " + args.mode)

--- a/decompctx.py
+++ b/decompctx.py
@@ -11,8 +11,8 @@ from pcpp import CmdPreprocessor
 from pcpp.evaluator import Value
 from contextlib import redirect_stdout
 
-# Note: requires being in the same directory as configure.py
-from configure import cflags_includes, cflags_defines
+# Note: requires being in the same directory as cflags_common.py
+from cflags_common import cflags_includes, cflags_defines
 
 #region Regex Patterns
 at_address_pattern = re.compile(r"(?:.*?)(?:[a-zA-Z_$][\w$]*\s*\*?\s[a-zA-Z_$][\w$]*)\s*((?:AT_ADDRESS|:)(?:\s*\(?\s*)(0x[0-9a-fA-F]+|[a-zA-Z_$][\w$]*)\)?);")


### PR DESCRIPTION
By default, `#define`s are preserved and macros are no longer expanded outside of preprocessor directives. This allows them to still be used in scratches, and generally keeps things more understandable.

There is also now an option to evaluate `__option()` macros such as `__option(longlong)` or `__option(wchar_type)`, for Ghidra or m2c pre-processing.

Before:
![image](https://github.com/DarkRTA/rb3/assets/29052821/8035b8d7-9d8e-43ef-b625-b30846479176)

After:
![image](https://github.com/DarkRTA/rb3/assets/29052821/d65fcc90-6f46-439f-baaa-2cc2f913a600)
