### PR TITLE
Clean up includes and enforce include path prefixes

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,8 +3,34 @@
         {
             "name": "Linux",
             "includePath": [
-                "${workspaceFolder}/src/",
-                "${workspaceFolder}/src/**"
+                // Recursive paths are deliberately not used to
+                // make it easier to spot improper includes
+
+                // Top-level
+                "${workspaceFolder}/src",
+                "${workspaceFolder}/src/libs",
+                "${workspaceFolder}/src/rb3",
+                "${workspaceFolder}/src/sdk",
+                "${workspaceFolder}/src/system",
+
+                // SDK
+                "${workspaceFolder}/src/sdk/RVL_SDK",
+                // Note: MSL_C++ comes before STLport here,
+                // since it's generally more relevant to view/edit
+                "${workspaceFolder}/src/sdk/MSL_C++",
+
+                // Libraries
+                "${workspaceFolder}/src/libs/stlport/stlport",
+                "${workspaceFolder}/src/libs/bt/gki/common",
+                "${workspaceFolder}/src/libs/bt/bta/include",
+                "${workspaceFolder}/src/libs/bt/utils/include",
+                "${workspaceFolder}/src/libs/bt/stack/l2cap",
+                "${workspaceFolder}/src/libs/bt/stack/btm",
+                "${workspaceFolder}/src/libs/bt/include",
+                "${workspaceFolder}/src/libs/bt/stack/include",
+                "${workspaceFolder}/src/libs/libogg/include",
+                "${workspaceFolder}/src/libs/speex/include",
+                "${workspaceFolder}/src/libs/speex"
             ],
             "cStandard": "c99",
             "cppStandard": "c++98",
@@ -13,8 +39,8 @@
             "configurationProvider": "ms-vscode.makefile-tools",
             "browse": {
                 "path": [
-                    "${workspaceFolder}/src/",
-                    "${workspaceFolder}/src/**"
+                    // Paths here are recursive by default
+                    "${workspaceFolder}/src"
                 ],
                 "limitSymbolsToIncludedHeaders": true
             },

--- a/cflags_common.py
+++ b/cflags_common.py
@@ -23,13 +23,6 @@ cflags_includes = [
     # Project source
     "-i src",
     "-i src/system",
-    "-i src/system/obj",
-    "-i src/system/os",
-    "-i src/system/math",
-    "-i src/system/synth",
-    "-i src/system/ui",
-    "-i src/system/utl",
-    "-i src/system/world",
     "-i src/rb3",
     "-i src/rb3/data",
     "-i src/rb3/mgrs",

--- a/cflags_common.py
+++ b/cflags_common.py
@@ -24,9 +24,6 @@ cflags_includes = [
     "-i src",
     "-i src/system",
     "-i src/rb3",
-    "-i src/rb3/data",
-    "-i src/rb3/mgrs",
-    "-i src/rb3/world",
 ]
 
 cflags_defines = [

--- a/cflags_common.py
+++ b/cflags_common.py
@@ -1,10 +1,18 @@
 cflags_includes = [
+    # STLport requires that it comes first in the include path list
     "-i src/libs/stlport/stlport",
+
+    # SDK
+    "-i src/sdk",
+    "-i src/sdk/RVL_SDK",
+    # "-i src/sdk/MSL_C++", # Handled by STLport
     "-i src/sdk/MSL_C/MSL_Common",
     "-i src/sdk/MSL_C/MSL_Common_Embedded",
     "-i src/sdk/MSL_C/MSL_Common_Embedded/Math",
     "-i src/sdk/MetroTRK",
-    # "-i src/tainted/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include",
+
+    # Libraries
+    "-i src/libs",
     "-i src/libs/bt/gki/common",
     "-i src/libs/bt/bta/include",
     "-i src/libs/bt/utils/include",
@@ -15,8 +23,9 @@ cflags_includes = [
     "-i src/libs/libogg/include",
     "-i src/libs/speex/include",
     "-i src/libs/speex",
-    "-i src/sdk/RVL_SDK",
-    "-i src/sdk/MSL_C++",
+
+    # Project source
+    "-i src",
     "-i src/system",
     "-i src/system/obj",
     "-i src/system/os",
@@ -29,8 +38,6 @@ cflags_includes = [
     "-i src/rb3/data",
     "-i src/rb3/mgrs",
     "-i src/rb3/world",
-    "-i src/libs",
-    "-i src",
 ]
 
 cflags_defines = [

--- a/cflags_common.py
+++ b/cflags_common.py
@@ -6,10 +6,6 @@ cflags_includes = [
     "-i src/sdk",
     "-i src/sdk/RVL_SDK",
     # "-i src/sdk/MSL_C++", # Handled by STLport
-    "-i src/sdk/MSL_C/MSL_Common",
-    "-i src/sdk/MSL_C/MSL_Common_Embedded",
-    "-i src/sdk/MSL_C/MSL_Common_Embedded/Math",
-    "-i src/sdk/MetroTRK",
 
     # Libraries
     "-i src/libs",

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -2,10 +2,10 @@
 #define COMMON_HPP
 #include "types.h"
 #include <new>
-
 #include <libspeex/math_approx.h>
-#include "Symbol.h"
-#include "TextFile.h"
+
+#include "obj/TextFile.h"
+#include "utl/Symbol.h"
 
 // misc functions
 int Minimum(int, int);

--- a/src/libs/bt/btif/co/bta_av_co.c
+++ b/src/libs/bt/btif/co/bta_av_co.c
@@ -23,7 +23,8 @@
  *
  ******************************************************************************/
 
-#include "string.h"
+#include <string.h>
+
 #include "a2d_api.h"
 #include "a2d_sbc.h"
 #include "bta_sys.h"
@@ -1500,5 +1501,3 @@ BOOLEAN bta_av_co_get_remote_bitpool_pref(UINT8 *min, UINT8 *max)
 
     return TRUE;
 }
-
-

--- a/src/libs/quazal/unknown/unk_80018968.cpp
+++ b/src/libs/quazal/unknown/unk_80018968.cpp
@@ -1,6 +1,7 @@
+#include <string.h>
+
 #include "stringstream.hpp"
 #include "specialarray.hpp"
-#include "string.h"
 
 Quazal::StringStream::StringStream() {
     unk0 = &unk_arr[0];

--- a/src/rb3/Rnd/dofproc.cpp
+++ b/src/rb3/Rnd/dofproc.cpp
@@ -1,4 +1,4 @@
-#include "dofproc.hpp"
+#include "Rnd/dofproc.hpp"
 
 DOFProc* TheDOFProc;
 

--- a/src/rb3/Rnd/dofproc.hpp
+++ b/src/rb3/Rnd/dofproc.hpp
@@ -1,10 +1,10 @@
 #ifndef RB3_DOFPROC_HPP
 #define RB3_DOFPROC_HPP
-#include "Object.h"
-#include "System.h"
+#include "math/Color.h"
+#include "obj/Object.h"
 #include "obj/Utl.h"
+#include "os/System.h"
 #include "Rnd/rndcam.hpp"
-#include "Color.h"
 
 class DOFProc : public Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndambientocclusion.cpp
+++ b/src/rb3/Rnd/rndambientocclusion.cpp
@@ -1,4 +1,4 @@
-#include "rndambientocclusion.hpp"
+#include "Rnd/rndambientocclusion.hpp"
 
 RndAmbientOcclusion::RndAmbientOcclusion(){
 

--- a/src/rb3/Rnd/rndambientocclusion.hpp
+++ b/src/rb3/Rnd/rndambientocclusion.hpp
@@ -1,6 +1,6 @@
 #ifndef RND_RNDAMBIENTOCCLUSION_HPP
 #define RND_RNDAMBIENTOCCLUSION_HPP
-#include "hmx/object.hpp"
+#include "obj/Object.h"
 
 class RndAmbientOcclusion : public Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndanimatable.cpp
+++ b/src/rb3/Rnd/rndanimatable.cpp
@@ -1,4 +1,4 @@
-#include "rndanimatable.hpp"
+#include "Rnd/rndanimatable.hpp"
 #include "symbols.hpp"
 
 int gRateUnits[5] = {0, 1, 2, 1, 3};

--- a/src/rb3/Rnd/rndanimatable.hpp
+++ b/src/rb3/Rnd/rndanimatable.hpp
@@ -1,6 +1,6 @@
 #ifndef RND_RNDANIMATABLE_HPP
 #define RND_RNDANIMATABLE_HPP
-#include "hmx/object.hpp"
+#include "obj/Object.h"
 
 class RndAnimatable : public virtual Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndanimfilter.cpp
+++ b/src/rb3/Rnd/rndanimfilter.cpp
@@ -1,4 +1,6 @@
-#include "rndanimfilter.hpp"
+#include "Rnd/rndanimfilter.hpp"
+
+#include <stddef.h>
 
 RndAnimFilter::RndAnimFilter() : animPtr(this, nullptr), period(0.0f), start(0.0f), end(0.0f), scale(1.0f), offset(0.0f), snap(0.0f), jitter(0.0f), unk38(0.0f), type(0) {
 

--- a/src/rb3/Rnd/rndanimfilter.hpp
+++ b/src/rb3/Rnd/rndanimfilter.hpp
@@ -2,7 +2,7 @@
 #define RND_RNDANIMFILTER_HPP
 #include "obj/Object.h"
 #include "obj/ObjPtr_p.h"
-#include "rndanimatable.hpp"
+#include "Rnd/rndanimatable.hpp"
 
 class RndAnimFilter : public RndAnimatable {
 public:

--- a/src/rb3/Rnd/rndanimfilter.hpp
+++ b/src/rb3/Rnd/rndanimfilter.hpp
@@ -1,8 +1,8 @@
 #ifndef RND_RNDANIMFILTER_HPP
 #define RND_RNDANIMFILTER_HPP
-#include "hmx/object.hpp"
+#include "obj/Object.h"
+#include "obj/ObjPtr_p.h"
 #include "rndanimatable.hpp"
-#include "objptr.hpp"
 
 class RndAnimFilter : public RndAnimatable {
 public:

--- a/src/rb3/Rnd/rndbitmap.cpp
+++ b/src/rb3/Rnd/rndbitmap.cpp
@@ -1,6 +1,6 @@
 #include "rndbitmap.hpp"
 #include "common.hpp"
-#include "rb3/bufstream.hpp"
+#include "utl/BufStream.h"
 
 /* oops! these are weak!
 RndBitmap::RndBitmap() {

--- a/src/rb3/Rnd/rndbitmap.cpp
+++ b/src/rb3/Rnd/rndbitmap.cpp
@@ -1,4 +1,5 @@
-#include "rndbitmap.hpp"
+#include "Rnd/rndbitmap.hpp"
+
 #include "common.hpp"
 #include "utl/BufStream.h"
 

--- a/src/rb3/Rnd/rndbitmap.hpp
+++ b/src/rb3/Rnd/rndbitmap.hpp
@@ -2,7 +2,7 @@
 #define RND_RNDBITMAP_HPP
 
 #include "types.h"
-#include "rb3/binstream.hpp"
+#include "utl/BinStream.h"
 
 /** Bitmap used for textures, normals, etc.
  * A custom bitmap format derived from Microsoft's DirectDraw Surface.

--- a/src/rb3/Rnd/rndcam.cpp
+++ b/src/rb3/Rnd/rndcam.cpp
@@ -1,5 +1,6 @@
-#include "rndcam.hpp"
-#include "rnddrawable.hpp"
+#include "Rnd/rndcam.hpp"
+#include "Rnd/rnddrawable.hpp"
+
 extern "C" void fn_805D66F8(BinStream&);
 extern "C" float fn_806598A0(float, float);
 

--- a/src/rb3/Rnd/rndcam.hpp
+++ b/src/rb3/Rnd/rndcam.hpp
@@ -1,11 +1,11 @@
 #ifndef RND_RNDCAM_HPP
 #define RND_RNDCAM_HPP
-#include "Object.h"
-#include <rb3/hmx/quat.hpp>
-#include <vector2.hpp>
-#include "BinStream.h"
-#include "rndtransformable.hpp"
+#include "obj/Object.h"
+#include "utl/BinStream.h"
 
+#include "rb3/hmx/quat.hpp"
+#include "rndtransformable.hpp"
+#include "vector2.hpp"
 
 /** A camera.
  * Can define a target texture, what part of the screen to render to, etc. */

--- a/src/rb3/Rnd/rndcam.hpp
+++ b/src/rb3/Rnd/rndcam.hpp
@@ -4,8 +4,8 @@
 #include "utl/BinStream.h"
 
 #include "rb3/hmx/quat.hpp"
-#include "rndtransformable.hpp"
-#include "vector2.hpp"
+#include "Rnd/rndtransformable.hpp"
+#include "world/vector2.hpp"
 
 /** A camera.
  * Can define a target texture, what part of the screen to render to, etc. */

--- a/src/rb3/Rnd/rndconsole.hpp
+++ b/src/rb3/Rnd/rndconsole.hpp
@@ -1,6 +1,6 @@
 #ifndef RND_RNDCONSOLE_HPP
 #define RND_RNDCONSOLE_HPP
-#include "hmx/object.hpp"
+#include "obj/Object.h"
 
 class RndConsole : Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndcubetex.cpp
+++ b/src/rb3/Rnd/rndcubetex.cpp
@@ -1,4 +1,4 @@
-#include "rndcubetex.hpp"
+#include "Rnd/rndcubetex.hpp"
 
 RndCubeTex::RndCubeTex(){
 

--- a/src/rb3/Rnd/rndcubetex.hpp
+++ b/src/rb3/Rnd/rndcubetex.hpp
@@ -1,8 +1,8 @@
 #ifndef RND_RNDCUBETEX_HPP
 #define RND_RNDCUBETEX_HPP
-#include "hmx/object.hpp"
+#include "obj/Object.h"
+#include "utl/FilePath.h"
 #include "rndbitmap.hpp"
-#include "filepath.hpp"
 
 class RndCubeTex : public Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndcubetex.hpp
+++ b/src/rb3/Rnd/rndcubetex.hpp
@@ -2,7 +2,7 @@
 #define RND_RNDCUBETEX_HPP
 #include "obj/Object.h"
 #include "utl/FilePath.h"
-#include "rndbitmap.hpp"
+#include "Rnd/rndbitmap.hpp"
 
 class RndCubeTex : public Hmx::Object {
 public:

--- a/src/rb3/Rnd/rnddrawable.cpp
+++ b/src/rb3/Rnd/rnddrawable.cpp
@@ -1,4 +1,4 @@
-#include "rnddrawable.hpp"
+#include "Rnd/rnddrawable.hpp"
 #include "obj/Data.h"
 
 RndDrawable::RndDrawable() : mShowing(mShowing | 0x80), mBoundSphere(), mDrawOrder(0.0f) {

--- a/src/rb3/Rnd/rnddrawable.cpp
+++ b/src/rb3/Rnd/rnddrawable.cpp
@@ -1,5 +1,5 @@
 #include "rnddrawable.hpp"
-#include "rb3/data.hpp"
+#include "obj/Data.h"
 
 RndDrawable::RndDrawable() : mShowing(mShowing | 0x80), mBoundSphere(), mDrawOrder(0.0f) {
     mBoundSphere.Zero();
@@ -34,4 +34,3 @@ Symbol RndDrawable::StaticClassName() {
 Symbol RndDrawable::ClassName() const {
     return StaticClassName();
 }
-

--- a/src/rb3/Rnd/rnddrawable.hpp
+++ b/src/rb3/Rnd/rnddrawable.hpp
@@ -1,6 +1,6 @@
 #ifndef RND_RNDDRAWABLE_HPP
 #define RND_RNDDRAWABLE_HPP
-#include "rndhighlightable.hpp"
+#include "Rnd/rndhighlightable.hpp"
 #include "sphere.hpp"
 
 class RndDrawable : public virtual RndHighlightable {

--- a/src/rb3/Rnd/rndfur.cpp
+++ b/src/rb3/Rnd/rndfur.cpp
@@ -1,4 +1,4 @@
-#include "rndfur.hpp"
+#include "Rnd/rndfur.hpp"
 
 RndFur::RndFur(){
 

--- a/src/rb3/Rnd/rndfur.hpp
+++ b/src/rb3/Rnd/rndfur.hpp
@@ -1,6 +1,6 @@
 #ifndef RND_RNDANIMATABLE_HPP
 #define RND_RNDANIMATABLE_HPP
-#include "hmx/object.hpp"
+#include "obj/Object.h"
 
 class RndFur : public Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndhighlightable.hpp
+++ b/src/rb3/Rnd/rndhighlightable.hpp
@@ -1,6 +1,6 @@
 #ifndef RND_RNDHIGHLIGHTABLE_HPP
 #define RND_RNDHIGHLIGHTABLE_HPP
-#include "Object.h"
+#include "obj/Object.h"
 
 class RndHighlightable : public virtual Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndtex.cpp
+++ b/src/rb3/Rnd/rndtex.cpp
@@ -1,4 +1,4 @@
-#include "rndtex.hpp"
+#include "Rnd/rndtex.hpp"
 
 RndTex::RndTex() : bitmap(), mipmapK(-8.0f), type(Regular), width(0), height(0), bpp(0x20), fpath(), unk58(0), forPS3(false), unk60(0) {
     

--- a/src/rb3/Rnd/rndtex.hpp
+++ b/src/rb3/Rnd/rndtex.hpp
@@ -2,7 +2,7 @@
 #define RND_RNDTEX_HPP
 #include "obj/Object.h"
 #include "utl/FilePath.h"
-#include "rndbitmap.hpp"
+#include "Rnd/rndbitmap.hpp"
 
 class RndTex : public Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndtex.hpp
+++ b/src/rb3/Rnd/rndtex.hpp
@@ -1,8 +1,8 @@
 #ifndef RND_RNDTEX_HPP
 #define RND_RNDTEX_HPP
-#include "hmx/object.hpp"
+#include "obj/Object.h"
+#include "utl/FilePath.h"
 #include "rndbitmap.hpp"
-#include "filepath.hpp"
 
 class RndTex : public Hmx::Object {
 public:

--- a/src/rb3/Rnd/rndtransformable.cpp
+++ b/src/rb3/Rnd/rndtransformable.cpp
@@ -1,4 +1,4 @@
-#include "rndtransformable.hpp"
+#include "Rnd/rndtransformable.hpp"
 
 RndTransformable::RndTransformable() : rndTransOwnerPtr(0, 0), rndTransPtr(0, 0) {
 

--- a/src/rb3/Rnd/rndtransformable.hpp
+++ b/src/rb3/Rnd/rndtransformable.hpp
@@ -1,7 +1,7 @@
 #ifndef RND_RNDTRANSFORMABLE_HPP
 #define RND_RNDTRANSFORMABLE_HPP
-#include "rndhighlightable.hpp"
 #include "obj/ObjPtr_p.h"
+#include "Rnd/rndhighlightable.hpp"
 
 class RndTransformable : public RndHighlightable {
 public:

--- a/src/rb3/Rnd/rndtransformable.hpp
+++ b/src/rb3/Rnd/rndtransformable.hpp
@@ -1,7 +1,7 @@
 #ifndef RND_RNDTRANSFORMABLE_HPP
 #define RND_RNDTRANSFORMABLE_HPP
 #include "rndhighlightable.hpp"
-#include "ObjPtr_p.h"
+#include "obj/ObjPtr_p.h"
 
 class RndTransformable : public RndHighlightable {
 public:

--- a/src/rb3/Rnd/rndtransproxy.cpp
+++ b/src/rb3/Rnd/rndtransproxy.cpp
@@ -1,4 +1,4 @@
-#include "rndtransproxy.hpp"
+#include "Rnd/rndtransproxy.hpp"
 
 RndTransProxy::RndTransProxy() : objdirPtr(0, 0) {
 

--- a/src/rb3/Rnd/rndtransproxy.hpp
+++ b/src/rb3/Rnd/rndtransproxy.hpp
@@ -1,8 +1,8 @@
 #ifndef RND_RNDTRANSPROXY_HPP
 #define RND_RNDTRANSPROXY_HPP
 #include "rndtransformable.hpp"
-#include "objptr.hpp"
-#include "symbol.hpp"
+#include "obj/ObjPtr_p.h"
+#include "utl/Symbol.h"
 
 class RndTransProxy : public virtual RndTransformable {
 public:

--- a/src/rb3/Rnd/rndtransproxy.hpp
+++ b/src/rb3/Rnd/rndtransproxy.hpp
@@ -1,8 +1,8 @@
 #ifndef RND_RNDTRANSPROXY_HPP
 #define RND_RNDTRANSPROXY_HPP
-#include "rndtransformable.hpp"
 #include "obj/ObjPtr_p.h"
 #include "utl/Symbol.h"
+#include "Rnd/rndtransformable.hpp"
 
 class RndTransProxy : public virtual RndTransformable {
 public:

--- a/src/rb3/Rnd/shaderoptions.cpp
+++ b/src/rb3/Rnd/shaderoptions.cpp
@@ -1,5 +1,5 @@
+#include "Rnd/shaderoptions.hpp"
 #include "utl/Symbol.h"
-#include "shaderoptions.hpp"
 
 Symbol sShaderTypes[26];
 

--- a/src/rb3/Rnd/shaderoptions.cpp
+++ b/src/rb3/Rnd/shaderoptions.cpp
@@ -1,5 +1,5 @@
+#include "utl/Symbol.h"
 #include "shaderoptions.hpp"
-#include "Symbol.h"
 
 Symbol sShaderTypes[26];
 

--- a/src/rb3/Rnd/wii/wiirnd.cpp
+++ b/src/rb3/Rnd/wii/wiirnd.cpp
@@ -1,8 +1,11 @@
 #include "wiirnd.hpp"
-#include "rb3/hmx/rect.hpp"
+
+#include "types.h"
 #include "revolution/GX.h"
 #include "revolution/OS.h"
-#include "types.h"
+
+#include "math/Rect.h"
+
 bool FakeGXinBegin, FakeGXIntMode;
 
 WiiRnd::WiiRnd() {

--- a/src/rb3/Rnd/wii/wiirnd.cpp
+++ b/src/rb3/Rnd/wii/wiirnd.cpp
@@ -1,4 +1,4 @@
-#include "wiirnd.hpp"
+#include "Rnd/wii/wiirnd.hpp"
 
 #include "types.h"
 #include "revolution/GX.h"

--- a/src/rb3/Rnd/wii/wiirnd.hpp
+++ b/src/rb3/Rnd/wii/wiirnd.hpp
@@ -1,9 +1,10 @@
 #ifndef RND_WII_WIIRND_HPP
 #define RND_WII_WIIRND_HPP
+#include "math/Color.h"
+#include "math/Rect.h"
+
 //#include "rb3/Rnd/rnd.hpp"
-#include "rb3/hmx/rect.hpp"
 #include "rb3/world/vector3.hpp"
-#include "rb3/hmx/color.hpp"
 
 class WiiRnd /*: Rnd*/ {
     WiiRnd();

--- a/src/rb3/Rnd/wii/wiirnd.hpp
+++ b/src/rb3/Rnd/wii/wiirnd.hpp
@@ -3,8 +3,8 @@
 #include "math/Color.h"
 #include "math/Rect.h"
 
-//#include "rb3/Rnd/rnd.hpp"
-#include "rb3/world/vector3.hpp"
+//#include "Rnd/rnd.hpp"
+#include "world/vector3.hpp"
 
 class WiiRnd /*: Rnd*/ {
     WiiRnd();

--- a/src/rb3/beatmatchcontroller.hpp
+++ b/src/rb3/beatmatchcontroller.hpp
@@ -1,8 +1,8 @@
 #ifndef RB3_BEATMATCHCONTROLLER_HPP
 #define RB3_BEATMATCHCONTROLLER_HPP
-#include "hmx/object.hpp"
-#include "data.hpp"
-#include "user.hpp"
+#include "obj/Data.h"
+#include "obj/Object.h"
+#include "os/User.h"
 
 class BeatMatchController : public Hmx::Object {
 public:

--- a/src/rb3/blockmgr.hpp
+++ b/src/rb3/blockmgr.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_BLOCKMGR_HPP
 #define RB3_BLOCKMGR_HPP
-#include "ArkFile.h"
+#include "os/ArkFile.h"
 
 class BlockMgr {
 public:

--- a/src/rb3/cacheidwii.hpp
+++ b/src/rb3/cacheidwii.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_CACHEIDWII_HPP
 #define RB3_CACHEIDWII_HPP
 #include "cacheid.hpp"
-#include "Str.h"
+#include "utl/Str.h"
 
 class CacheIDWii : CacheID {
 public:

--- a/src/rb3/contentinstalledmsg.hpp
+++ b/src/rb3/contentinstalledmsg.hpp
@@ -1,8 +1,8 @@
 #ifndef RB3_CONTENTINSTALLEDMSG_HPP
 #define RB3_CONTENTINSTALLEDMSG_HPP
-#include "message.hpp"
-#include "data.hpp"
-#include "symbol.hpp"
+#include "obj/Data.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
 
 class ContentInstalledMsg : Message {
 public:

--- a/src/rb3/data/datafuncobj.hpp
+++ b/src/rb3/data/datafuncobj.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_DATAFUNCOBJ_HPP
 #define RB3_DATAFUNCOBJ_HPP
-#include "Object.h"
+#include "obj/Object.h"
 
 class DataFuncObj : public Hmx::Object {
 public:

--- a/src/rb3/data/datamergefilter.hpp
+++ b/src/rb3/data/datamergefilter.hpp
@@ -1,8 +1,8 @@
 #ifndef RB3_DATAMERGEFILTER_HPP
 #define RB3_DATAMERGEFILTER_HPP
-#include "Data.h"
+#include "obj/Data.h"
+#include "obj/Object.h"
 #include "mergefilter.hpp"
-#include "Object.h"
 
 class DataMergeFilter : public MergeFilter {
 public:

--- a/src/rb3/debug.hpp
+++ b/src/rb3/debug.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_DEBUG_HPP
 #define RB3_DEBUG_HPP
-#include "textstream.hpp"
+#include "utl/TextStream.h"
 
 
 /** Implements most debugging features, such as printing to the console's text output and handling error checking & failure */

--- a/src/rb3/file_ops.cpp
+++ b/src/rb3/file_ops.cpp
@@ -1,5 +1,5 @@
 #include "file_ops.hpp"
-#include "string.h"
+#include <string.h>
 
 char lbl_809071C8[0x100];
 

--- a/src/rb3/filecache.hpp
+++ b/src/rb3/filecache.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_FILECACHE_HPP
 #define RB3_FILECACHE_HPP
-#include "filepath.hpp"
+#include "utl/FilePath.h"
 
 class FileCache {
 public:

--- a/src/rb3/filecachefile.hpp
+++ b/src/rb3/filecachefile.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_FILECACHEFILE_HPP
 #define RB3_FILECACHEFILE_HPP
-#include "file.hpp"
-#include "string.hpp"
+#include "os/File.h"
+#include "utl/Str.h"
 
 class FileCacheFile : File {
 public:

--- a/src/rb3/fixedsizesaveablestream.hpp
+++ b/src/rb3/fixedsizesaveablestream.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_FIXEDSIZESAVEABLESTREAM_HPP
 #define RB3_FIXEDSIZESAVEABLESTREAM_HPP
-#include "BufStream.h"
+#include "utl/BufStream.h"
 
 class FixedSizeSaveableStream : public BufStream {
 public:

--- a/src/rb3/game.hpp
+++ b/src/rb3/game.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_THEGAME_HPP
 #define RB3_THEGAME_HPP
-#include <types.h>
+#include "types.h"
 
 class Game {
 public:

--- a/src/rb3/gamemode.cpp
+++ b/src/rb3/gamemode.cpp
@@ -1,13 +1,15 @@
 #include "gamemode.hpp"
-#include "objectdir.hpp"
-#include "system.hpp"
-#include "data.hpp"
-#include "symbols.hpp"
+
+#include "obj/Data.h"
+#include "obj/DataUtl.h"
+#include "obj/Dir.h"
+#include "obj/Object.h"
+#include "os/System.h"
+
+#include "messages/modechangedmsg.hpp"
 #include "messages.hpp"
 #include "platformmgr.hpp"
-#include "messages/modechangedmsg.hpp"
-#include "hmx/object.hpp"
-#include "datautil.hpp"
+#include "symbols.hpp"
 
 GameMode* TheGameMode;
 extern PlatformMgr ThePlatformMgr;

--- a/src/rb3/gamemode.hpp
+++ b/src/rb3/gamemode.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_GAMEMODE_HPP
 #define RB3_GAMEMODE_HPP
+#include "utl/Symbol.h"
 #include "msgsource.hpp"
-#include "symbol.hpp"
 
 class GameMode : public MsgSource {
 public:

--- a/src/rb3/hmx/object2.cpp
+++ b/src/rb3/hmx/object2.cpp
@@ -1,6 +1,7 @@
-#include "object.hpp"
+#include "obj/Object.h"
+
 #include "types.h"
-#include "rb3/symbol.hpp"
+#include "utl/Symbol.h"
 
 extern uint fn_802623AC(u32, u32);
 extern uint fn_80262684(u32);

--- a/src/rb3/hmx/quat.hpp
+++ b/src/rb3/hmx/quat.hpp
@@ -1,7 +1,7 @@
 #ifndef HMX_QUAT_HPP
 #define HMX_QUAT_HPP
+#include "math/Mtx.h"
 #include "vector3.hpp"
-#include "Mtx.h"
 
 namespace Hmx {
     class Quat {

--- a/src/rb3/hmx/quat.hpp
+++ b/src/rb3/hmx/quat.hpp
@@ -1,7 +1,7 @@
 #ifndef HMX_QUAT_HPP
 #define HMX_QUAT_HPP
 #include "math/Mtx.h"
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 
 namespace Hmx {
     class Quat {

--- a/src/rb3/idatachunk.hpp
+++ b/src/rb3/idatachunk.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_IDATACHUNK_HPP
 #define RB3_IDATACHUNK_HPP
-#include "BinStream.h"
+#include "utl/BinStream.h"
 
 class IDataChunk : BinStream {
 public:

--- a/src/rb3/joinresultmsg.hpp
+++ b/src/rb3/joinresultmsg.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_JOINRESULTMSG_HPP
 #define RB3_JOINRESULTMSG_HPP
-#include "message.hpp"
-#include "data.hpp"
+#include "obj/Data.h"
+#include "utl/Message.h"
 
 class JoinResultMsg : Message {
 public:

--- a/src/rb3/localuser.hpp
+++ b/src/rb3/localuser.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_LOCALUSER_HPP
 #define RB3_LOCALUSER_HPP
-#include "user.hpp"
+#include "os/User.h"
 
 class LocalUser : public virtual User {
 public:

--- a/src/rb3/main.cpp
+++ b/src/rb3/main.cpp
@@ -1,4 +1,4 @@
-#include <rb3/app.hpp>
+#include "app.hpp"
 
 int main(int argc, char **argv) {
     App app(argc, argv);

--- a/src/rb3/matchmakingsettings.hpp
+++ b/src/rb3/matchmakingsettings.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_MATCHMAKINGSETTINGS_HPP
 #define RB3_MATCHMAKINGSETTINGS_HPP
-#include "symbol.hpp"
-#include "binstream.hpp"
+#include "utl/BinStream.h"
+#include "utl/Symbol.h"
 
 class MatchmakingSettings {
 public:

--- a/src/rb3/memstream.hpp
+++ b/src/rb3/memstream.hpp
@@ -1,8 +1,8 @@
 #ifndef RB3_MEMSTREAM_HPP
 #define RB3_MEMSTREAM_HPP
-#include "binstream.hpp"
-#include "string.hpp"
-#include "file.hpp"
+#include "os/File.h"
+#include "utl/BinStream.h"
+#include "utl/Str.h"
 #include "streamchecksum.hpp"
 
 class MemStream : BinStream {

--- a/src/rb3/mergefilter.hpp
+++ b/src/rb3/mergefilter.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_MERGEFILTER_HPP
 #define RB3_MERGEFILTER_HPP
-#include "Object.h"
+#include "obj/Object.h"
 
 enum Action {
     kMerge = 0,

--- a/src/rb3/messages/key_messages.cpp
+++ b/src/rb3/messages/key_messages.cpp
@@ -1,4 +1,4 @@
-#include "key_messages.hpp"
+#include "messages/key_messages.hpp"
 #include "obj/Data.h"
 
 // fn_80315298

--- a/src/rb3/messages/key_messages.cpp
+++ b/src/rb3/messages/key_messages.cpp
@@ -1,6 +1,5 @@
-#include "Data.h"
-#include "Symbol.h"
 #include "key_messages.hpp"
+#include "obj/Data.h"
 
 // fn_80315298
 KeyboardKeyReleasedMsg::KeyboardKeyReleasedMsg(int i1, int i2)

--- a/src/rb3/messages/key_messages.hpp
+++ b/src/rb3/messages/key_messages.hpp
@@ -1,6 +1,7 @@
 #ifndef RB3_KEY_MESSAGES_HPP
 #define RB3_KEY_MESSAGES_HPP
-#include "Message.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
 
 class KeysAccelerometerMsg : public Message {
 public:

--- a/src/rb3/messages/modechangedmsg.hpp
+++ b/src/rb3/messages/modechangedmsg.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_MODECHANGEDMSG_HPP
 #define RB3_MODECHANGEDMSG_HPP
-#include "Symbol.h"
-#include "Message.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
 
 class ModeChangedMsg : public Message {
 public:

--- a/src/rb3/messages/rg_messages.cpp
+++ b/src/rb3/messages/rg_messages.cpp
@@ -1,4 +1,4 @@
-#include "rg_messages.hpp"
+#include "messages/rg_messages.hpp"
 #include "obj/Data.h"
 
 // fn_80313FFC

--- a/src/rb3/messages/rg_messages.cpp
+++ b/src/rb3/messages/rg_messages.cpp
@@ -1,6 +1,5 @@
-#include "Data.h"
-#include "Symbol.h"
 #include "rg_messages.hpp"
+#include "obj/Data.h"
 
 // fn_80313FFC
 RGAccelerometerMsg::RGAccelerometerMsg(int i1, int i2, int i3, int i4)

--- a/src/rb3/messages/rg_messages.hpp
+++ b/src/rb3/messages/rg_messages.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_RG_MESSAGES_HPP
 #define RB3_RG_MESSAGES_HPP
-#include "Message.h"
-#include "Symbol.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
 
 class RGAccelerometerMsg : public Message {
 public:

--- a/src/rb3/messages/stringstoppedmsg.cpp
+++ b/src/rb3/messages/stringstoppedmsg.cpp
@@ -1,4 +1,4 @@
-#include "stringstoppedmsg.hpp"
+#include "messages/stringstoppedmsg.hpp"
 #include "obj/Data.h"
 
 // fn_80313FB0

--- a/src/rb3/messages/stringstoppedmsg.cpp
+++ b/src/rb3/messages/stringstoppedmsg.cpp
@@ -1,6 +1,5 @@
-#include "Data.h"
-#include "Symbol.h"
 #include "stringstoppedmsg.hpp"
+#include "obj/Data.h"
 
 // fn_80313FB0
 Symbol StringStoppedMsg::Type() {

--- a/src/rb3/messages/stringstoppedmsg.hpp
+++ b/src/rb3/messages/stringstoppedmsg.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_STRINGSTOPPEDMSG_HPP
 #define RB3_STRINGSTOPPEDMSG_HPP
-#include "Symbol.h"
-#include "Message.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
 
 class StringStoppedMsg : public Message {
 public:

--- a/src/rb3/messages/stringstrummedmsg.cpp
+++ b/src/rb3/messages/stringstrummedmsg.cpp
@@ -1,4 +1,4 @@
-#include "stringstrummedmsg.hpp"
+#include "messages/stringstrummedmsg.hpp"
 #include "obj/Data.h"
 
 // fn_80313E98

--- a/src/rb3/messages/stringstrummedmsg.cpp
+++ b/src/rb3/messages/stringstrummedmsg.cpp
@@ -1,6 +1,5 @@
-#include "Data.h"
-#include "Symbol.h"
 #include "stringstrummedmsg.hpp"
+#include "obj/Data.h"
 
 // fn_80313E98
 StringStrummedMsg::StringStrummedMsg(int i1, int i2, int i3, int i4)

--- a/src/rb3/messages/stringstrummedmsg.hpp
+++ b/src/rb3/messages/stringstrummedmsg.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_STRINGSTRUMMEDMSG_HPP
 #define RB3_STRINGSTRUMMEDMSG_HPP
-#include "Symbol.h"
-#include "Message.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
 
 class StringStrummedMsg : public Message {
 public:

--- a/src/rb3/mgrs/trainingmgr.cpp
+++ b/src/rb3/mgrs/trainingmgr.cpp
@@ -1,4 +1,4 @@
-#include "trainingmgr.hpp"
+#include "mgrs/trainingmgr.hpp"
 #include "obj/Dir.h"
 
 extern const char* gNullStr;

--- a/src/rb3/mgrs/trainingmgr.cpp
+++ b/src/rb3/mgrs/trainingmgr.cpp
@@ -1,5 +1,5 @@
 #include "trainingmgr.hpp"
-#include "objectdir.hpp"
+#include "obj/Dir.h"
 
 extern const char* gNullStr;
 TrainingMgr* TheTrainingMgr;

--- a/src/rb3/mgrs/trainingmgr.hpp
+++ b/src/rb3/mgrs/trainingmgr.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_TRAININGMGR_HPP
 #define RB3_TRAININGMGR_HPP
-#include "hmx/object.hpp"
+#include "obj/Object.h"
 
 class TrainingMgr : public Hmx::Object {
 public:

--- a/src/rb3/mgrs/usermgr.hpp
+++ b/src/rb3/mgrs/usermgr.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_USERMGR_HPP
 #define RB3_USERMGR_HPP
-#include "user.hpp"
+#include "os/User.h"
 
 class UserMgr : public User {
 public:

--- a/src/rb3/midiparser.hpp
+++ b/src/rb3/midiparser.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_MIDIPARSER_HPP
 #define RB3_MIDIPARSER_HPP
+#include "obj/Object.h"
 #include "msgsource.hpp"
-#include "hmx/object.hpp"
 
 class MidiParser : public MsgSource, public virtual Hmx::Object {
 public:

--- a/src/rb3/msgsource.hpp
+++ b/src/rb3/msgsource.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_MSGSOURCE_HPP
 #define RB3_MSGSOURCE_HPP
-#include "Object.h"
 #include <list>
+#include "obj/Object.h"
 
 class MsgSource : public virtual Hmx::Object {
 public:

--- a/src/rb3/netmessage.hpp
+++ b/src/rb3/netmessage.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_NETMESSAGE_HPP
 #define RB3_NETMESSAGE_HPP
-#include "textstream.hpp"
-#include "binstream.hpp"
+#include "utl/BinStream.h"
+#include "utl/TextStream.h"
 
 class NetMessage {
 public:

--- a/src/rb3/netstream.cpp
+++ b/src/rb3/netstream.cpp
@@ -1,3 +1,2 @@
 #include "netstream.hpp"
 #include "types.h"
-

--- a/src/rb3/netstream.hpp
+++ b/src/rb3/netstream.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_NETSTREAM_HPP
 #define RB3_NETSTREAM_HPP
-#include "binstream.hpp"
 #include "types.h"
+#include "utl/BinStream.h"
 class NetStream : public BinStream {
 public:
     NetStream(); // not in the vtable? odd

--- a/src/rb3/notetube.hpp
+++ b/src/rb3/notetube.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_NOTETUBE_HPP
 #define RB3_NOTETUBE_HPP
-#include "hmx/object.hpp"
 #include "types.h"
+#include "obj/Object.h"
 
 class NoteTube : Hmx::Object { // 0x64
     NoteTube();

--- a/src/rb3/objdirptr.hpp
+++ b/src/rb3/objdirptr.hpp
@@ -1,7 +1,6 @@
 #ifndef RB3_OBJDIRPTR_HPP
 #define RB3_OBJDIRPTR_HPP
-#include "objref.hpp"
-#include "hmx/object.hpp"
+#include "obj/Object.h"
 
 template <class T> class ObjDirPtr : public ObjRef {
 public:

--- a/src/rb3/sessionmsg.hpp
+++ b/src/rb3/sessionmsg.hpp
@@ -1,8 +1,8 @@
 #ifndef RB3_SESSIONMSG_HPP
 #define RB3_SESSIONMSG_HPP
 #include "netmessage.hpp"
-#include "textstream.hpp"
-#include "binstream.hpp"
+#include "utl/BinStream.h"
+#include "utl/TextStream.h"
 
 class SessionMsg : NetMessage {
 public:

--- a/src/rb3/songmetadata.hpp
+++ b/src/rb3/songmetadata.hpp
@@ -1,8 +1,8 @@
 #ifndef RB3_SONGMETADATA_HPP
 #define RB3_SONGMETADATA_HPP
-#include "hmx/object.hpp"
-#include "symbol.hpp"
-#include "data.hpp"
+#include "obj/Data.h"
+#include "obj/Object.h"
+#include "utl/Symbol.h"
 
 class SongMetadata : public Hmx::Object {
 public:

--- a/src/rb3/storagechangedmsg.hpp
+++ b/src/rb3/storagechangedmsg.hpp
@@ -1,8 +1,8 @@
 #ifndef RB3_STORAGECHANGEDMSG_HPP
 #define RB3_STORAGECHANGEDMSG_HPP
-#include "message.hpp"
-#include "data.hpp"
-#include "symbol.hpp"
+#include "obj/Data.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
 
 class StorageChangedMsg : Message {
 public:

--- a/src/rb3/stringtablelocks.cpp
+++ b/src/rb3/stringtablelocks.cpp
@@ -1,6 +1,6 @@
 #include "stringtablelocks.hpp"
-#include "StringTable.h"
-#include "Symbol.h"
+#include "utl/StringTable.h"
+#include "utl/Symbol.h"
 
 extern StringTable* gStringTable;
 extern bool StringTableLocked;

--- a/src/rb3/symbols/messageset1.cpp
+++ b/src/rb3/symbols/messageset1.cpp
@@ -1,6 +1,6 @@
+#include "messageset1.hpp"
+#include "utl/Symbol.h"
 #include "stringtablelocks.hpp"
-#include "symbol.hpp"
-#include "message.hpp"
 
 StringTableLockBegin msglock1;
 

--- a/src/rb3/symbols/messageset1.cpp
+++ b/src/rb3/symbols/messageset1.cpp
@@ -1,4 +1,4 @@
-#include "messageset1.hpp"
+#include "symbols/messageset1.hpp"
 #include "utl/Symbol.h"
 #include "stringtablelocks.hpp"
 

--- a/src/rb3/symbols/messageset1.hpp
+++ b/src/rb3/symbols/messageset1.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_MESSAGESET1_HPP
 #define RB3_MESSAGESET1_HPP
-#include "message.hpp"
+#include "utl/Message.h"
 
 extern Message MsgAllowsHiding;
 extern Message MsgAllowsInputToShell;

--- a/src/rb3/symbols/messageset2.cpp
+++ b/src/rb3/symbols/messageset2.cpp
@@ -1,6 +1,6 @@
+#include "messageset2.hpp"
+#include "utl/Symbol.h"
 #include "stringtablelocks.hpp"
-#include "symbol.hpp"
-#include "message.hpp"
 
 StringTableLockBegin msglock2;
 

--- a/src/rb3/symbols/messageset2.cpp
+++ b/src/rb3/symbols/messageset2.cpp
@@ -1,4 +1,4 @@
-#include "messageset2.hpp"
+#include "symbols/messageset2.hpp"
 #include "utl/Symbol.h"
 #include "stringtablelocks.hpp"
 

--- a/src/rb3/symbols/messageset2.hpp
+++ b/src/rb3/symbols/messageset2.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_MESSAGESET2_HPP
 #define RB3_MESSAGESET2_HPP
-#include "message.hpp"
+#include "utl/Message.h"
 
 extern Message MsgGetSongSelectScreen;
 extern Message MsgGotoCreateDialog;

--- a/src/rb3/symbols/messageset3.cpp
+++ b/src/rb3/symbols/messageset3.cpp
@@ -1,4 +1,4 @@
-#include "messageset3.hpp"
+#include "symbols/messageset3.hpp"
 #include "utl/Symbol.h"
 #include "stringtablelocks.hpp"
 

--- a/src/rb3/symbols/messageset3.cpp
+++ b/src/rb3/symbols/messageset3.cpp
@@ -1,6 +1,6 @@
+#include "messageset3.hpp"
+#include "utl/Symbol.h"
 #include "stringtablelocks.hpp"
-#include "symbol.hpp"
-#include "message.hpp"
 
 StringTableLockBegin msglock3;
 

--- a/src/rb3/symbols/messageset3.hpp
+++ b/src/rb3/symbols/messageset3.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_MESSAGESET3_HPP
 #define RB3_MESSAGESET3_HPP
-#include "message.hpp"
+#include "utl/Message.h"
 
 extern Message MsgOnNotOnline;
 extern Message MsgOnPreloadFailed;

--- a/src/rb3/symbols/messageset4.cpp
+++ b/src/rb3/symbols/messageset4.cpp
@@ -1,4 +1,4 @@
-#include "messageset4.hpp"
+#include "symbols/messageset4.hpp"
 #include "utl/Symbol.h"
 #include "stringtablelocks.hpp"
 

--- a/src/rb3/symbols/messageset4.cpp
+++ b/src/rb3/symbols/messageset4.cpp
@@ -1,6 +1,6 @@
+#include "messageset4.hpp"
+#include "utl/Symbol.h"
 #include "stringtablelocks.hpp"
-#include "symbol.hpp"
-#include "message.hpp"
 
 StringTableLockBegin msglock4;
 

--- a/src/rb3/symbols/messageset4.hpp
+++ b/src/rb3/symbols/messageset4.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_MESSAGESET4_HPP
 #define RB3_MESSAGESET4_HPP
-#include "message.hpp"
+#include "utl/Message.h"
 
 extern Message MsgSendUpdateCrowd;
 extern Message MsgSendUpdateEnergy;

--- a/src/rb3/symbols/symbolset1.cpp
+++ b/src/rb3/symbols/symbolset1.cpp
@@ -1,4 +1,4 @@
-#include "symbolset1.hpp"
+#include "symbols/symbolset1.hpp"
 #include "stringtablelocks.hpp"
 
 StringTableLockBegin lock1;

--- a/src/rb3/symbols/symbolset1.cpp
+++ b/src/rb3/symbols/symbolset1.cpp
@@ -1,5 +1,5 @@
+#include "symbolset1.hpp"
 #include "stringtablelocks.hpp"
-#include "Symbol.h"
 
 StringTableLockBegin lock1;
 

--- a/src/rb3/symbols/symbolset1.hpp
+++ b/src/rb3/symbols/symbolset1.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_SYMBOLSET1_HPP
 #define RB3_SYMBOLSET1_HPP
-#include "Symbol.h"
+#include "utl/Symbol.h"
 
 extern Symbol SymSetFeedbackState;
 extern Symbol SymSetFileMerger;

--- a/src/rb3/symbols/symbolset2.cpp
+++ b/src/rb3/symbols/symbolset2.cpp
@@ -1,5 +1,5 @@
+#include "symbolset2.hpp"
 #include "stringtablelocks.hpp"
-#include "Symbol.h"
 
 StringTableLockBegin lock2;
 

--- a/src/rb3/symbols/symbolset2.cpp
+++ b/src/rb3/symbols/symbolset2.cpp
@@ -1,4 +1,4 @@
-#include "symbolset2.hpp"
+#include "symbols/symbolset2.hpp"
 #include "stringtablelocks.hpp"
 
 StringTableLockBegin lock2;

--- a/src/rb3/symbols/symbolset2.hpp
+++ b/src/rb3/symbols/symbolset2.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_SYMBOLSET2_HPP
 #define RB3_SYMBOLSET2_HPP
-#include "Symbol.h"
+#include "utl/Symbol.h"
 
 extern Symbol SymArena;
 extern Symbol SymAlphabetize;

--- a/src/rb3/symbols/symbolset3.cpp
+++ b/src/rb3/symbols/symbolset3.cpp
@@ -1,5 +1,5 @@
+#include "symbolset3.hpp"
 #include "stringtablelocks.hpp"
-#include "Symbol.h"
 
 StringTableLockBegin lock3;
 

--- a/src/rb3/symbols/symbolset3.cpp
+++ b/src/rb3/symbols/symbolset3.cpp
@@ -1,4 +1,4 @@
-#include "symbolset3.hpp"
+#include "symbols/symbolset3.hpp"
 #include "stringtablelocks.hpp"
 
 StringTableLockBegin lock3;

--- a/src/rb3/symbols/symbolset3.hpp
+++ b/src/rb3/symbols/symbolset3.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_SYMBOLSET3_HPP
 #define RB3_SYMBOLSET3_HPP
-#include "Symbol.h"
+#include "utl/Symbol.h"
 
 extern Symbol SymForceNextPlayIndex;
 extern Symbol SymForcePoll;

--- a/src/rb3/symbols/symbolset4.cpp
+++ b/src/rb3/symbols/symbolset4.cpp
@@ -1,5 +1,5 @@
+#include "symbolset4.hpp"
 #include "stringtablelocks.hpp"
-#include "Symbol.h"
 
 StringTableLockBegin lock4;
 

--- a/src/rb3/symbols/symbolset4.cpp
+++ b/src/rb3/symbols/symbolset4.cpp
@@ -1,4 +1,4 @@
-#include "symbolset4.hpp"
+#include "symbols/symbolset4.hpp"
 #include "stringtablelocks.hpp"
 
 StringTableLockBegin lock4;

--- a/src/rb3/symbols/symbolset4.hpp
+++ b/src/rb3/symbols/symbolset4.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_SYMBOLSET4_HPP
 #define RB3_SYMBOLSET4_HPP
-#include "Symbol.h"
+#include "utl/Symbol.h"
 
 extern Symbol SymMaxDisplay;
 extern Symbol SymMaxDisplayButtons;

--- a/src/rb3/syncallmsg.hpp
+++ b/src/rb3/syncallmsg.hpp
@@ -1,9 +1,9 @@
 #ifndef RB3_SYNCALLMSG_HPP
 #define RB3_SYNCALLMSG_HPP
-#include "netmessage.hpp"
-#include "binstream.hpp"
-#include "string.hpp"
+#include "utl/BinStream.h"
+#include "utl/Str.h"
 #include "memstream.hpp"
+#include "netmessage.hpp"
 
 class SyncAllMsg : NetMessage {
 public:

--- a/src/rb3/syncobjmsg.hpp
+++ b/src/rb3/syncobjmsg.hpp
@@ -1,9 +1,9 @@
 #ifndef RB3_SYNCOBJMSG_HPP
 #define RB3_SYNCOBJMSG_HPP
-#include "netmessage.hpp"
-#include "binstream.hpp"
-#include "string.hpp"
+#include "utl/BinStream.h"
+#include "utl/Str.h"
 #include "memstream.hpp"
+#include "netmessage.hpp"
 
 // this class is 0x34 big! according to NewNetMessage()
 class SyncObjMsg : NetMessage {

--- a/src/rb3/syncusermsg.hpp
+++ b/src/rb3/syncusermsg.hpp
@@ -1,9 +1,9 @@
 #ifndef RB3_SYNCUSERMSG_HPP
 #define RB3_SYNCUSERMSG_HPP
-#include "netmessage.hpp"
-#include "binstream.hpp"
-#include "string.hpp"
+#include "utl/BinStream.h"
+#include "utl/Str.h"
 #include "memstream.hpp"
+#include "netmessage.hpp"
 
 // this class is 0x14 big! according to NewNetMessage()
 class SyncUserMsg : NetMessage {

--- a/src/rb3/unknown/800/unk_8000D980.cpp
+++ b/src/rb3/unknown/800/unk_8000D980.cpp
@@ -1,10 +1,11 @@
-#include "string.hpp"
-#include "textstream.hpp"
-#include "filepath.hpp"
-#include "objref.hpp"
+#include "obj/Object.h"
+#include "utl/FilePath.h"
+#include "utl/Message.h"
+#include "utl/Str.h"
+#include "utl/Symbol.h"
+#include "utl/TextStream.h"
+
 #include "unknown.hpp"
-#include "symbol.hpp"
-#include "message.hpp"
 #include "matchmakingsettings.hpp"
 #include "jsonobjects.hpp"
 

--- a/src/rb3/unknown/800/unk_8000F9B0.cpp
+++ b/src/rb3/unknown/800/unk_8000F9B0.cpp
@@ -1,7 +1,8 @@
+#include "obj/Object.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
+
 #include "common.hpp"
-#include "symbol.hpp"
-#include "message.hpp"
-#include "hmx/object.hpp"
 
 extern char *gNullStr;
 

--- a/src/rb3/unknown/800/unk_800A673C.cpp
+++ b/src/rb3/unknown/800/unk_800A673C.cpp
@@ -1,14 +1,16 @@
-#include "string.hpp"
-#include "textstream.hpp"
-#include "unknown.hpp"
-#include "string.h"
-#include "jsonobjects.hpp"
-#include "binstream.hpp"
-#include "bufstream.hpp"
-#include "matchmakingsettings.hpp"
-#include "symbol.hpp"
-#include "memstream.hpp"
+#include <string.h>
 #include "json-c/printbuf.h"
+
+#include "utl/BinStream.h"
+#include "utl/BufStream.h"
+#include "utl/Str.h"
+#include "utl/Symbol.h"
+#include "utl/TextStream.h"
+
+#include "unknown.hpp"
+#include "jsonobjects.hpp"
+#include "matchmakingsettings.hpp"
+#include "memstream.hpp"
 
 // fn_800A6E18
 // probably inline

--- a/src/rb3/unknown/800/unk_800AAE1C.cpp
+++ b/src/rb3/unknown/800/unk_800AAE1C.cpp
@@ -1,10 +1,10 @@
+#include "obj/Data.h"
+#include "utl/Str.h"
+
 #include "netmessage.hpp"
+#include "syncallmsg.hpp"
 #include "syncobjmsg.hpp"
 #include "syncusermsg.hpp"
-#include "syncallmsg.hpp"
-#include "string.hpp"
-#include "data.hpp"
-
 
 // fn_800AAE9C
 NetMessage::NetMessage() {

--- a/src/rb3/unknown/800/unk_800AC804.cpp
+++ b/src/rb3/unknown/800/unk_800AC804.cpp
@@ -1,14 +1,16 @@
-#include "string.hpp"
-#include "textstream.hpp"
+#include <string.h>
+
+#include "obj/Data.h"
+#include "obj/Object.h"
+#include "os/User.h"
+#include "utl/MakeString.h"
+#include "utl/Message.h"
+#include "utl/Str.h"
+#include "utl/TextStream.h"
+
 #include "unknown.hpp"
-#include "string.h"
-#include "message.hpp"
-#include "jsonconverter.hpp"
-#include "data.hpp"
 #include "joinresultmsg.hpp"
-#include "hmx/object.hpp"
-#include "makestring.hpp"
-#include "user.hpp"
+#include "jsonobjects.hpp"
 
 // fn_800AFE60
 // probably inline

--- a/src/rb3/unknown/800/unk_800B4630.cpp
+++ b/src/rb3/unknown/800/unk_800B4630.cpp
@@ -1,11 +1,11 @@
-#include "syncobjmsg.hpp"
-#include "binstream.hpp"
-#include "string.hpp"
-#include "memstream.hpp"
-#include "message.hpp"
+#include "utl/BinStream.h"
+#include "utl/MakeString.h"
+#include "utl/Message.h"
+#include "utl/Str.h"
+
 #include "common.hpp"
-#include "formatstring.hpp"
-#include "makestring.hpp"
+#include "memstream.hpp"
+#include "syncobjmsg.hpp"
 
 // fn_800B95C4
 BinStream &BinStream::operator<<(float f) {

--- a/src/rb3/unknown/800/unk_800BF1A8.cpp
+++ b/src/rb3/unknown/800/unk_800BF1A8.cpp
@@ -1,7 +1,9 @@
-#include "string.hpp"
-#include "filestream.hpp"
+#include <string.h>
+
+#include "utl/FileStream.h"
+#include "utl/Str.h"
+
 #include "unknown.hpp"
-#include "string.h"
 
 // fn_800C20FC
 // probably inlined

--- a/src/rb3/unknown/800/unk_800C9D04.cpp
+++ b/src/rb3/unknown/800/unk_800C9D04.cpp
@@ -1,9 +1,11 @@
+#include <math.h>
+
+#include "math/Mtx.h"
+#include "obj/ObjPtr_p.h"
+
 #include "common.hpp"
-#include "math.h"
 #include "vector3.hpp"
-#include "hmx/matrix3.hpp"
 #include "vector_ops.hpp"
-#include "objptr.hpp"
 
 // fn_800CF370
 int Minimum(int x, int y) {

--- a/src/rb3/unknown/800/unk_800C9D04.cpp
+++ b/src/rb3/unknown/800/unk_800C9D04.cpp
@@ -4,7 +4,7 @@
 #include "obj/ObjPtr_p.h"
 
 #include "common.hpp"
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 #include "vector_ops.hpp"
 
 // fn_800CF370

--- a/src/rb3/unknown/800/unk_800DB160.cpp
+++ b/src/rb3/unknown/800/unk_800DB160.cpp
@@ -1,8 +1,10 @@
+#include <math.h>
+
+#include "math/Mtx.h"
+
 #include "common.hpp"
-#include "math.h"
 #include "vector3.hpp"
 #include "triangle.hpp"
-#include "hmx/matrix3.hpp"
 #include "vector_ops.hpp"
 
 // fn_800E25EC

--- a/src/rb3/unknown/800/unk_800DB160.cpp
+++ b/src/rb3/unknown/800/unk_800DB160.cpp
@@ -3,7 +3,7 @@
 #include "math/Mtx.h"
 
 #include "common.hpp"
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 #include "triangle.hpp"
 #include "vector_ops.hpp"
 

--- a/src/rb3/unknown/800/unk_800F6DF8.cpp
+++ b/src/rb3/unknown/800/unk_800F6DF8.cpp
@@ -1,7 +1,8 @@
+#include "obj/Data.h"
+#include "utl/Symbol.h"
+
 #include "unknown.hpp"
 #include "common.hpp"
-#include "data.hpp"
-#include "symbol.hpp"
 
 // fn_80119C38
 unsigned short SwapDataHalfWord(unsigned short s) {

--- a/src/rb3/unknown/801/unk_8011AED8.cpp
+++ b/src/rb3/unknown/801/unk_8011AED8.cpp
@@ -1,5 +1,5 @@
+#include <math.h>
 #include "common.hpp"
-#include "math.h"
 
 // fn_8015506C
 float PowFloat(double d1, double d2) {
@@ -16,4 +16,3 @@ float CosFloat(double d) {
 float CosThunk(double d) {
     return CosFloat(d);
 }
-

--- a/src/rb3/unknown/801/unk_801660DC.cpp
+++ b/src/rb3/unknown/801/unk_801660DC.cpp
@@ -1,8 +1,10 @@
-#include "message.hpp"
-#include "symbol.hpp"
-#include "data.hpp"
+#include <math.h>
+
+#include "obj/Data.h"
+#include "utl/Message.h"
+#include "utl/Symbol.h"
+
 #include "common.hpp"
-#include "math.h"
 
 extern DataArray *fn_8035CF9C(int, int, int);
 
@@ -44,4 +46,3 @@ float LogFloat(double d) {
 float LogThunk(double d) {
     return LogFloat(d);
 }
-

--- a/src/rb3/unknown/801/unk_80188850.cpp
+++ b/src/rb3/unknown/801/unk_80188850.cpp
@@ -1,5 +1,6 @@
-#include "data.hpp"
-#include "binstream.hpp"
+#include "obj/Data.h"
+#include "utl/BinStream.h"
+
 #include "rnd/rndhighlightable.hpp"
 
 // fn_801C7058

--- a/src/rb3/unknown/802/unk_802D4B74.cpp
+++ b/src/rb3/unknown/802/unk_802D4B74.cpp
@@ -1,7 +1,8 @@
+#include "math/Mtx.h"
+
 #include "common.hpp"
 #include "vector3.hpp"
 #include "vector_ops.hpp"
-#include "hmx/matrix3.hpp"
 
 extern float fn_802D54E8(float);
 // fn_802D54A8

--- a/src/rb3/unknown/802/unk_802D4B74.cpp
+++ b/src/rb3/unknown/802/unk_802D4B74.cpp
@@ -1,7 +1,7 @@
 #include "math/Mtx.h"
 
 #include "common.hpp"
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 #include "vector_ops.hpp"
 
 extern float fn_802D54E8(float);

--- a/src/rb3/unknown/802/unk_802DDEA0.cpp
+++ b/src/rb3/unknown/802/unk_802DDEA0.cpp
@@ -1,12 +1,13 @@
-#include "rot.hpp"
+#include <math.h>
+
+#include "math/Rot.h"
+#include "math/Trig.h"
+#include "utl/BinStream.h"
 
 #include "common.hpp"
-#include "math.h"
-#include "vector_ops.hpp"
-#include "trig.hpp"
-#include "binstream.hpp"
 #include "shortquat.hpp"
 #include "shorttransform.hpp"
+#include "vector_ops.hpp"
 
 BinStream &operator<<(BinStream &bs, const Vector3 &vec) {
     bs << vec.x << vec.y << vec.z;

--- a/src/rb3/unknown/802/unk_802E0CA0.cpp
+++ b/src/rb3/unknown/802/unk_802E0CA0.cpp
@@ -3,7 +3,7 @@
 
 #include "common.hpp"
 #include "hmx/quat.hpp"
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 #include "vector_ops.hpp"
 
 Vector3 *Vector3::operator+=(const Vector3 &v) {

--- a/src/rb3/unknown/802/unk_802E0CA0.cpp
+++ b/src/rb3/unknown/802/unk_802E0CA0.cpp
@@ -1,9 +1,10 @@
-#include "hmx/matrix3.hpp"
+#include "math/Mtx.h"
+#include "math/Trig.h"
+
+#include "common.hpp"
+#include "hmx/quat.hpp"
 #include "vector3.hpp"
 #include "vector_ops.hpp"
-#include "common.hpp"
-#include "trig.hpp"
-#include "hmx/quat.hpp"
 
 Vector3 *Vector3::operator+=(const Vector3 &v) {
     x += v.x;

--- a/src/rb3/unknown/802/unk_802F02EC.cpp
+++ b/src/rb3/unknown/802/unk_802F02EC.cpp
@@ -1,6 +1,7 @@
+#include "utl/Symbol.h"
+
 #include "storagechangedmsg.hpp"
 #include "contentinstalledmsg.hpp"
-#include "symbol.hpp"
 
 ContentInstalledMsg::ContentInstalledMsg(DataArray *da) : Message(da) {
 }

--- a/src/rb3/unknown/802/unk_802F98DC.cpp
+++ b/src/rb3/unknown/802/unk_802F98DC.cpp
@@ -1,10 +1,12 @@
-#include "string.h"
-#include "string.hpp"
-#include "file_ops.hpp"
-#include "data.hpp"
-#include "common.hpp"
 #include <stdio.h>
-#include "file.hpp"
+#include <string.h>
+
+#include "obj/Data.h"
+#include "os/File.h"
+#include "utl/Str.h"
+
+#include "common.hpp"
+#include "file_ops.hpp"
 
 // fn_802FA190
 void FileQualifiedFilename(String &s, const char *c) {

--- a/src/rb3/unknown/802/unk_802F98DC.cpp
+++ b/src/rb3/unknown/802/unk_802F98DC.cpp
@@ -3,7 +3,7 @@
 #include "file_ops.hpp"
 #include "data.hpp"
 #include "common.hpp"
-#include "MSL_C/MSL_Common/printf.h"
+#include <stdio.h>
 #include "file.hpp"
 
 // fn_802FA190

--- a/src/rb3/unknown/802/unk_802F98DC.cpp
+++ b/src/rb3/unknown/802/unk_802F98DC.cpp
@@ -3,7 +3,7 @@
 #include "file_ops.hpp"
 #include "data.hpp"
 #include "common.hpp"
-#include "sdk/MSL_C/MSL_Common/printf.h"
+#include "MSL_C/MSL_Common/printf.h"
 #include "file.hpp"
 
 // fn_802FA190

--- a/src/rb3/unknown/802/unk_802FA994.cpp
+++ b/src/rb3/unknown/802/unk_802FA994.cpp
@@ -1,4 +1,4 @@
-#include "string.h"
+#include <string.h>
 #include "unknown.hpp"
 
 extern "C" bool FileMatch(const char *, const char *);

--- a/src/rb3/unknown/802/unk_802FB548.cpp
+++ b/src/rb3/unknown/802/unk_802FB548.cpp
@@ -1,4 +1,4 @@
-#include "string.h"
+#include <string.h>
 #include "unknown.hpp"
 #include "filecachefile.hpp"
 

--- a/src/rb3/unknown/803/unk_8030A494.cpp
+++ b/src/rb3/unknown/803/unk_8030A494.cpp
@@ -1,5 +1,5 @@
+#include "utl/Symbol.h"
 #include "storagechangedmsg.hpp"
-#include "symbol.hpp"
 
 StorageChangedMsg::StorageChangedMsg() : Message(Type()) {
 }

--- a/src/rb3/unknown/803/unk_8031144C.cpp
+++ b/src/rb3/unknown/803/unk_8031144C.cpp
@@ -1,4 +1,4 @@
-#include "user.hpp"
+#include "os/User.h"
 #include "common.hpp"
 #include "localuser.hpp"
 

--- a/src/rb3/unknown/803/unk_8034C91C.cpp
+++ b/src/rb3/unknown/803/unk_8034C91C.cpp
@@ -1,5 +1,5 @@
-#include "filepath.hpp"
-#include "string.hpp"
+#include "utl/FilePath.h"
+#include "utl/Str.h"
 #include "unknown.hpp"
 
 extern char lbl_80856E78[];

--- a/src/rb3/unknown/803/unk_80357E10.cpp
+++ b/src/rb3/unknown/803/unk_80357E10.cpp
@@ -1,13 +1,14 @@
-#include "string.hpp"
-#include "textstream.hpp"
-#include "unknown.hpp"
-#include "string.h"
-#include "tempomap.hpp"
-#include "multitempotempomap.hpp"
-#include "data.hpp"
-#include "symbol.hpp"
-#include "common.hpp"
+#include <string.h>
 
+#include "obj/Data.h"
+#include "utl/MultiTempoTempoMap.h"
+#include "utl/Str.h"
+#include "utl/Symbol.h"
+#include "utl/TempoMap.h"
+#include "utl/TextStream.h"
+
+#include "common.hpp"
+#include "unknown.hpp"
 
 // fn_8035824C
 TempoMap::TempoMap() {

--- a/src/rb3/unknown/804/unk_80421240.cpp
+++ b/src/rb3/unknown/804/unk_80421240.cpp
@@ -1,5 +1,5 @@
-#include "data.hpp"
-#include "makestring.hpp"
+#include "obj/Data.h"
+#include "utl/MakeString.h"
 #include "beatmatchcontroller.hpp"
 
 extern char *DataVarName(const DataNode *);

--- a/src/rb3/unknown/805/unk_805CE140.cpp
+++ b/src/rb3/unknown/805/unk_805CE140.cpp
@@ -1,3 +1,3 @@
-#include "data.hpp"
+#include "obj/Data.h"
 
 // fn_805D128C

--- a/src/rb3/varstack.hpp
+++ b/src/rb3/varstack.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_VARSTACK_HPP
 #define RB3_VARSTACK_HPP
-#include "Data.h"
+#include "obj/Data.h"
 
 class VarStack {
 public:

--- a/src/rb3/world/shortquat.hpp
+++ b/src/rb3/world/shortquat.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_SHORTQUAT_HPP
 #define RB3_SHORTQUAT_HPP
-#include "hmx/quat.hpp"
 #include "math/Mtx.h"
+#include "hmx/quat.hpp"
 
 class ShortQuat {
 public:

--- a/src/rb3/world/shortquat.hpp
+++ b/src/rb3/world/shortquat.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_SHORTQUAT_HPP
 #define RB3_SHORTQUAT_HPP
 #include "hmx/quat.hpp"
-#include "Mtx.h"
+#include "math/Mtx.h"
 
 class ShortQuat {
 public:

--- a/src/rb3/world/shorttransform.hpp
+++ b/src/rb3/world/shorttransform.hpp
@@ -1,8 +1,8 @@
 #ifndef RB3_SHORTTRANSFORM_HPP
 #define RB3_SHORTTRANSFORM_HPP
-#include "shortquat.hpp"
-#include "vector3.hpp"
-#include "transform.hpp"
+#include "world/shortquat.hpp"
+#include "world/transform.hpp"
+#include "world/vector3.hpp"
 
 class ShortTransform {
 public:

--- a/src/rb3/world/transform.hpp
+++ b/src/rb3/world/transform.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_TRANSFORM_HPP
 #define RB3_TRANSFORM_HPP
-#include "Mtx.h"
+#include "math/Mtx.h"
 #include "vector3.hpp"
 
 class Transform {

--- a/src/rb3/world/transform.hpp
+++ b/src/rb3/world/transform.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_TRANSFORM_HPP
 #define RB3_TRANSFORM_HPP
 #include "math/Mtx.h"
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 
 class Transform {
 public:

--- a/src/rb3/world/triangle.hpp
+++ b/src/rb3/world/triangle.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_TRIANGLE_HPP
 #define RB3_TRIANGLE_HPP
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 
 class Triangle {
 public:

--- a/src/rb3/world/vector_ops.hpp
+++ b/src/rb3/world/vector_ops.hpp
@@ -1,7 +1,7 @@
 #ifndef RB3_VECTOR_OPS_HPP
 #define RB3_VECTOR_OPS_HPP
 #include "vector3.hpp"
-#include "Mtx.h"
+#include "math/Mtx.h"
 
 // taken from RB2 and GDRB
 void operator-(const Vector3 &, const Vector3 &);

--- a/src/rb3/world/vector_ops.hpp
+++ b/src/rb3/world/vector_ops.hpp
@@ -1,6 +1,6 @@
 #ifndef RB3_VECTOR_OPS_HPP
 #define RB3_VECTOR_OPS_HPP
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 #include "math/Mtx.h"
 
 // taken from RB2 and GDRB

--- a/src/sdk/MSL_C++/assert.h
+++ b/src/sdk/MSL_C++/assert.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include "sdk/MSL_C/MSL_Common/assert_api.h"
+#include "MSL_C/MSL_Common/assert_api.h"
 
 #ifdef NDEBUG
 #define assert(condition) ((void)0)

--- a/src/sdk/MSL_C++/ctype.h
+++ b/src/sdk/MSL_C++/ctype.h
@@ -3,7 +3,7 @@
 
 #include "types.h"
 #include <locale.h>
-#include "sdk/MSL_C/MSL_Common/ctype_api.h"
+#include "MSL_C/MSL_Common/ctype_api.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/MSL_C++/locale.h
+++ b/src/sdk/MSL_C++/locale.h
@@ -3,7 +3,7 @@
 
 #include "types.h"
 #include <stdlib.h>
-#include "sdk/MSL_C/MSL_Common/locale_api.h"
+#include "MSL_C/MSL_Common/locale_api.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/MSL_C++/math.h
+++ b/src/sdk/MSL_C++/math.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-#include "sdk/MSL_C/MSL_Common/math_api.h"
+#include "MSL_C/MSL_Common/math_api.h"
 
 extern int __float_nan[];
 extern int __float_huge[];

--- a/src/sdk/MSL_C++/stdio.h
+++ b/src/sdk/MSL_C++/stdio.h
@@ -7,11 +7,11 @@
 extern "C" {
 #endif
 
-#include "sdk/MSL_C/MSL_Common/stdio_api.h"
-#include "sdk/MSL_C/MSL_Common/FILE_POS.h"
-#include "sdk/MSL_C/MSL_Common/file_io.h"
-#include "sdk/MSL_C/MSL_Common/printf.h"
-#include "sdk/MSL_C/MSL_Common/scanf.h"
+#include "MSL_C/MSL_Common/stdio_api.h"
+#include "MSL_C/MSL_Common/FILE_POS.h"
+#include "MSL_C/MSL_Common/file_io.h"
+#include "MSL_C/MSL_Common/printf.h"
+#include "MSL_C/MSL_Common/scanf.h"
 
 // Unorganized things which have yet to be RE'd
 

--- a/src/sdk/MSL_C++/stdlib.h
+++ b/src/sdk/MSL_C++/stdlib.h
@@ -6,12 +6,12 @@
 extern "C" {
 #endif
 
-#include "sdk/MSL_C/MSL_Common/alloc.h"
-#include "sdk/MSL_C/MSL_Common/arith.h"
-#include "sdk/MSL_C/MSL_Common/mbstring.h"
-#include "sdk/MSL_C/MSL_Common/rand.h"
-#include "sdk/MSL_C/MSL_Common/strtold.h"
-#include "sdk/MSL_C/MSL_Common/strtoul.h"
+#include "MSL_C/MSL_Common/alloc.h"
+#include "MSL_C/MSL_Common/arith.h"
+#include "MSL_C/MSL_Common/mbstring.h"
+#include "MSL_C/MSL_Common/rand.h"
+#include "MSL_C/MSL_Common/strtold.h"
+#include "MSL_C/MSL_Common/strtoul.h"
 
 // For functions that return 0 on a success and -1 on failure
 #ifndef EXIT_SUCCESS

--- a/src/sdk/MSL_C++/string.h
+++ b/src/sdk/MSL_C++/string.h
@@ -7,8 +7,8 @@
 extern "C" {
 #endif
 
-#include "sdk/MSL_C/MSL_Common/string_api.h"
-#include "sdk/MSL_C/MSL_Common/extras.h"
+#include "MSL_C/MSL_Common/string_api.h"
+#include "MSL_C/MSL_Common/extras.h"
 
 char *strcpy(char *RESTRICT dest, const char *RESTRICT src);
 char *strncpy(char *RESTRICT dest, const char *RESTRICT src, size_t count);

--- a/src/sdk/MSL_C++/wchar.h
+++ b/src/sdk/MSL_C++/wchar.h
@@ -5,15 +5,15 @@
 extern "C" {
 #endif
 
-#include "sdk/MSL_C/MSL_Common/wchar_def.h"
-#include "sdk/MSL_C/MSL_Common/wchar_io.h"
-#include "sdk/MSL_C/MSL_Common/wchar_time.h"
-#include "sdk/MSL_C/MSL_Common/wcstoul.h"
-#include "sdk/MSL_C/MSL_Common/wmem.h"
-#include "sdk/MSL_C/MSL_Common/wprintf.h"
-#include "sdk/MSL_C/MSL_Common/wscanf.h"
-#include "sdk/MSL_C/MSL_Common/wstring.h"
-#include "sdk/MSL_C/MSL_Common/mbconvert.h"
+#include "MSL_C/MSL_Common/wchar_def.h"
+#include "MSL_C/MSL_Common/wchar_io.h"
+#include "MSL_C/MSL_Common/wchar_time.h"
+#include "MSL_C/MSL_Common/wcstoul.h"
+#include "MSL_C/MSL_Common/wmem.h"
+#include "MSL_C/MSL_Common/wprintf.h"
+#include "MSL_C/MSL_Common/wscanf.h"
+#include "MSL_C/MSL_Common/wstring.h"
+#include "MSL_C/MSL_Common/mbconvert.h"
 
 #ifdef __cplusplus
 }

--- a/src/sdk/MSL_C++/wctype.h
+++ b/src/sdk/MSL_C++/wctype.h
@@ -3,7 +3,7 @@
 
 #include "types.h"
 #include <locale.h>
-#include "sdk/MSL_C/MSL_Common/wctype_api.h"
+#include "MSL_C/MSL_Common/wctype_api.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/MSL_C/MSL_Common/ansi_fp.h
+++ b/src/sdk/MSL_C/MSL_Common/ansi_fp.h
@@ -4,7 +4,7 @@
 #include "types.h"
 #include <math.h>
 #include <float.h>
-#include "sdk/MSL_C/MSL_Common_Embedded/Math/fdlibm.h"
+#include "MSL_C/MSL_Common_Embedded/Math/fdlibm.h"
 
 #define SIGDIGLEN 36
 

--- a/src/sdk/MSL_C/MSL_Common/mbconvert.h
+++ b/src/sdk/MSL_C/MSL_Common/mbconvert.h
@@ -2,7 +2,7 @@
 #define MSL_MBCONVERT_H
 
 #include "macros.h"
-#include "sdk/MSL_C/MSL_Common/wchar_def.h"
+#include "MSL_C/MSL_Common/wchar_def.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/MSL_C/MSL_Common/mbstring.h
+++ b/src/sdk/MSL_C/MSL_Common/mbstring.h
@@ -2,7 +2,7 @@
 #define MSL_MBSTRING_H
 
 #include "macros.h"
-#include "sdk/MSL_C/MSL_Common/wchar_def.h"
+#include "MSL_C/MSL_Common/wchar_def.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/MSL_C/MSL_Common/stdio_api.h
+++ b/src/sdk/MSL_C/MSL_Common/stdio_api.h
@@ -2,7 +2,7 @@
 #define STDIO_API_H
 
 #include "types.h"
-#include "sdk/MSL_C/MSL_Common/file_struc.h"
+#include "MSL_C/MSL_Common/file_struc.h"
 #include <wchar.h>
 
 #ifdef __cplusplus

--- a/src/sdk/MSL_C/MSL_Common/wchar_io.h
+++ b/src/sdk/MSL_C/MSL_Common/wchar_io.h
@@ -3,7 +3,7 @@
 
 #include <stdio.h>
 #include "macros.h"
-#include "sdk/MSL_C/MSL_Common/wchar_def.h"
+#include "MSL_C/MSL_Common/wchar_def.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/MSL_C/MSL_Common/wchar_time.h
+++ b/src/sdk/MSL_C/MSL_Common/wchar_time.h
@@ -2,7 +2,7 @@
 #define _WCHAR_TIME_H
 
 #include <time.h>
-#include "sdk/MSL_C/MSL_Common/wchar_def.h"
+#include "MSL_C/MSL_Common/wchar_def.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/MSL_C/MSL_Common/wctype_api.h
+++ b/src/sdk/MSL_C/MSL_Common/wctype_api.h
@@ -3,7 +3,6 @@
 
 #include "types.h"
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/sdk/MetroTRK/Processor/ppc/Board/dolphin/memmap.h
+++ b/src/sdk/MetroTRK/Processor/ppc/Board/dolphin/memmap.h
@@ -1,7 +1,7 @@
 #ifndef METROTRK_MEM_TRK_H
 #define METROTRK_MEM_TRK_H
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
 
 typedef struct memRange{
 	ui8* start;

--- a/src/sdk/MetroTRK/Processor/ppc/Export/ppc_reg.h
+++ b/src/sdk/MetroTRK/Processor/ppc/Export/ppc_reg.h
@@ -1,8 +1,8 @@
 #ifndef METROTRK_PPC_REG
 #define METROTRK_PPC_REG
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
 
 typedef struct Default_PPC{
 	ui32 GPR[32];

--- a/src/sdk/MetroTRK/Processor/ppc/Generic/flush_cache.h
+++ b/src/sdk/MetroTRK/Processor/ppc/Generic/flush_cache.h
@@ -2,7 +2,7 @@
 #define METROTRK_FLUSH_CACHE
 
 #include "macros.h"
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 ASM_DECL void TRK_flush_cache(ui32 addr, ui32 length);
 

--- a/src/sdk/MetroTRK/Processor/ppc/Generic/ppc_targimpl.h
+++ b/src/sdk/MetroTRK/Processor/ppc/Generic/ppc_targimpl.h
@@ -1,10 +1,10 @@
 #ifndef METROTRK_PPC_TARGIMPL
 #define METROTRK_PPC_TARGIMPL
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
-#include "sdk/MetroTRK/Processor/ppc/Export/ppc_except.h"
-#include "sdk/MetroTRK/Processor/ppc/Export/ppc_reg.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
+#include "MetroTRK/Processor/ppc/Export/ppc_except.h"
+#include "MetroTRK/Processor/ppc/Export/ppc_reg.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/custconn/CircleBuffer.h
+++ b/src/sdk/MetroTRK/custconn/CircleBuffer.h
@@ -1,7 +1,7 @@
 #ifndef TRK_CIRCLE_BUFFER_H
 #define TRK_CIRCLE_BUFFER_H
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 typedef struct CircleBuffer {
     ui8* unk0;

--- a/src/sdk/MetroTRK/custconn/cc_gdev.h
+++ b/src/sdk/MetroTRK/custconn/cc_gdev.h
@@ -1,7 +1,7 @@
 #ifndef TRK_CC_GDEV_H
 #define TRK_CC_GDEV_H
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 #include "NdevExi2A/DebuggerDriver.h"
 
 //TODO: figure out what these values represent

--- a/src/sdk/MetroTRK/dispatch.h
+++ b/src/sdk/MetroTRK/dispatch.h
@@ -1,8 +1,8 @@
 #ifndef METROTRK_DISPATCH
 #define METROTRK_DISPATCH
 
-#include "sdk/MetroTRK/trk.h"
-#include "sdk/MetroTRK/msgbuf.h"
+#include "MetroTRK/trk.h"
+#include "MetroTRK/msgbuf.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/dolphin_trk_glue.h
+++ b/src/sdk/MetroTRK/dolphin_trk_glue.h
@@ -1,9 +1,9 @@
 #ifndef _TRK_DOLPHIN_TRK_GLUE_H
 #define _TRK_DOLPHIN_TRK_GLUE_H
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 #include "revolution/OS.h"
-#include "sdk/MSL_C/MSL_Common_Embedded/UART.h"
+#include "MSL_C/MSL_Common_Embedded/UART.h"
 
 typedef enum{
     HARDWARE_GDEV = 0,

--- a/src/sdk/MetroTRK/dsversions.h
+++ b/src/sdk/MetroTRK/dsversions.h
@@ -1,7 +1,7 @@
 #ifndef METROTRK_DSVERSIONS
 #define METROTRK_DSVERSIONS
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 typedef struct DSVersions{
 	ui8 kernelMajor;

--- a/src/sdk/MetroTRK/main_TRK.h
+++ b/src/sdk/MetroTRK/main_TRK.h
@@ -1,7 +1,7 @@
 #ifndef METROTRK_MAIN_TRK_H
 #define METROTRK_MAIN_TRK_H
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/mainloop.h
+++ b/src/sdk/MetroTRK/mainloop.h
@@ -1,7 +1,7 @@
 #ifndef METROTRK_MAINLOOP
 #define METROTRK_MAINLOOP
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/mem_TRK.h
+++ b/src/sdk/MetroTRK/mem_TRK.h
@@ -1,7 +1,7 @@
 #ifndef METROTRK_MEM_TRK_H
 #define METROTRK_MEM_TRK_H
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/mpc_7xx_603e.h
+++ b/src/sdk/MetroTRK/mpc_7xx_603e.h
@@ -1,7 +1,7 @@
 #ifndef TRK_MPC_7XX_603E
 #define TRK_MPC_7XX_603E
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/msg.h
+++ b/src/sdk/MetroTRK/msg.h
@@ -1,9 +1,9 @@
 #ifndef TRK_MSG
 #define TRK_MSG
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
-#include "sdk/MetroTRK/msgbuf.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
+#include "MetroTRK/msgbuf.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/msgbuf.h
+++ b/src/sdk/MetroTRK/msgbuf.h
@@ -1,8 +1,8 @@
 #ifndef TRK_MSGBUF
 #define TRK_MSGBUF
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
 
 
 typedef int MessageBufferID;

--- a/src/sdk/MetroTRK/msghndlr.h
+++ b/src/sdk/MetroTRK/msghndlr.h
@@ -1,9 +1,9 @@
 #ifndef TRK_MSGHNDLR
 #define TRK_MSGHNDLR
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
-#include "sdk/MetroTRK/msgbuf.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
+#include "MetroTRK/msgbuf.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/mslsupp.h
+++ b/src/sdk/MetroTRK/mslsupp.h
@@ -1,8 +1,8 @@
 #ifndef _TRK_MSLSUPP_H
 #define _TRK_MSLSUPP_H
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
 #include <stdio.h>
 
 #ifdef __cplusplus

--- a/src/sdk/MetroTRK/notify.h
+++ b/src/sdk/MetroTRK/notify.h
@@ -1,8 +1,8 @@
 #ifndef METROTRK_NOTIFY
 #define METROTRK_NOTIFY
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/nubevent.h
+++ b/src/sdk/MetroTRK/nubevent.h
@@ -1,9 +1,9 @@
 #ifndef TRK_NUBEVENT
 #define TRK_NUBEVENT
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
-#include "sdk/MetroTRK/msgbuf.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
+#include "MetroTRK/msgbuf.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/nubinit.h
+++ b/src/sdk/MetroTRK/nubinit.h
@@ -1,8 +1,8 @@
 #ifndef TRK_NUBINIT
 #define TRK_NUBINIT
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/serpoll.h
+++ b/src/sdk/MetroTRK/serpoll.h
@@ -1,8 +1,8 @@
 #ifndef TRK_SERPOLL
 #define TRK_SERPOLL
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/string_TRK.h
+++ b/src/sdk/MetroTRK/string_TRK.h
@@ -1,7 +1,7 @@
 #ifndef METROTRK_STRING_TRK
 #define METROTRK_STRING_TRK
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/support.h
+++ b/src/sdk/MetroTRK/support.h
@@ -1,9 +1,9 @@
 #ifndef METROTRK_SUPPORT
 #define METROTRK_SUPPORT
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
-#include "sdk/MetroTRK/msgbuf.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
+#include "MetroTRK/msgbuf.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/targcont.h
+++ b/src/sdk/MetroTRK/targcont.h
@@ -1,8 +1,8 @@
 #ifndef TRK_TARGCONT
 #define TRK_TARGCONT
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/target_options.h
+++ b/src/sdk/MetroTRK/target_options.h
@@ -1,7 +1,7 @@
 #ifndef _TRK_TARGET_OPTIONS_H
 #define _TRK_TARGET_OPTIONS_H
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/targimpl.h
+++ b/src/sdk/MetroTRK/targimpl.h
@@ -1,10 +1,10 @@
 #ifndef TRK_TARGIMPL
 #define TRK_TARGIMPL
 
-#include "sdk/MetroTRK/dstypes.h"
-#include "sdk/MetroTRK/trk.h"
-#include "sdk/MetroTRK/nubevent.h"
-#include "sdk/MetroTRK/msgbuf.h"
+#include "MetroTRK/dstypes.h"
+#include "MetroTRK/trk.h"
+#include "MetroTRK/nubevent.h"
+#include "MetroTRK/msgbuf.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/targsupp.h
+++ b/src/sdk/MetroTRK/targsupp.h
@@ -1,7 +1,7 @@
 #ifndef _TRK_TARGSUPP_H
 #define _TRK_TARGSUPP_H
 
-#include "sdk/MetroTRK/dstypes.h"
+#include "MetroTRK/dstypes.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/sdk/MetroTRK/trk.h
+++ b/src/sdk/MetroTRK/trk.h
@@ -1,9 +1,9 @@
 #ifndef _METROTRK_TRK_H
 #define _METROTRK_TRK_H
 
-#include "sdk/MetroTRK/msgcmd.h"
-#include "sdk/MetroTRK/dserror.h"
-#include "sdk/MetroTRK/dsversions.h"
-#include "sdk/MSL_C/MSL_Common_Embedded/UART.h"
+#include "MetroTRK/msgcmd.h"
+#include "MetroTRK/dserror.h"
+#include "MetroTRK/dsversions.h"
+#include "MSL_C/MSL_Common_Embedded/UART.h"
 
 #endif

--- a/src/sdk/RVL_SDK/revolution/euart/euart.h
+++ b/src/sdk/RVL_SDK/revolution/euart/euart.h
@@ -1,7 +1,7 @@
 #ifndef RVL_SDK_EUART_H
 #define RVL_SDK_EUART_H
 #include "types.h"
-#include "sdk/MSL_C/MSL_Common_Embedded/UART.h"
+#include "MSL_C/MSL_Common_Embedded/UART.h"
 
 typedef enum {
 	EUART_ERROR_NONE = 0,

--- a/src/sdk/RVL_SDK/revolution/math.h
+++ b/src/sdk/RVL_SDK/revolution/math.h
@@ -2,8 +2,8 @@
 #define _REVOSDK_MATH_H
 
 #include "types.h"
-#include "sdk/MSL_C/MSL_Common_Embedded/Math/fdlibm.h"
-#include "sdk/MSL_C/MSL_Common/math_api.h"
+#include "MSL_C/MSL_Common_Embedded/Math/fdlibm.h"
+#include "MSL_C/MSL_Common/math_api.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/RVL_SDK/revolution/os/__ppc_eabi_init.h
+++ b/src/sdk/RVL_SDK/revolution/os/__ppc_eabi_init.h
@@ -2,8 +2,8 @@
 #define _RVL_SDK_PPC_EABI_INIT_H
 
 #include "types.h"
-#include "sdk/Runtime/__ppc_eabi_linker.h"
-#include "sdk/Runtime/__ppc_eabi_init.h"
+#include "Runtime/__ppc_eabi_linker.h"
+#include "Runtime/__ppc_eabi_init.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/sdk/Runtime/NMWException.h
+++ b/src/sdk/Runtime/NMWException.h
@@ -2,7 +2,7 @@
 #define _NMWEXCEPTION
 
 #include "types.h"
-#include "sdk/Runtime/__ppc_eabi_linker.h"
+#include "Runtime/__ppc_eabi_linker.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/system/math/Interp.cpp
+++ b/src/system/math/Interp.cpp
@@ -1,8 +1,6 @@
-#include "common.hpp"
-#include "Data.h"
 #include "Interp.h"
-#include "math.h"
-
+#include <math.h>
+#include "common.hpp"
 
 // fn_802DCEDC
 LinearInterpolator::LinearInterpolator(float y0, float y1, float x0, float x1) {

--- a/src/system/math/Interp.cpp
+++ b/src/system/math/Interp.cpp
@@ -1,4 +1,4 @@
-#include "Interp.h"
+#include "math/Interp.h"
 #include <math.h>
 #include "common.hpp"
 

--- a/src/system/math/Interp.h
+++ b/src/system/math/Interp.h
@@ -1,6 +1,6 @@
 #ifndef MATH_INTERP_H
 #define MATH_INTERP_H
-#include "Data.h"
+#include "obj/Data.h"
 
 class Interpolator {
 public:

--- a/src/system/math/Mtx.h
+++ b/src/system/math/Mtx.h
@@ -1,6 +1,6 @@
 #ifndef MATH_MTX_H
 #define MATH_MTX_H
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 
 namespace Hmx {
     class Matrix3 {

--- a/src/system/math/Primes.cpp
+++ b/src/system/math/Primes.cpp
@@ -1,4 +1,4 @@
-#include "Primes.h"
+#include "math/Primes.h"
 
 int NextHashPrime(int i){
     static int primes[62] = {  

--- a/src/system/math/Rand.cpp
+++ b/src/system/math/Rand.cpp
@@ -1,5 +1,5 @@
-#include "Rand.h"
-#include "Random.h"
+#include "math/Rand.h"
+#include "math/Random.h"
 #include "common.hpp"
 
 extern unsigned int gMainThreadID;

--- a/src/system/math/Rand2.cpp
+++ b/src/system/math/Rand2.cpp
@@ -1,4 +1,4 @@
-#include "Rand2.h"
+#include "math/Rand2.h"
 
 // fn_802DDE34
 Rand2::Rand2(int i) {

--- a/src/system/math/Rot.cpp
+++ b/src/system/math/Rot.cpp
@@ -1,4 +1,4 @@
-#include "Rot.h"
+#include "math/Rot.h"
 
 #include <math.h>
 #include "math/Trig.h"

--- a/src/system/math/Rot.cpp
+++ b/src/system/math/Rot.cpp
@@ -1,10 +1,11 @@
 #include "Rot.h"
 
+#include <math.h>
+#include "math/Trig.h"
+#include "utl/BinStream.h"
+
 #include "common.hpp"
-#include "math.h"
 #include "vector_ops.hpp"
-#include "Trig.h"
-#include "BinStream.h"
 #include "shortquat.hpp"
 #include "shorttransform.hpp"
 

--- a/src/system/math/Rot.h
+++ b/src/system/math/Rot.h
@@ -1,9 +1,9 @@
 #ifndef MATH_ROT_H
 #define MATH_ROT_H
 #include "hmx/quat.hpp"
-#include "Mtx.h"
+#include "math/Mtx.h"
 #include "vector3.hpp"
-#include "TextStream.h"
+#include "utl/TextStream.h"
 #include "vector2.hpp"
 #include "transform.hpp"
 

--- a/src/system/math/Rot.h
+++ b/src/system/math/Rot.h
@@ -1,11 +1,12 @@
 #ifndef MATH_ROT_H
 #define MATH_ROT_H
-#include "hmx/quat.hpp"
 #include "math/Mtx.h"
-#include "vector3.hpp"
 #include "utl/TextStream.h"
-#include "vector2.hpp"
-#include "transform.hpp"
+
+#include "hmx/quat.hpp"
+#include "world/vector3.hpp"
+#include "world/vector2.hpp"
+#include "world/transform.hpp"
 
 // TODO: the quat class header and weak methods go in here according to RB2
 

--- a/src/system/math/Trig.cpp
+++ b/src/system/math/Trig.cpp
@@ -1,4 +1,4 @@
-#include "Trig.h"
+#include "math/Trig.h"
 
 #include <math.h>
 #include "utl/Symbol.h"

--- a/src/system/math/Trig.cpp
+++ b/src/system/math/Trig.cpp
@@ -1,7 +1,8 @@
 #include "Trig.h"
-#include "Symbol.h"
+
+#include <math.h>
+#include "utl/Symbol.h"
 #include "common.hpp"
-#include "math.h"
 
 float gBigSinTable[0x200];
 

--- a/src/system/math/strips/Adjacency.cpp
+++ b/src/system/math/strips/Adjacency.cpp
@@ -1,4 +1,4 @@
-#include "Adjacency.h"
+#include "math/strips/Adjacency.h"
 
 Adjacencies::Adjacencies() : mNbEdges(0), mCurrentNbFaces(0), mEdges(0), mNbFaces(0), mFaces(0) {
 

--- a/src/system/math/strips/CustomArray.cpp
+++ b/src/system/math/strips/CustomArray.cpp
@@ -1,4 +1,4 @@
-#include "CustomArray.h"
+#include "math/strips/CustomArray.h"
 #include <string.h>
 
 CustomArray::CustomArray(unsigned long startsize, void* inputbuffer) : mCollapsed(0), mAddresses(0), mNbPushedAddies(0), mNbAllocatedAddies(0), mBitCount(0), mBitMask(0) {

--- a/src/system/math/strips/CustomArray.cpp
+++ b/src/system/math/strips/CustomArray.cpp
@@ -1,5 +1,5 @@
 #include "CustomArray.h"
-#include "string.h"
+#include <string.h>
 
 CustomArray::CustomArray(unsigned long startsize, void* inputbuffer) : mCollapsed(0), mAddresses(0), mNbPushedAddies(0), mNbAllocatedAddies(0), mBitCount(0), mBitMask(0) {
     NewBlock(0, startsize);

--- a/src/system/math/strips/RevisitedRadix.cpp
+++ b/src/system/math/strips/RevisitedRadix.cpp
@@ -1,4 +1,4 @@
-#include "RevisitedRadix.h"
+#include "math/strips/RevisitedRadix.h"
 
 RadixSorter::RadixSorter(){
     mIndices = 0;

--- a/src/system/obj/Data.h
+++ b/src/system/obj/Data.h
@@ -1,9 +1,9 @@
 #ifndef OBJ_DATA_H
 #define OBJ_DATA_H
-#include "Symbol.h"
-#include "Str.h"
-#include "TextStream.h"
-#include "BinStream.h"
+#include "utl/BinStream.h"
+#include "utl/Str.h"
+#include "utl/Symbol.h"
+#include "utl/TextStream.h"
 
 // forward declarations
 class DataNode;

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -1,11 +1,14 @@
-#include "Data.h"
-#include "Symbol.h"
-#include "string.h"
-#include "stdlib.h"
-#include "common.hpp"
-#include "Object.h"
+#include "obj/Data.h"
+
+#include <stdlib.h>
+#include <string.h>
 #include <new>
 #include <list>
+
+#include "obj/Object.h"
+#include "utl/Symbol.h"
+
+#include "common.hpp"
 
 // std::list<bool> gConditional;
 Symbol gFile;

--- a/src/system/obj/DataFunc.cpp
+++ b/src/system/obj/DataFunc.cpp
@@ -1,21 +1,24 @@
-#include "Data.h"
-#include "Symbol.h"
-#include "common.hpp"
-#include "file_ops.hpp"
-#include "Str.h"
-#include "string.h"
-#include "stdlib.h"
-#include "vector3.hpp"
-#include "MakeString.h"
-#include "Debug.h"
-#include "Random.h"
-#include "Object.h"
-#include "Dir.h"
-#include "mergefilter.hpp"
-#include "datamergefilter.hpp"
-#include "DataFunc.h"
-#include <map>
+#include "obj/DataFunc.h"
+
+#include <stdlib.h>
+#include <string.h>
 #include <new>
+#include <map>
+
+#include "math/Random.h"
+#include "obj/Data.h"
+#include "obj/Dir.h"
+#include "obj/Object.h"
+#include "os/Debug.h"
+#include "utl/MakeString.h"
+#include "utl/Str.h"
+#include "utl/Symbol.h"
+
+#include "common.hpp"
+#include "datamergefilter.hpp"
+#include "file_ops.hpp"
+#include "mergefilter.hpp"
+#include "vector3.hpp"
 
 // std::map<Symbol, DataFunc*> gDataFuncs;
 

--- a/src/system/obj/DataFunc.cpp
+++ b/src/system/obj/DataFunc.cpp
@@ -18,7 +18,7 @@
 #include "datamergefilter.hpp"
 #include "file_ops.hpp"
 #include "mergefilter.hpp"
-#include "vector3.hpp"
+#include "world/vector3.hpp"
 
 // std::map<Symbol, DataFunc*> gDataFuncs;
 

--- a/src/system/obj/DataFunc.h
+++ b/src/system/obj/DataFunc.h
@@ -1,6 +1,7 @@
 #ifndef OBJ_DATAFUNC_H
 #define OBJ_DATAFUNC_H
-#include "Object.h"
+#include "obj/Data.h"
+#include "obj/Object.h"
 
 class DataFuncObj : public Hmx::Object {
 public:

--- a/src/system/obj/DataNode.cpp
+++ b/src/system/obj/DataNode.cpp
@@ -1,9 +1,11 @@
-#include "Data.h"
-#include "Str.h"
-#include "Object.h"
-#include "string.h"
+#include "obj/Data.h"
+
+#include <string.h>
 #include <new>
 #include <map>
+
+#include "obj/Object.h"
+#include "utl/Str.h"
 
 // std::map<Symbol, DataNode> gDataVars;
 DataNode gEvalNode[8];

--- a/src/system/obj/DataUtl.cpp
+++ b/src/system/obj/DataUtl.cpp
@@ -1,8 +1,9 @@
-#include "Data.h"
-#include "Object.h"
+#include "obj/DataUtl.h"
+
+#include "obj/Data.h"
+#include "obj/Object.h"
+#include "obj/TextFile.h"
 #include "varstack.hpp"
-#include "DataUtl.h"
-#include "TextFile.h"
 
 void DataMergeTags(DataArray *dest, DataArray *src) {
     if(dest == 0 || src == 0 || dest == src) return;

--- a/src/system/obj/DataUtl.h
+++ b/src/system/obj/DataUtl.h
@@ -1,6 +1,6 @@
 #ifndef OBJ_DATAUTL_H
 #define OBJ_DATAUTL_H
-#include "Data.h"
+#include "obj/Data.h"
 
 void DataMergeTags(DataArray*, DataArray*);
 void DataReplaceTags(DataArray*, DataArray*);

--- a/src/system/obj/Dir.cpp
+++ b/src/system/obj/Dir.cpp
@@ -1,5 +1,6 @@
-#include "Object.h"
-#include "Dir.h"
+#include "obj/Dir.h"
+
+#include "obj/Object.h"
 
 Hmx::Object* Hmx::Object::NewObject(){
     return new Hmx::Object();

--- a/src/system/obj/Dir.h
+++ b/src/system/obj/Dir.h
@@ -1,8 +1,8 @@
 #ifndef OBJ_DIR_H
 #define OBJ_DIR_H
-#include "Object.h"
-#include "StringTable.h"
-#include "FilePath.h"
+#include "obj/Object.h"
+#include "utl/FilePath.h"
+#include "utl/StringTable.h"
 
 enum ViewportId {
     kPerspective = 0,

--- a/src/system/obj/ObjPtr_p.h
+++ b/src/system/obj/ObjPtr_p.h
@@ -1,6 +1,6 @@
 #ifndef OBJ_OBJPTR_H
 #define OBJ_OBJPTR_H
-#include "Object.h"
+#include "obj/Object.h"
 
 template <class T1, class T2> class ObjPtr : public ObjRef {
 public:

--- a/src/system/obj/Object.cpp
+++ b/src/system/obj/Object.cpp
@@ -1,9 +1,11 @@
-#include "Object.h"
-#include "Data.h"
+#include "obj/Object.h"
+
+#include "obj/Data.h"
+#include "obj/Dir.h"
+#include "obj/Utl.h"
+
 #include "common.hpp"
 #include "msgsource.hpp"
-#include "Dir.h"
-#include "obj/Utl.h"
 
 extern const char* gNullStr;
 extern void PropertyNOP(const char*, char*, String&);

--- a/src/system/obj/Object.h
+++ b/src/system/obj/Object.h
@@ -1,10 +1,10 @@
 #ifndef OBJ_OBJECT_H
 #define OBJ_OBJECT_H
-#include "Data.h"
-#include "Symbol.h"
-#include "Str.h"
-#include "TextStream.h"
-#include "BinStream.h"
+#include "obj/Data.h"
+#include "utl/BinStream.h"
+#include "utl/Str.h"
+#include "utl/Symbol.h"
+#include "utl/TextStream.h"
 
 // forward declarations
 class ObjRef;

--- a/src/system/obj/PropSync.cpp
+++ b/src/system/obj/PropSync.cpp
@@ -1,6 +1,7 @@
-#include "PropSync.h"
+#include "obj/PropSync.h"
+
+#include "math/Rot.h"
 #include "symbols.hpp"
-#include "Rot.h"
 
 bool PropSync(String& str, DataNode& node, DataArray* da, int i, PropOp op){
     da->Size();

--- a/src/system/obj/PropSync.h
+++ b/src/system/obj/PropSync.h
@@ -10,8 +10,8 @@
 #include "box.hpp"
 #include "sphere.hpp"
 #include "transform.hpp"
-#include "vector2.hpp"
-#include "vector3.hpp"
+#include "world/vector2.hpp"
+#include "world/vector3.hpp"
 
 bool PropSync(String&, DataNode&, DataArray*, int, PropOp);
 bool PropSync(FilePath&, DataNode&, DataArray*, int, PropOp);

--- a/src/system/obj/PropSync.h
+++ b/src/system/obj/PropSync.h
@@ -1,16 +1,17 @@
 #ifndef OBJ_PROPSYNC_H
 #define OBJ_PROPSYNC_H
-#include "Object.h"
-#include "vector2.hpp"
-#include "vector3.hpp"
+#include "math/Color.h"
+#include "math/Mtx.h"
+#include "math/Rect.h"
+#include "obj/Object.h"
+#include "utl/FilePath.h"
+#include "utl/Symbol.h"
+
+#include "box.hpp"
 #include "sphere.hpp"
 #include "transform.hpp"
-#include "Mtx.h"
-#include "Color.h"
-#include "FilePath.h"
-#include "Rect.h"
-#include "box.hpp"
-#include "Symbol.h"
+#include "vector2.hpp"
+#include "vector3.hpp"
 
 bool PropSync(String&, DataNode&, DataArray*, int, PropOp);
 bool PropSync(FilePath&, DataNode&, DataArray*, int, PropOp);

--- a/src/system/obj/TextFile.cpp
+++ b/src/system/obj/TextFile.cpp
@@ -1,9 +1,11 @@
-#include "TextFile.h"
-#include "MakeString.h"
-#include "System.h"
+#include "obj/TextFile.h"
+
 #include "obj/Utl.h"
+#include "os/Debug.h"
+#include "os/System.h"
+#include "utl/MakeString.h"
+
 #include "symbols.hpp"
-#include "Debug.h"
 
 void TextFile::SetName(const char* c, ObjectDir* dir){
     Hmx::Object::SetName(c, dir);

--- a/src/system/obj/TextFile.h
+++ b/src/system/obj/TextFile.h
@@ -1,11 +1,11 @@
 #ifndef OBJ_TEXTFILE_H
 #define OBJ_TEXTFILE_H
-#include "Symbol.h"
-#include "TextStream.h"
-#include "Object.h"
-#include "File.h"
-#include "System.h"
+#include "utl/Symbol.h"
+#include "utl/TextStream.h"
+#include "obj/Object.h"
 #include "obj/Utl.h"
+#include "os/File.h"
+#include "os/System.h"
 
 class TextFile : public Hmx::Object, TextStream {
 public:

--- a/src/system/obj/TypeProps.cpp
+++ b/src/system/obj/TypeProps.cpp
@@ -1,7 +1,9 @@
-#include "Object.h"
-#include "Data.h"
-#include "symbols.hpp"
+#include "obj/Object.h"
+
 #include <new>
+
+#include "obj/Data.h"
+#include "symbols.hpp"
 
 DataArray* TypeProps::GetArray(Symbol prop, DataArray* typeDef, ObjRef* ref){
     DataNode* kv = KeyValue(prop, false);

--- a/src/system/obj/Utl.cpp
+++ b/src/system/obj/Utl.cpp
@@ -1,5 +1,6 @@
 #include "obj/Utl.h"
-#include "System.h"
+
+#include "os/System.h"
 
 void InitObject(Hmx::Object* obj){
     static DataArray* objects = SystemConfig("objects");

--- a/src/system/obj/Utl.h
+++ b/src/system/obj/Utl.h
@@ -1,7 +1,7 @@
 #ifndef OBJ_UTL_H
 #define OBJ_UTL_H
-#include "Object.h"
-#include "Symbol.h"
+#include "obj/Object.h"
+#include "utl/Symbol.h"
 
 void InitObject(Hmx::Object*);
 char* PathName(const Hmx::Object*);

--- a/src/system/os/ArkFile.cpp
+++ b/src/system/os/ArkFile.cpp
@@ -1,9 +1,10 @@
-#include "File.h"
-#include "file_ops.hpp"
-#include "ArkFile.h"
-#include "Archive.h"
+#include "os/ArkFile.h"
+
+#include "os/Archive.h"
+#include "os/AsyncTask.h"
+
 #include "blockmgr.hpp"
-#include "AsyncTask.h"
+#include "file_ops.hpp"
 
 int File::sOpenCount[4];
 

--- a/src/system/os/ArkFile.h
+++ b/src/system/os/ArkFile.h
@@ -1,7 +1,7 @@
 #ifndef OS_ARKFILE_H
 #define OS_ARKFILE_H
 #include <types.h>
-#include "File.h"
+#include "os/File.h"
 
 class ArkFile : public File {
 public:

--- a/src/system/os/AsyncFile.cpp
+++ b/src/system/os/AsyncFile.cpp
@@ -1,7 +1,10 @@
-#include "file.hpp"
-#include "AsyncFile.h"
-#include "string.h"
-#include "Str.h"
+#include "os/AsyncFile.h"
+
+#include <string.h>
+
+#include "os/File.h"
+#include "utl/Str.h"
+
 #include "unknown.hpp"
 
 // fn_802E7B68

--- a/src/system/os/AsyncFile.h
+++ b/src/system/os/AsyncFile.h
@@ -1,7 +1,7 @@
 #ifndef OS_ASYNCFILE_H
 #define OS_ASYNCFILE_H
-#include "file.hpp"
-#include "Str.h"
+#include "os/File.h"
+#include "utl/Str.h"
 
 class AsyncFile : public File {
 public:

--- a/src/system/os/AsyncFileCNT.cpp
+++ b/src/system/os/AsyncFileCNT.cpp
@@ -1,7 +1,9 @@
-#include "file.hpp"
 #include "AsyncFileCNT.h"
-#include "string.h"
-#include "Str.h"
+
+#include <string.h>
+
+#include "os/File.h"
+#include "utl/Str.h"
 
 extern char fn_802FB54C(const char *, int);
 

--- a/src/system/os/AsyncFileCNT.h
+++ b/src/system/os/AsyncFileCNT.h
@@ -1,7 +1,7 @@
 #ifndef OS_ASYNCFILECNT_H
 #define OS_ASYNCFILECNT_H
-#include "AsyncFile.h"
-#include "Str.h"
+#include "os/AsyncFile.h"
+#include "utl/Str.h"
 
 class AsyncFileCNT : public AsyncFile {
 public:

--- a/src/system/os/AsyncFile_Wii.cpp
+++ b/src/system/os/AsyncFile_Wii.cpp
@@ -1,11 +1,14 @@
-#include "Str.h"
-#include "TextStream.h"
+#include "os/AsyncFile_Wii.h"
+
+#include <string.h>
+
+#include "os/AsyncFile.h"
+#include "os/AsyncFileCNT.h"
+#include "os/File.h"
+#include "utl/Str.h"
+#include "utl/TextStream.h"
+
 #include "unknown.hpp"
-#include "string.h"
-#include "file.hpp"
-#include "AsyncFile.h"
-#include "AsyncFileCNT.h"
-#include "AsyncFile_Wii.h"
 
 // fn_802E8B7C
 // AsyncFileWii's ctor

--- a/src/system/os/AsyncFile_Wii.h
+++ b/src/system/os/AsyncFile_Wii.h
@@ -1,7 +1,7 @@
 #ifndef OS_ASYNCFILEWII_H
 #define OS_ASYNCFILEWII_H
-#include "AsyncFile.h"
-#include "Str.h"
+#include "os/AsyncFile.h"
+#include "utl/Str.h"
 
 class AsyncFileWii : public AsyncFile {
 public:

--- a/src/system/os/AsyncTask.h
+++ b/src/system/os/AsyncTask.h
@@ -1,6 +1,6 @@
 #ifndef OS_ASYNCTASK_H
 #define OS_ASYNCTASK_H
-#include "ArkFile.h"
+#include "os/ArkFile.h"
 
 class AsyncTask {
 public:

--- a/src/system/os/Debug.h
+++ b/src/system/os/Debug.h
@@ -1,7 +1,7 @@
 #ifndef OS_DEBUG_H
 #define OS_DEBUG_H
-#include "TextStream.h"
-#include "TextFileStream.h"
+#include "utl/TextFileStream.h"
+#include "utl/TextStream.h"
 
 class Debug : public TextStream {
 public:

--- a/src/system/os/File.h
+++ b/src/system/os/File.h
@@ -1,6 +1,6 @@
 #ifndef OS_FILE_H
 #define OS_FILE_H
-#include "Str.h"
+#include "utl/Str.h"
 
 class File {
 public:

--- a/src/system/os/Joypad.cpp
+++ b/src/system/os/Joypad.cpp
@@ -1,5 +1,5 @@
-#include "Data.h"
-#include "Symbol.h"
+#include "obj/Data.h"
+#include "utl/Symbol.h"
 #include "common.hpp"
 
 extern void DataRegisterFunc(Symbol, DataNode (*)(DataArray *));

--- a/src/system/os/System.cpp
+++ b/src/system/os/System.cpp
@@ -1,4 +1,5 @@
-#include "System.h"
+#include "os/System.h"
+
 #include "symbols.hpp"
 
 extern int StubOne();

--- a/src/system/os/System.h
+++ b/src/system/os/System.h
@@ -1,7 +1,7 @@
 #ifndef OS_SYSTEM_H
 #define OS_SYSTEM_H
-#include "Symbol.h"
-#include "Data.h"
+#include "obj/Data.h"
+#include "utl/Symbol.h"
 
 DataNode OnSystemLanguage(DataArray*);
 DataNode OnSystemExec(DataArray*);

--- a/src/system/os/User.h
+++ b/src/system/os/User.h
@@ -1,7 +1,7 @@
 #ifndef OS_USER_H
 #define OS_USER_H
-#include "hmx/object.hpp"
-#include "hxguid.hpp"
+#include "obj/Object.h"
+#include "utl/HxGuid.h"
 #include "onlineid.hpp"
 
 class User : public Hmx::Object {

--- a/src/system/synth/ADSR.cpp
+++ b/src/system/synth/ADSR.cpp
@@ -1,4 +1,4 @@
-#include "ADSR.h"
+#include "synth/ADSR.h"
 
 const float gDecayRate[16] = {
     0.00007f, 0.00018f, 0.00039f, 0.00081f, 0.0016f, 0.0033f, 0.00669999989f, 0.013f,

--- a/src/system/synth/ByteGrinder.cpp
+++ b/src/system/synth/ByteGrinder.cpp
@@ -1,7 +1,7 @@
 #include "ByteGrinder.h"
 #include "Data.h"
 #include "string.h"
-#include "MSL_C/MSL_Common/printf.h"
+#include <stdio.h>
 #include "Str.h"
 #include <vector>
 

--- a/src/system/synth/ByteGrinder.cpp
+++ b/src/system/synth/ByteGrinder.cpp
@@ -1,9 +1,11 @@
-#include "ByteGrinder.h"
-#include "Data.h"
-#include "string.h"
+#include "synth/ByteGrinder.h"
+
+#include <string.h>
 #include <stdio.h>
-#include "Str.h"
 #include <vector>
+
+#include "obj/Data.h"
+#include "utl/Str.h"
 
 namespace {
     int GetEncMethod(int ver){

--- a/src/system/synth/ByteGrinder.cpp
+++ b/src/system/synth/ByteGrinder.cpp
@@ -1,7 +1,7 @@
 #include "ByteGrinder.h"
 #include "Data.h"
 #include "string.h"
-#include "sdk/MSL_C/MSL_Common/printf.h"
+#include "MSL_C/MSL_Common/printf.h"
 #include "Str.h"
 #include <vector>
 

--- a/src/system/synth/ByteGrinder.h
+++ b/src/system/synth/ByteGrinder.h
@@ -1,7 +1,6 @@
 #ifndef SYNTH_BYTEGRINDER_H
 #define SYNTH_BYTEGRINDER_H
 
-
 /** Handles MOGG/BIK encryption, as it is unique from BinStream encryption. */
 class ByteGrinder {
 public:

--- a/src/system/synth/FxSend.cpp
+++ b/src/system/synth/FxSend.cpp
@@ -1,4 +1,6 @@
-#include "FxSend.h"
+#include "synth/FxSend.h"
+
+#include <stddef.h>
 
 FxSend::FxSend() : ptr(this, nullptr), unk28(0), unk2c(0), unk30(-96.0f), 
     unk34(0.0f), unk38(0.0f), unk3c(-96.0f), unk40(0), unk41(1), unk44(0) {

--- a/src/system/synth/FxSend.h
+++ b/src/system/synth/FxSend.h
@@ -1,7 +1,7 @@
 #ifndef SYNTH_FXSEND_H
 #define SYNTH_FXSEND_H
-#include "hmx/object.hpp"
-#include "objownerptr.hpp"
+#include "obj/Object.h"
+#include "obj/ObjPtr_p.h"
 
 class FxSend : public Hmx::Object {
 public:

--- a/src/system/synth/oggvorbis/VorbisMem.cpp
+++ b/src/system/synth/oggvorbis/VorbisMem.cpp
@@ -1,5 +1,5 @@
-#include <ogg/os_types.h>
 #include <string.h>
+#include <ogg/os_types.h>
 
 extern void *MemAllocTemp(int, int);
 

--- a/src/system/ui/UIPanel.cpp
+++ b/src/system/ui/UIPanel.cpp
@@ -1,4 +1,5 @@
-#include "UIPanel.h"
+#include "ui/UIPanel.h"
+
 #include "messages.hpp"
 
 extern int lbl_80988298; // wonder if this lbl represents total panel count, and unk34 of a UIPanel is its unique panel id?

--- a/src/system/ui/UIPanel.h
+++ b/src/system/ui/UIPanel.h
@@ -1,8 +1,8 @@
 #ifndef UI_UIPANEL_H
 #define UI_UIPANEL_H
-#include "Object.h"
-#include "String.h"
-#include "FilePath.h"
+#include "obj/Object.h"
+#include "utl/FilePath.h"
+#include "utl/Str.h"
 
 enum State {
     kUnloaded = 0,

--- a/src/system/utl/BinStream.cpp
+++ b/src/system/utl/BinStream.cpp
@@ -1,10 +1,13 @@
-#include "Str.h"
-#include "TextStream.h"
-#include "BinStream.h"
-#include "string.h"
-#include "Symbol.h"
+#include "utl/BinStream.h"
+
+#include <string.h>
+
+#include "math/Random.h"
+#include "utl/Str.h"
+#include "utl/Symbol.h"
+#include "utl/TextStream.h"
+
 #include "common.hpp"
-#include "Random.h"
 
 const char *BinStream::Name() const {
     return "<unnamed>";

--- a/src/system/utl/BinStream.h
+++ b/src/system/utl/BinStream.h
@@ -1,8 +1,8 @@
 #ifndef UTL_BINSTREAM_H
 #define UTL_BINSTREAM_H
-#include "Symbol.h"
-#include "Str.h"
-#include "Rand2.h"
+#include "math/Rand2.h"
+#include "utl/Str.h"
+#include "utl/Symbol.h"
 
 class BinStream {
 public:

--- a/src/system/utl/BufStream.cpp
+++ b/src/system/utl/BufStream.cpp
@@ -1,4 +1,4 @@
-#include "BufStream.h"
+#include "utl/BufStream.h"
 
 // fn_803431F4
 BufStream::BufStream(void * buffer, int size, bool lilEndian) : BinStream(lilEndian), mChecksum(0), mBytesChecksummed() {

--- a/src/system/utl/BufStream.h
+++ b/src/system/utl/BufStream.h
@@ -1,7 +1,7 @@
 #ifndef UTL_BUFSTREAM_H
 #define UTL_BUFSTREAM_H
-#include "BinStream.h"
-#include "Str.h"
+#include "utl/BinStream.h"
+#include "utl/Str.h"
 #include "streamchecksum.hpp"
 
 class BufStream : public BinStream {

--- a/src/system/utl/ChunkIDs.cpp
+++ b/src/system/utl/ChunkIDs.cpp
@@ -1,4 +1,4 @@
-#include "ChunkIDs.h"
+#include "utl/ChunkIDs.h"
 
 ChunkID kListChunkID("LIST");
 ChunkID kRiffChunkID("RIFF");

--- a/src/system/utl/ChunkIDs.h
+++ b/src/system/utl/ChunkIDs.h
@@ -1,6 +1,6 @@
 #ifndef UTL_CHUNKIDS_H
 #define UTL_CHUNKIDS_H
-#include "string.h"
+#include <string.h>
 
 class ChunkID {
 public:

--- a/src/system/utl/Chunks.cpp
+++ b/src/system/utl/Chunks.cpp
@@ -1,4 +1,4 @@
-#include "Chunks.h"
+#include "utl/Chunks.h"
 
 // IDataChunk::IDataChunk(IListChunk& iParent) : BinStream(true) {
 //     mBaseBinStream = iParent.mBaseBinStream;

--- a/src/system/utl/Chunks.h
+++ b/src/system/utl/Chunks.h
@@ -1,7 +1,7 @@
 #ifndef UTL_CHUNKS_H
 #define UTL_CHUNKS_H
-#include "ChunkIDs.h"
-#include "BinStream.h"
+#include "utl/BinStream.h"
+#include "utl/ChunkIDs.h"
 
 class ChunkHeader {
 public:

--- a/src/system/utl/EncryptXTEA.cpp
+++ b/src/system/utl/EncryptXTEA.cpp
@@ -1,5 +1,6 @@
-#include "EncryptXTEA.h"
-#include "string.h"
+#include "utl/EncryptXTEA.h"
+
+#include <string.h>
 
 XTEABlockEncrypter::XTEABlockEncrypter(){
     mNonce[0] = 0;

--- a/src/system/utl/FilePath.cpp
+++ b/src/system/utl/FilePath.cpp
@@ -1,4 +1,5 @@
-#include "FilePath.h"
+#include "utl/FilePath.h"
+
 #include "file_ops.hpp"
 
 FilePath FilePath::sRoot;

--- a/src/system/utl/FilePath.h
+++ b/src/system/utl/FilePath.h
@@ -1,6 +1,6 @@
 #ifndef UTL_FILEPATH_H
 #define UTL_FILEPATH_H
-#include "Str.h"
+#include "utl/Str.h"
 
 class FilePath : public String {
 public:

--- a/src/system/utl/FileStream.cpp
+++ b/src/system/utl/FileStream.cpp
@@ -1,4 +1,4 @@
-#include "FileStream.h"
+#include "utl/FileStream.h"
 
 extern File *NewFile(const char *, int);
 

--- a/src/system/utl/FileStream.h
+++ b/src/system/utl/FileStream.h
@@ -1,8 +1,8 @@
 #ifndef UTL_FILESTREAM_H
 #define UTL_FILESTREAM_H
-#include "BinStream.h"
-#include "Str.h"
-#include "File.h"
+#include "os/File.h"
+#include "utl/BinStream.h"
+#include "utl/Str.h"
 #include "streamchecksum.hpp"
 
 class FileStream : public BinStream {

--- a/src/system/utl/HxGuid.cpp
+++ b/src/system/utl/HxGuid.cpp
@@ -1,4 +1,4 @@
-#include "HxGuid.h"
+#include "utl/HxGuid.h"
 
 HxGuid::HxGuid(){
     Clear();

--- a/src/system/utl/IntPacker.cpp
+++ b/src/system/utl/IntPacker.cpp
@@ -1,5 +1,6 @@
-#include "IntPacker.h"
-#include "string.h"
+#include "utl/IntPacker.h"
+
+#include <string.h>
 
 IntPacker::IntPacker(void* v, unsigned int ui){
     unk0 = (unsigned char*)v;

--- a/src/system/utl/Loader.h
+++ b/src/system/utl/Loader.h
@@ -1,7 +1,7 @@
 #ifndef UTL_LOADER_H
 #define UTL_LOADER_H
-#include "FilePath.h"
-#include "System.h"
+#include "os/System.h"
+#include "utl/FilePath.h"
 
 enum LoaderPos {
     kLoadFront = 0,

--- a/src/system/utl/Locale.cpp
+++ b/src/system/utl/Locale.cpp
@@ -1,4 +1,4 @@
-#include "Locale.h"
+#include "utl/Locale.h"
 
 Locale TheLocale;
 

--- a/src/system/utl/Locale.h
+++ b/src/system/utl/Locale.h
@@ -1,12 +1,13 @@
 #ifndef UTL_LOCALE_H
 #define UTL_LOCALE_H
-#include "Symbol.h"
-#include "Data.h"
+#include "obj/Data.h"
+#include "utl/Symbol.h"
 
 enum LocaleGender {
     LocaleGenderMasculine = 0,
     LocaleGenderFeminine = 1,
 };
+
 enum LocaleNumber {
     LocaleSingular = 0,
     LocalePlural = 1,

--- a/src/system/utl/LocaleOrdinal.cpp
+++ b/src/system/utl/LocaleOrdinal.cpp
@@ -1,11 +1,14 @@
-#include "LocaleOrdinal.h"
-#include "Locale.h"
-#include "Symbol.h"
-#include "symbols.hpp"
-#include "MakeString.h"
-#include "System.h"
-#include "UTF8.h"
+#include "utl/LocaleOrdinal.h"
+
 #include <string.h>
+
+#include "os/System.h"
+#include "utl/Locale.h"
+#include "utl/MakeString.h"
+#include "utl/Symbol.h"
+#include "utl/UTF8.h"
+
+#include "symbols.hpp"
 
 const char* LocalizeOrdinal(int i, LocaleGender gender, LocaleNumber number, bool super){
     char buf[254];

--- a/src/system/utl/LocaleOrdinal.h
+++ b/src/system/utl/LocaleOrdinal.h
@@ -1,6 +1,6 @@
 #ifndef UTL_LOCALEORDINAL_H
 #define UTL_LOCALEORDINAL_H
-#include "Locale.h"
+#include "utl/Locale.h"
 
 const char* LocalizeOrdinal(int, LocaleGender, LocaleNumber, bool);
 

--- a/src/system/utl/LogFile.cpp
+++ b/src/system/utl/LogFile.cpp
@@ -1,4 +1,4 @@
-#include "LogFile.h"
+#include "utl/LogFile.h"
 
 LogFile::LogFile(const char* file_pattern) : mFilePattern(file_pattern), mSerialNumber(0), mDirty(0), mFile(0), mActive(0){
 

--- a/src/system/utl/LogFile.h
+++ b/src/system/utl/LogFile.h
@@ -1,7 +1,7 @@
 #ifndef UTL_LOGFILE_H
 #define UTL_LOGFILE_H
-#include "TextStream.h"
-#include "TextFileStream.h"
+#include "utl/TextFileStream.h"
+#include "utl/TextStream.h"
 
 class LogFile : public TextStream {
 public:

--- a/src/system/utl/MakeString.cpp
+++ b/src/system/utl/MakeString.cpp
@@ -1,8 +1,11 @@
-#include "MakeString.h"
-#include "common.hpp"
-#include "string.h"
+#include "utl/MakeString.h"
+
 #include <stdio.h>
-#include "Data.h"
+#include <string.h>
+
+#include "obj/Data.h"
+
+#include "common.hpp"
 
 extern char *NextBuf();
 

--- a/src/system/utl/MakeString.cpp
+++ b/src/system/utl/MakeString.cpp
@@ -1,7 +1,7 @@
 #include "MakeString.h"
 #include "common.hpp"
 #include "string.h"
-#include "MSL_C/MSL_Common/printf.h"
+#include <stdio.h>
 #include "Data.h"
 
 extern char *NextBuf();

--- a/src/system/utl/MakeString.cpp
+++ b/src/system/utl/MakeString.cpp
@@ -1,7 +1,7 @@
 #include "MakeString.h"
 #include "common.hpp"
 #include "string.h"
-#include "sdk/MSL_C/MSL_Common/printf.h"
+#include "MSL_C/MSL_Common/printf.h"
 #include "Data.h"
 
 extern char *NextBuf();

--- a/src/system/utl/MakeString.cpp
+++ b/src/system/utl/MakeString.cpp
@@ -4,7 +4,6 @@
 #include <string.h>
 
 #include "obj/Data.h"
-
 #include "common.hpp"
 
 extern char *NextBuf();

--- a/src/system/utl/MakeString.h
+++ b/src/system/utl/MakeString.h
@@ -1,7 +1,7 @@
 #ifndef UTL_MAKESTRING_H
 #define UTL_MAKESTRING_H
-#include "Str.h"
-#include "Data.h"
+#include "obj/Data.h"
+#include "utl/Str.h"
 
 class FormatString {
 public:

--- a/src/system/utl/Message.h
+++ b/src/system/utl/Message.h
@@ -1,8 +1,9 @@
 #ifndef UTL_MESSAGE_H
 #define UTL_MESSAGE_H
-#include "Data.h"
-#include "Symbol.h"
 #include <new>
+
+#include "obj/Data.h"
+#include "utl/Symbol.h"
 
 // every method in here is weak
 class Message {

--- a/src/system/utl/MultiTempoTempoMap.h
+++ b/src/system/utl/MultiTempoTempoMap.h
@@ -1,7 +1,7 @@
 #ifndef UTL_MULTITEMPOTEMPOMAP_H
 #define UTL_MULTITEMPOTEMPOMAP_H
-#include "TempoMap.h"
-#include "string.hpp"
+#include "utl/Str.h"
+#include "utl/TempoMap.h"
 
 class MultiTempoTempoMap : public TempoMap {
 public:

--- a/src/system/utl/Option.cpp
+++ b/src/system/utl/Option.cpp
@@ -1,5 +1,5 @@
-#include "Data.h"
-#include "Symbol.h"
+#include "obj/Data.h"
+#include "utl/Symbol.h"
 #include "common.hpp"
 
 extern void DataRegisterFunc(Symbol, DataNode (*)(DataArray *));

--- a/src/system/utl/SimpleTempoMap.h
+++ b/src/system/utl/SimpleTempoMap.h
@@ -1,6 +1,6 @@
 #ifndef UTL_SIMPLETEMPOMAP_H
 #define UTL_SIMPLETEMPOMAP_H
-#include "TempoMap.h"
+#include "utl/TempoMap.h"
 
 class SimpleTempoMap : public TempoMap {
 public:

--- a/src/system/utl/Str.cpp
+++ b/src/system/utl/Str.cpp
@@ -3,7 +3,6 @@
 #include <string.h>
 
 #include "utl/Symbol.h"
-
 #include "unknown.hpp"
 
 extern char gEmpty;

--- a/src/system/utl/Str.cpp
+++ b/src/system/utl/Str.cpp
@@ -1,7 +1,10 @@
-#include "Str.h"
+#include "utl/Str.h"
+
+#include <string.h>
+
+#include "utl/Symbol.h"
+
 #include "unknown.hpp"
-#include "string.h"
-#include "Symbol.h"
 
 extern char gEmpty;
 

--- a/src/system/utl/Str.h
+++ b/src/system/utl/Str.h
@@ -1,7 +1,7 @@
 #ifndef UTL_STR_H
 #define UTL_STR_H
-#include "TextStream.h"
-#include "Symbol.h"
+#include "utl/TextStream.h"
+#include "utl/Symbol.h"
 
 /** An object representing a sequence of characters. */
 class String : public TextStream {

--- a/src/system/utl/TempoMap.cpp
+++ b/src/system/utl/TempoMap.cpp
@@ -1,5 +1,5 @@
-#include "SimpleTempoMap.h"
-#include "TempoMap.h"
+#include "utl/SimpleTempoMap.h"
+#include "utl/TempoMap.h"
 
 SimpleTempoMap gDefaultTempoMap(1000.0f);
 TempoMap* TheTempoMap = &gDefaultTempoMap;

--- a/src/system/utl/TextFileStream.cpp
+++ b/src/system/utl/TextFileStream.cpp
@@ -1,7 +1,7 @@
 #include "TextFileStream.h"
 #include "FileStream.h"
 #include "unknown.hpp"
-#include "sdk/MSL_C/MSL_Common/printf.h"
+#include "MSL_C/MSL_Common/printf.h"
 
 // fn_8037A58C - TextFileStream ctor
 TextFileStream::TextFileStream(const char *file, bool append)

--- a/src/system/utl/TextFileStream.cpp
+++ b/src/system/utl/TextFileStream.cpp
@@ -1,7 +1,9 @@
-#include "TextFileStream.h"
-#include "FileStream.h"
-#include "unknown.hpp"
+#include "utl/TextFileStream.h"
+
 #include <stdio.h>
+
+#include "utl/FileStream.h"
+#include "unknown.hpp"
 
 // fn_8037A58C - TextFileStream ctor
 TextFileStream::TextFileStream(const char *file, bool append)

--- a/src/system/utl/TextFileStream.cpp
+++ b/src/system/utl/TextFileStream.cpp
@@ -1,7 +1,7 @@
 #include "TextFileStream.h"
 #include "FileStream.h"
 #include "unknown.hpp"
-#include "MSL_C/MSL_Common/printf.h"
+#include <stdio.h>
 
 // fn_8037A58C - TextFileStream ctor
 TextFileStream::TextFileStream(const char *file, bool append)

--- a/src/system/utl/TextFileStream.h
+++ b/src/system/utl/TextFileStream.h
@@ -1,8 +1,8 @@
 #ifndef UTL_TEXTFILESTREAM_H
 #define UTL_TEXTFILESTREAM_H
-#include "TextStream.h"
-#include "FileStream.h"
-#include "BinStream.h"
+#include "utl/BinStream.h"
+#include "utl/FileStream.h"
+#include "utl/TextStream.h"
 
 class TextFileStream : public TextStream {
 public:

--- a/src/system/utl/TextStream.cpp
+++ b/src/system/utl/TextStream.cpp
@@ -1,6 +1,6 @@
 #include "TextStream.h"
 #include "unknown.hpp"
-#include "MSL_C/MSL_Common/printf.h"
+#include <stdio.h>
 
 // fn_8037A67C
 TextStream::TextStream() {

--- a/src/system/utl/TextStream.cpp
+++ b/src/system/utl/TextStream.cpp
@@ -1,6 +1,6 @@
 #include "TextStream.h"
 #include "unknown.hpp"
-#include "sdk/MSL_C/MSL_Common/printf.h"
+#include "MSL_C/MSL_Common/printf.h"
 
 // fn_8037A67C
 TextStream::TextStream() {

--- a/src/system/utl/TextStream.cpp
+++ b/src/system/utl/TextStream.cpp
@@ -1,6 +1,7 @@
-#include "TextStream.h"
-#include "unknown.hpp"
+#include "utl/TextStream.h"
+
 #include <stdio.h>
+#include "unknown.hpp"
 
 // fn_8037A67C
 TextStream::TextStream() {

--- a/src/system/utl/TextStream.h
+++ b/src/system/utl/TextStream.h
@@ -1,6 +1,6 @@
 #ifndef UTL_TEXTSTREAM_H
 #define UTL_TEXTSTREAM_H
-#include "Symbol.h"
+#include "utl/Symbol.h"
 
 // class DataArray;
 

--- a/src/system/utl/UTF8.cpp
+++ b/src/system/utl/UTF8.cpp
@@ -1,7 +1,9 @@
-#include "Str.h"
+#include "utl/Str.h"
+
+#include <string.h>
+
 #include "unknown.hpp"
-#include "string.h"
-#include "UTF8.h"
+#include "utl/UTF8.h"
 
 extern char lbl_80874588[]; //"*"
 

--- a/src/system/utl/UTF8.h
+++ b/src/system/utl/UTF8.h
@@ -1,6 +1,6 @@
 #ifndef UTL_UTF8_H
 #define UTL_UTF8_H
-#include "Str.h"
+#include "utl/Str.h"
 
 int EncodeUTF8(String&, unsigned int);
 

--- a/src/unknown.hpp
+++ b/src/unknown.hpp
@@ -3,6 +3,7 @@
 #include "types.h"
 #include "obj/TextFile.h"
 #include "utl/Symbol.h"
+
 extern int fn_80324278;
 extern int lbl_808556A4;
 extern char lbl_808E3060;

--- a/src/unknown.hpp
+++ b/src/unknown.hpp
@@ -1,8 +1,8 @@
 #ifndef UNKNOWN_HPP
 #define UNKNOWN_HPP
 #include "types.h"
-#include "Symbol.h"
-#include "TextFile.h"
+#include "obj/TextFile.h"
+#include "utl/Symbol.h"
 extern int fn_80324278;
 extern int lbl_808556A4;
 extern char lbl_808E3060;


### PR DESCRIPTION
Just about every include should have a proper prefix now, aside from the loose files inside `src/rb3` (as there is no proper prefix to give to them yet).

The include prefixes have been done such that fixing includes after a file has been moved should be a simple find-and-replace operation. That means *every* inclusion of a file has the prefix, regardless of if files are in the same folder as each other: no exceptions.

Only `rb3` and `system` includes have been checked here; outside of the unnecessary `sdk/` prefix being removed and some overly-specific SDK includes being replaced with their stdlib equivalents, libraries are untouched. I want to do some more organization on those so we don't need to have multiple include paths for each library.