### PR TITLE
Some macro fixes

### DIFF
--- a/src/RVL_SDK/revolution/ai/ai_hardware.h
+++ b/src/RVL_SDK/revolution/ai/ai_hardware.h
@@ -1,5 +1,6 @@
 #ifndef RVL_SDK_AI_HARDWARE_H
 #define RVL_SDK_AI_HARDWARE_H
+#include "revolution/os/OSUtils.h"
 #include "types.h"
 #ifdef __cplusplus
 extern "C" {

--- a/src/RVL_SDK/revolution/dsp/dsp_hardware.h
+++ b/src/RVL_SDK/revolution/dsp/dsp_hardware.h
@@ -1,5 +1,6 @@
 #ifndef RVL_SDK_DSP_HARDWARE_H
 #define RVL_SDK_DSP_HARDWARE_H
+#include "revolution/os/OSUtils.h"
 #include "types.h"
 #ifdef __cplusplus
 extern "C" {

--- a/src/RVL_SDK/revolution/exi/EXIHardware.h
+++ b/src/RVL_SDK/revolution/exi/EXIHardware.h
@@ -1,6 +1,7 @@
 #ifndef RVL_SDK_EXI_HARDWARE_H
 #define RVL_SDK_EXI_HARDWARE_H
 #include "revolution/exi/EXICommon.h"
+#include "revolution/os/OSUtils.h"
 #include "types.h"
 #ifdef __cplusplus
 extern "C" {

--- a/src/RVL_SDK/revolution/gx/GXHardware.h
+++ b/src/RVL_SDK/revolution/gx/GXHardware.h
@@ -1,6 +1,7 @@
 #ifndef RVL_SDK_GX_HARDWARE_H
 #define RVL_SDK_GX_HARDWARE_H
 #include "revolution/gx/GXTypes.h"
+#include "revolution/os/OSUtils.h"
 #include "types.h"
 #ifdef __cplusplus
 extern "C" {

--- a/src/RVL_SDK/revolution/ipc/ipcMain.h
+++ b/src/RVL_SDK/revolution/ipc/ipcMain.h
@@ -1,5 +1,6 @@
 #ifndef RVL_SDK_IPC_MAIN_H
 #define RVL_SDK_IPC_MAIN_H
+#include "revolution/os/OSUtils.h"
 #include "types.h"
 #ifdef __cplusplus
 extern "C" {

--- a/src/RVL_SDK/revolution/os/OSHardware.h
+++ b/src/RVL_SDK/revolution/os/OSHardware.h
@@ -2,6 +2,7 @@
 #define RVL_SDK_OS_HARDWARE_H
 #include "revolution/os/OSAddress.h"
 #include "revolution/os/OSThread.h"
+#include "revolution/os/OSUtils.h"
 #include "revolution/dvd/dvdidutils.h"
 #include "types.h"
 #ifdef __cplusplus

--- a/src/RVL_SDK/revolution/os/OSHardware.h
+++ b/src/RVL_SDK/revolution/os/OSHardware.h
@@ -105,7 +105,7 @@ OS_DEF_GLOBAL_VAR(u32, CPU_CLOCK_SPEED,                    0x800000FC);
  */
 OS_DEF_GLOBAL_ARR(void*, EXCEPTION_TABLE, 15,            0x80003000);
 OS_DEF_GLOBAL_VAR(void*, INTR_HANDLER_TABLE,             0x80003040);
-OS_DEF_GLOBAL_ARR(volatile s32, EXI_800030C0, 0,         0x800030C0);
+OS_DEF_GLOBAL_ARR(volatile s32, EXI_800030C0, 1,         0x800030C0);
 OS_DEF_GLOBAL_VAR(void*, FIRST_REL,                      0x800030C8);
 OS_DEF_GLOBAL_VAR(void*, LAST_REL,                       0x800030CC);
 OS_DEF_GLOBAL_VAR(void*, REL_NAME_TABLE,                 0x800030D0);

--- a/src/RVL_SDK/revolution/vi/vihardware.h
+++ b/src/RVL_SDK/revolution/vi/vihardware.h
@@ -1,5 +1,6 @@
 #ifndef RVL_SDK_VI_HARDWARE_H
 #define RVL_SDK_VI_HARDWARE_H
+#include "revolution/os/OSUtils.h"
 #include "types.h"
 #ifdef __cplusplus
 extern "C" {

--- a/src/macros.h
+++ b/src/macros.h
@@ -40,7 +40,7 @@
 #ifdef __MWERKS__
 #define AT_ADDRESS(x) : (x)
 #define ASM_DECL asm
-#define ASM_BLOCK(...) asm { __VA_ARGS__ }
+#define ASM_BLOCK asm
 #else
 #define AT_ADDRESS(x)
 #define ASM_DECL

--- a/src/macros.h
+++ b/src/macros.h
@@ -38,11 +38,9 @@
 
 // For VSCode
 #ifdef __MWERKS__
-#define AT_ADDRESS(x) : (x)
 #define ASM_DECL asm
 #define ASM_BLOCK asm
 #else
-#define AT_ADDRESS(x)
 #define ASM_DECL
 #define ASM_BLOCK(...)
 #define __declspec(x)

--- a/src/macros.h
+++ b/src/macros.h
@@ -43,6 +43,7 @@
 #else
 #define ASM_DECL
 #define ASM_BLOCK(...)
+#define __option(x)
 #define __declspec(x)
 #define __attribute__(x)
 #endif


### PR DESCRIPTION
- `ASM_BLOCK` is now defined as just `asm` under MWCC, both `asm{}` and `asm()` are valid forms of asm blocks. Without this, instructions with variable operand counts won't work correctly due to everything being smooshed onto one line without semicolon separation.
- `AT_ADDRESS` is already defined in `revolution/os/OSUtils.h`, we don't need to re-define it ourselves.
- Add `__option` macro stub for VS Code
- Fix invalid array length in `OSHardware.h`