### PR TITLE
Allow specifying compile/link flags per-version

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,30 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "configure SZBE69",
+      "type": "shell",
+      "command": "python",
+      "args": [
+        "configure.py",
+        "--version",
+        "SZBE69"
+      ],
+      "problemMatcher": [],
+      "group": "none"
+    },
+    {
+      "label": "configure SZBE69_B8",
+      "type": "shell",
+      "command": "python",
+      "args": [
+        "configure.py",
+        "--version",
+        "SZBE69_B8"
+      ],
+      "problemMatcher": [],
+      "group": "none"
+    },
+    {
       "label": "ninja",
       "type": "shell",
       "command": "ninja",

--- a/cflags_common.py
+++ b/cflags_common.py
@@ -13,6 +13,3 @@ cflags_includes = [
     "-i src/system",
     "-i src/rb3",
 ]
-
-cflags_defines = [
-]

--- a/config/SZBE69/flags.json
+++ b/config/SZBE69/flags.json
@@ -1,0 +1,44 @@
+{
+    "ldflags": [
+        "-fp hardware",
+        "-nodefaults",
+        "-listclosure",
+        "-code_merging safe,aggressive"
+    ],
+    "cflags": {
+        "runtime": [
+            "-use_lmw_stmw on",
+            "-str reuse,pool,readonly",
+            "-common off",
+            "-inline auto"
+        ],
+        "base": [
+            "-nodefaults",
+            "-proc gekko",
+            "-align powerpc",
+            "-enum int",
+            "-fp hardware",
+            "-Cpp_exceptions off",
+            "-O4,s",
+            "-pragma \"cats off\"",
+            "-pragma \"warn_notinlined off\"",
+            "-maxerrors 1",
+            "-nosyspath",
+            "-fp_contract on",
+            "-str reuse,pool",
+            "-func_align 4",
+            "-gccinc",
+            "-d NDEBUG"
+        ],
+        "rb3": [
+            "-sdata 2",
+            "-sdata2 2",
+            "-pragma \"merge_float_consts on\"",
+            "-RTTI on",
+            "-inline off"
+        ],
+        "sdk": [
+            "-func_align 16"
+        ]
+    }
+}

--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -1,0 +1,41 @@
+{
+    "ldflags": [
+        "-fp hardware",
+        "-nodefaults",
+        "-listclosure"
+    ],
+    "cflags": {
+        "runtime": [
+            "-use_lmw_stmw on",
+            "-str reuse,pool,readonly",
+            "-common off",
+            "-inline auto"
+        ],
+        "base": [
+            "-nodefaults",
+            "-proc gekko",
+            "-align powerpc",
+            "-enum int",
+            "-fp hardware",
+            "-Cpp_exceptions off",
+            "-O4,p",
+            "-pragma \"cats off\"",
+            "-pragma \"warn_notinlined off\"",
+            "-maxerrors 1",
+            "-nosyspath",
+            "-fp_contract on",
+            "-str reuse,pool",
+            "-gccinc"
+        ],
+        "rb3": [
+            "-sdata 2",
+            "-sdata2 2",
+            "-pragma \"merge_float_consts on\"",
+            "-RTTI on",
+            "-inline noauto"
+        ],
+        "sdk": [
+            "-func_align 16"
+        ]
+    }
+}

--- a/decompctx.py
+++ b/decompctx.py
@@ -12,7 +12,7 @@ from pcpp.evaluator import Value
 from contextlib import redirect_stdout
 
 # Note: requires being in the same directory as cflags_common.py
-from cflags_common import cflags_includes, cflags_defines
+from cflags_common import cflags_includes
 
 #region Regex Patterns
 at_address_pattern = re.compile(r"(?:.*?)(?:[a-zA-Z_$][\w$]*\s*\*?\s[a-zA-Z_$][\w$]*)\s*((?:AT_ADDRESS|:)(?:\s*\(?\s*)(0x[0-9a-fA-F]+|[a-zA-Z_$][\w$]*)\)?);")
@@ -79,18 +79,6 @@ passthrough_defines: list[str] = [
     "_STLP_USE_NAMESPACES",
     "_STLP_NO_NAMESPACES",
 ]
-
-# Bring in defines from configure.py so we don't have to duplicate them here
-for flag in cflags_defines:
-    parts = flag.strip("-d").lstrip().split("=")
-    partCount = len(parts)
-
-    symbol = parts[0]
-    value = "1"
-    if partCount > 1:
-        value = parts[1]
-
-    default_defines[symbol] = value
 
 src_dir = "src"
 include_dir = "include"


### PR DESCRIPTION
The base retail flags should be fully restored now, aside from `cflags_c` and its derivatives.