### PR TITLE
Ghidra symbol importer upgrades

### DIFF
--- a/tools/batch-demangle/Cargo.lock
+++ b/tools/batch-demangle/Cargo.lock
@@ -142,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +171,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "cwdemangle",
+ "lazy_static",
 ]
 
 [[package]]

--- a/tools/batch-demangle/Cargo.toml
+++ b/tools/batch-demangle/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.4.18", features = ["derive"] }
 cwdemangle = { git = "https://github.com/encounter/cwdemangle", version = "0.1.7" }
+lazy_static = "1.4.0"

--- a/tools/batch-demangle/src/main.rs
+++ b/tools/batch-demangle/src/main.rs
@@ -12,11 +12,11 @@ fn main() {
     let f = read_to_string(args.input).unwrap();
 
     for line in f.lines() {
-        let parts = line.split(" ").collect::<Vec<_>>();
-        let sym = parts[0];
-
-        let addr_idx = parts[2].find("0x").unwrap();
-        let addr = &parts[2][addr_idx..addr_idx + 10];
+        // Symbol info: symbol = section:0x<address>; // type:<type> [flags...]
+        let (sym, remaining) = line.split_once(" = ").unwrap();
+        let (_section, remaining) = remaining.split_once(':').unwrap();
+        let (addr, _remaining) = remaining.split_once("; // ").unwrap();
+        // let flags = remaining.split(' ').collect::<Vec<_>>();
 
         match demangle(sym, &DemangleOptions {
             omit_empty_parameters: false

--- a/tools/batch-demangle/src/main.rs
+++ b/tools/batch-demangle/src/main.rs
@@ -14,16 +14,19 @@ fn main() {
     for line in f.lines() {
         let parts = line.split(" ").collect::<Vec<_>>();
         let sym = parts[0];
-        let demangled = match demangle(parts[0], &DemangleOptions {
-            omit_empty_parameters: false
-        }) {
-            Some(x) => x,
-            None => "@@@@@".into()
-        };
 
         let addr_idx = parts[2].find("0x").unwrap();
         let addr = &parts[2][addr_idx..addr_idx + 10];
 
-        println!("{sym}|||{demangled}|||{addr}");
+        match demangle(sym, &DemangleOptions {
+            omit_empty_parameters: false
+        }) {
+            Some(demangled) => {
+                println!("{addr}|||{sym}|||{demangled}");
+            },
+            None => {
+                println!("{addr}|||{sym}");
+            }
+        };
     }
 }

--- a/tools/batch-demangle/src/main.rs
+++ b/tools/batch-demangle/src/main.rs
@@ -16,17 +16,84 @@ fn main() {
         let (sym, remaining) = line.split_once(" = ").unwrap();
         let (_section, remaining) = remaining.split_once(':').unwrap();
         let (addr, _remaining) = remaining.split_once("; // ").unwrap();
-        // let flags = remaining.split(' ').collect::<Vec<_>>();
 
         match demangle(sym, &DemangleOptions {
             omit_empty_parameters: false
         }) {
             Some(demangled) => {
-                println!("{addr}|||{sym}|||{demangled}");
+                if !demangled.contains('(') {
+                    // Variable: [namespace::]name
+                    let (namespace, name) = split_namespace(demangled.as_str());
+                    println!("{addr}|||{sym}|||{demangled}|||{namespace}|||{name}");
+                } else {
+                    // Function: [return-type] [namespace::]name([parameter_types]) [cv-qualifier]
+                    let (prolog, _remaining) = demangled.split_once('(').unwrap();
+
+                    let (_return_type, qualified_name) = split_return(prolog);
+                    let (namespace, name) = split_namespace(qualified_name);
+
+                    println!("{addr}|||{sym}|||{demangled}|||{namespace}|||{name}");
+                }
             },
             None => {
                 println!("{addr}|||{sym}");
             }
         };
     }
+}
+
+fn split_return<'a>(prolog: &'a str) -> (&'a str, &'a str) {
+    const PATTERN: &str = " ";
+    match prolog.find(PATTERN) {
+        Some(space_index) => match prolog.find('<') {
+            // Template args, make sure space doesn't come from there
+            Some(template_index) => match space_index < template_index {
+                true => {
+                    let (ret, _) = prolog.split_at(space_index);
+                    let (_, qualified) = prolog.split_at(space_index + PATTERN.len());
+                    (ret, qualified)
+                },
+                false => ("", prolog)
+            },
+            None => {
+                let (ret, _) = prolog.split_at(space_index);
+                let (_, qualified) = prolog.split_at(space_index + PATTERN.len());
+                (ret, qualified)
+            }
+        },
+        None => ("", prolog)
+    }
+}
+
+fn split_namespace(prolog: &str) -> (String, String) {
+    const PATTERN: &str = "::";
+
+    let mut namespaces = Vec::<String>::new();
+
+    // Ensure template arguments aren't split up
+    let mut template_depth = 0;
+    let mut template_buffer = String::new();
+    for split in prolog.split(PATTERN) {
+        template_depth += split.matches('<').count();
+
+        if template_depth > 0 {
+            template_buffer += split;
+
+            template_depth -= split.matches('>').count();
+            if template_depth < 1 {
+                namespaces.push(template_buffer);
+                template_buffer = String::new();
+            } else {
+                // Keep namespace delimiter in the final namespace
+                template_buffer += PATTERN;
+            }
+        } else {
+            namespaces.push(split.to_string());
+        }
+    }
+
+    // Split off name, and re-join namespaces with a padded separator to make later splitting easier
+    let name = namespaces.pop().unwrap();
+    let namespaces = namespaces.join(" :: ");
+    return (namespaces, name);
 }

--- a/tools/ghidra-scripts/dtk_symbol_importer.py
+++ b/tools/ghidra-scripts/dtk_symbol_importer.py
@@ -55,12 +55,10 @@ for l in demangler_output.splitlines():
         namespace = None
 
     sym = getSymbolAt(address)
-    if sym == None:
-        createLabel(address, lbl, namespace, False, SourceType.IMPORTED)
-        createLabel(address, name, namespace, True, SourceType.ANALYSIS)
-    else:
-        createLabel(address, lbl, namespace, False, SourceType.IMPORTED)
-        createLabel(address, name, namespace, sym.getSource() != SourceType.USER_DEFINED, SourceType.ANALYSIS)
+    primary = True if sym is None else sym.getSource() != SourceType.USER_DEFINED
+
+    createLabel(address, lbl, False, SourceType.IMPORTED)
+    createLabel(address, name, namespace, primary, SourceType.ANALYSIS)
 
 # Fix up class namespaces
 class_symbols = ["__vt", "__vtable", "__RTTI", "__superclasses", "__classname"]

--- a/tools/ghidra-scripts/dtk_symbol_importer.py
+++ b/tools/ghidra-scripts/dtk_symbol_importer.py
@@ -27,18 +27,21 @@ for l in demangler_output.splitlines():
     lbl = str(tokens[1])
     if len(tokens) > 3:
         demangled = str(tokens[2])
-        namespaces = str(tokens[3]).split(" :: ")
+        namespaces = str(tokens[3])
         name = str(tokens[4])
+
+        print("Creating label {} in namespace {} at address {}".format(name, namespaces.replace(" :: ", "::"), address))
     else:
         demangled = None
-        namespaces = None
+        namespaces = ""
         name = lbl
+
+        print("Creating label {} in global namespace at address {}".format(name, address))
 
     name = SymbolUtilities.replaceInvalidChars(name, True)
 
-    print("Creating label {} in namespace {} at address {}".format(name, "::".join(namespaces), address))
-
-    if namespaces is not None:
+    if namespaces != "":
+        namespaces = namespaces.split(" :: ")
         parent_namespace = None
         for namespace_lbl in namespaces:
             namespace_lbl = SymbolUtilities.replaceInvalidChars(namespace_lbl, True)

--- a/tools/ghidra-scripts/dtk_symbol_importer.py
+++ b/tools/ghidra-scripts/dtk_symbol_importer.py
@@ -21,17 +21,15 @@ for sym in currentProgram.getSymbolTable().getSymbolIterator():
 
 for l in demangler_output.splitlines():
     tokens = l.split("|||")
-    lbl = tokens[0]
-    name = SymbolUtilities.replaceInvalidChars(str(tokens[1]).split("(")[0], False)
+    address = toAddr(tokens[0])
+    lbl = tokens[1]
+    name = tokens[2] if len(tokens) > 2 else lbl
 
-    if name == "@@@@@":
-        name = lbl
+    name = SymbolUtilities.replaceInvalidChars(str(name).split("(")[0], False)
 
-    address = toAddr(tokens[2])
-    print("Created label {} at address {}".format(name, address))
+    print("Creating label {} at address {}".format(name, address))
 
     sym = getSymbolAt(address)
-
     if sym == None:
         createLabel(address, lbl, False, IMPORTED)
         createLabel(address, name, True, ANALYSIS)

--- a/tools/ghidra-scripts/dtk_symbol_importer.py
+++ b/tools/ghidra-scripts/dtk_symbol_importer.py
@@ -29,8 +29,8 @@ for l in demangler_output.splitlines():
     lbl = str(tokens[1])
     if len(tokens) > 3:
         demangled = str(tokens[2])
-        namespaces = str(tokens[3])
-        name = str(tokens[4])
+        namespaces = str(tokens[3]).replace(", ", ",") # Remove spaces in template parameters
+        name = str(tokens[4]).replace(", ", ",")       # to match built-in demangler
 
         print("Creating label {} in namespace {} at address {}".format(name, namespaces.replace(" :: ", "::"), address))
     else:


### PR DESCRIPTION
The demangled name is now split into name and namespaces, with the namespaces being created in Ghidra and converted to classes where possible.

Templates, function pointer types, return types, and parameter types are all handled correctly now in the demangling process. The latter two aren't applied to the program yet however, seems a bit out of scope currently (have to make sure all types are resolved, and determining whether or not a `this` parameter exists is a fool's errand with only MWCC symbols).