### PR TITLE
Fix up splits paths and add script to generate TODO source files from them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ orig/*
 # or else this file will always be ignored
 !*.gitkeep
 
+# To-be-RE'd source files generated from splits.txt
+src_todo/
+
 # General-purpose ignore
 ignore/
 ignored/

--- a/doc/SZBE69_B8_splits_original.txt
+++ b/doc/SZBE69_B8_splits_original.txt
@@ -13,7 +13,7 @@ Sections:
 	.sbss2      type:bss
 	.bss        type:bss
 
-App.cpp:
+App.o:
 	.text       start:0x8000DE20 end:0x80010DF0
 	.ctors      start:0x80B34824 end:0x80B34828
 	.rodata     start:0x80B34B80 end:0x80B34BD8
@@ -21,17 +21,17 @@ App.cpp:
 	.sbss       start:0x80C79AC0 end:0x80C79AD0
 	.bss        start:0x80C7C500 end:0x80C865B0
 
-BudgetScreen.cpp:
+BudgetScreen.o:
 	.text       start:0x80010DF0 end:0x80015930
 	.rodata     start:0x80B34BD8 end:0x80B34BF0
 	.data       start:0x80B4A5D8 end:0x80B4AC90
 	.sbss       start:0x80C79AD0 end:0x80C79AD8
 	.bss        start:0x80C865B0 end:0x80C865E8
 
-Main.cpp:
+Main.o:
 	.text       start:0x80015930 end:0x80015980
 
-BandOffline.cpp:
+BandOffline.o:
 	.text       start:0x80015980 end:0x8001A140
 	.rodata     start:0x80B34BF0 end:0x80B34C08
 	.data       start:0x80B4AC90 end:0x80B4B1F8
@@ -39,461 +39,461 @@ BandOffline.cpp:
 	.sbss       start:0x80C79AD8 end:0x80C79AE0
 	.bss        start:0x80C865E8 end:0x80C86630
 
-ChecksumData_wii.cpp:
+ChecksumData_wii.o:
 	.text       start:0x8001A140 end:0x8001A150
 	.data       start:0x80B4B1F8 end:0x80B5D8F8
 
-keygen_wii.cpp:
+keygen_wii.o:
 	.text       start:0x8001A150 end:0x8001A880
 	.rodata     start:0x80B34C08 end:0x80B34D88
 	.sdata      start:0x80C788E8 end:0x80C788F0
 	.sbss       start:0x80C79AE0 end:0x80C79AE8
 
-network/Platform/BadEvents.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/BadEvents.o:
 	.text       start:0x8001A880 end:0x8001A8B0
 	.bss        start:0x80C86630 end:0x80C86638
 
-network/Platform/BandwidthCounter.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/BandwidthCounter.o:
 	.text       start:0x8001A8B0 end:0x8001B980
 	.ctors      start:0x80B34828 end:0x80B3482C
 	.data       start:0x80B5D8F8 end:0x80B5D930
 	.sdata      start:0x80C788F0 end:0x80C788F8
 	.bss        start:0x80C86638 end:0x80C86678
 
-network/Platform/CIDLogFilter.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/CIDLogFilter.o:
 	.text       start:0x8001B980 end:0x8001B980
 	.data       start:0x80B5D930 end:0x80B5D950
 
-network/Platform/CriticalSection.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/CriticalSection.o:
 	.text       start:0x8001B980 end:0x8001BA80
 
-network/Platform/DateTime.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/DateTime.o:
 	.text       start:0x8001BA80 end:0x8001BCF0
 	.ctors      start:0x80B3482C end:0x80B34830
 	.bss        start:0x80C86678 end:0x80C86688
 
-network/Platform/Event.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/Event.o:
 	.text       start:0x8001BCF0 end:0x8001BD60
 
-network/Platform/EventHandler.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/EventHandler.o:
 	.text       start:0x8001BD60 end:0x8001C800
 	.data       start:0x80B5D950 end:0x80B5D968
 	.bss        start:0x80C86688 end:0x80C86690
 
-network/Platform/EventLog.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/EventLog.o:
 	.text       start:0x8001C800 end:0x8001CC00
 	.ctors      start:0x80B34830 end:0x80B34834
 	.data       start:0x80B5D968 end:0x80B5DA28
 	.bss        start:0x80C86690 end:0x80C86808
 
-network/Platform/ExceptionHandler.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/ExceptionHandler.o:
 	.text       start:0x8001CC00 end:0x8001CC20
 
-network/Platform/HighResolutionChrono.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/HighResolutionChrono.o:
 	.text       start:0x8001CC20 end:0x8001CE40
 
-network/Platform/HighResolutionClock.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/HighResolutionClock.o:
 	.text       start:0x8001CE40 end:0x8001CF70
 
-network/Platform/LockChecker.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/LockChecker.o:
 	.text       start:0x8001CF70 end:0x8001CFD0
 
-network/Platform/Log.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/Log.o:
 	.text       start:0x8001CFD0 end:0x8001D470
 	.data       start:0x80B5DA28 end:0x80B5DA70
 
-network/Platform/LogDeviceDebugOutput.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/LogDeviceDebugOutput.o:
 	.text       start:0x8001D470 end:0x8001D4D0
 	.data       start:0x80B5DA70 end:0x80B5DAC8
 
-network/Platform/MemoryManager.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/MemoryManager.o:
 	.text       start:0x8001D4D0 end:0x8001DBF0
 	.data       start:0x80B5DAC8 end:0x80B5DB38
 	.sbss       start:0x80C79AE8 end:0x80C79AF0
 	.bss        start:0x80C86808 end:0x80C86820
 
-network/Platform/MutexPrimitive.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/MutexPrimitive.o:
 	.text       start:0x8001DBF0 end:0x8001DCE0
 	.data       start:0x80B5DB38 end:0x80B5DB50
 	.sbss       start:0x80C79AF0 end:0x80C79AF8
 
-network/Platform/ObjectThreadRoot.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/ObjectThreadRoot.o:
 	.text       start:0x8001DCE0 end:0x8001FAD0
 	.ctors      start:0x80B34834 end:0x80B34838
 	.data       start:0x80B5DB50 end:0x80B5DC70
 	.sdata      start:0x80C788F8 end:0x80C78900
 	.bss        start:0x80C86820 end:0x80C86890
 
-network/Platform/OutputFormat.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/OutputFormat.o:
 	.text       start:0x8001FAD0 end:0x80020770
 	.rodata     start:0x80B34D88 end:0x80B34DA8
 	.data       start:0x80B5DC70 end:0x80B5DD58
 	.bss        start:0x80C86890 end:0x80C868A8
 
-network/Platform/PerfCounter.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/PerfCounter.o:
 	.text       start:0x80020770 end:0x800212B0
 	.ctors      start:0x80B34838 end:0x80B3483C
 	.sbss       start:0x80C79AF8 end:0x80C79B00
 	.bss        start:0x80C868A8 end:0x80C868E8
 
-network/Platform/Platform.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/Platform.o:
 	.text       start:0x800212B0 end:0x80021430
 	.ctors      start:0x80B3483C end:0x80B34840
 	.data       start:0x80B5DD58 end:0x80B5E128
 	.bss        start:0x80C868E8 end:0x80C872D8
 
-network/Platform/ProfilingUnit.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/ProfilingUnit.o:
 	.text       start:0x80021430 end:0x80021C20
 	.ctors      start:0x80B34840 end:0x80B34844
 	.rodata     start:0x80B34DA8 end:0x80B34DC0
 	.data       start:0x80B5E128 end:0x80B5E1D8
 	.bss        start:0x80C872D8 end:0x80C87308
 
-network/Platform/RandomNumberGenerator.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/RandomNumberGenerator.o:
 	.text       start:0x80021C20 end:0x80022210
 	.rodata     start:0x80B34DC0 end:0x80B34DC8
 
-network/Platform/RefCountedObject.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/RefCountedObject.o:
 	.text       start:0x80022210 end:0x80022440
 	.ctors      start:0x80B34844 end:0x80B34848
 	.data       start:0x80B5E1D8 end:0x80B5E220
 	.bss        start:0x80C87308 end:0x80C87328
 
-network/Platform/Result.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/Result.o:
 	.text       start:0x80022440 end:0x80022530
 	.data       start:0x80B5E220 end:0x80B5E250
 
-network/Platform/RootObject.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/RootObject.o:
 	.text       start:0x80022530 end:0x80022710
 
-network/Platform/SpinTest.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/SpinTest.o:
 	.text       start:0x80022710 end:0x80022900
 	.data       start:0x80B5E250 end:0x80B5E288
 
-network/Platform/StackTracer.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/StackTracer.o:
 	.text       start:0x80022900 end:0x80022CA0
 	.ctors      start:0x80B34848 end:0x80B3484C
 	.data       start:0x80B5E288 end:0x80B5E350
 	.bss        start:0x80C87328 end:0x80C87368
 
-network/Platform/String.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/String.o:
 	.text       start:0x80022CA0 end:0x80023ED0
 	.data       start:0x80B5E350 end:0x80B5E370
 
-network/Platform/StringConversion.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/StringConversion.o:
 	.text       start:0x80023ED0 end:0x80024040
 
-network/Platform/StringConverter.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/StringConverter.o:
 	.text       start:0x80024040 end:0x80024280
 	.data       start:0x80B5E370 end:0x80B5E388
 
-network/Platform/StringStream.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/StringStream.o:
 	.text       start:0x80024280 end:0x80024CC0
 	.data       start:0x80B5E388 end:0x80B5E3D0
 
-network/Platform/SystemChecker.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/SystemChecker.o:
 	.text       start:0x80024CC0 end:0x80024CC0
 	.bss        start:0x80C87368 end:0x80C87370
 
-network/Platform/SystemClock.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/SystemClock.o:
 	.text       start:0x80024CC0 end:0x800250A0
 	.ctors      start:0x80B3484C end:0x80B34850
 	.sbss       start:0x80C79B00 end:0x80C79B08
 	.bss        start:0x80C87370 end:0x80C873A8
 
-network/Platform/SystemError.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/SystemError.o:
 	.text       start:0x800250A0 end:0x80026A20
 	.ctors      start:0x80B34850 end:0x80B34854
 	.data       start:0x80B5E3D0 end:0x80B5E4A8
 	.sdata      start:0x80C78900 end:0x80C78908
 	.bss        start:0x80C873A8 end:0x80C87448
 
-network/Platform/ThreadScrambler.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/ThreadScrambler.o:
 	.text       start:0x80026A20 end:0x80026A20
 
-network/Platform/ThreadVariable.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/ThreadVariable.o:
 	.text       start:0x80026A20 end:0x80027000
 	.data       start:0x80B5E4A8 end:0x80B5E4C0
 	.sbss       start:0x80C79B08 end:0x80C79B10
 	.bss        start:0x80C87448 end:0x80C87478
 
-network/Platform/Time.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/Time.o:
 	.text       start:0x80027000 end:0x800275A0
 	.bss        start:0x80C87478 end:0x80C87480
 
-network/Platform/TraceLog.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/TraceLog.o:
 	.text       start:0x800275A0 end:0x80027730
 	.ctors      start:0x80B34854 end:0x80B34858
 	.data       start:0x80B5E4C0 end:0x80B5E508
 	.bss        start:0x80C87480 end:0x80C874A0
 
-network/Platform/VirtualRootObject.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/VirtualRootObject.o:
 	.text       start:0x80027730 end:0x800277D0
 
-network/Platform/WaterMark.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/WaterMark.o:
 	.text       start:0x800277D0 end:0x80027D80
 	.sdata      start:0x80C78908 end:0x80C78910
 	.sbss       start:0x80C79B10 end:0x80C79B18
 	.bss        start:0x80C874A0 end:0x80C874C0
 
-network/Platform/BerkeleySocketDriver.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/BerkeleySocketDriver.o:
 	.text       start:0x80027D80 end:0x80028A10
 	.data       start:0x80B5E508 end:0x80B5E668
 
-network/Platform/Inet.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/Inet.o:
 	.text       start:0x80028A10 end:0x80028A30
 
-network/Platform/InetAddress.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/InetAddress.o:
 	.text       start:0x80028A30 end:0x80029130
 	.data       start:0x80B5E668 end:0x80B5E698
 
-network/Platform/InterfaceInfo.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/InterfaceInfo.o:
 	.text       start:0x80029130 end:0x80029230
 
-network/Platform/InterfaceTable.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/InterfaceTable.o:
 	.text       start:0x80029230 end:0x800294E0
 	.data       start:0x80B5E698 end:0x80B5E6B0
 
-network/Platform/IOCompletionContext.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/IOCompletionContext.o:
 	.text       start:0x800294E0 end:0x80029510
 
-network/Platform/IOCompletionNotifier.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/IOCompletionNotifier.o:
 	.text       start:0x80029510 end:0x80029C00
 	.data       start:0x80B5E6B0 end:0x80B5E6D0
 
-network/Platform/Socket.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/Socket.o:
 	.text       start:0x80029C00 end:0x8002A270
 	.ctors      start:0x80B34858 end:0x80B3485C
 	.data       start:0x80B5E6D0 end:0x80B5E6D8
 	.bss        start:0x80C874C0 end:0x80C874C8
 
-network/Platform/WiiNetInit.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/WiiNetInit.o:
 	.text       start:0x8002A270 end:0x8002A270
 
-network/Platform/WiiIpStack.cpp:
+lib.a/hproj/band3_wii/network/src/Platform/wii_release/WiiIpStack.o:
 	.text       start:0x8002A270 end:0x8002A400
 	.data       start:0x80B5E6D8 end:0x80B5E6F0
 
-network/Core/CacheManager.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/CacheManager.o:
 	.text       start:0x8002A400 end:0x8002A400
 
-network/Core/CallContext.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/CallContext.o:
 	.text       start:0x8002A400 end:0x8002BD60
 	.data       start:0x80B5E6F0 end:0x80B5E7F0
 
-network/Core/CallContextRegister.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/CallContextRegister.o:
 	.text       start:0x8002BD60 end:0x8002D1C0
 	.data       start:0x80B5E7F0 end:0x80B5EA68
 	.sdata      start:0x80C78910 end:0x80C78918
 
-network/Core/Core.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/Core.o:
 	.text       start:0x8002D1C0 end:0x8002D9D0
 	.ctors      start:0x80B3485C end:0x80B34860
 	.data       start:0x80B5EA68 end:0x80B5EAC8
 	.sdata      start:0x80C78918 end:0x80C78920
 	.bss        start:0x80C874C8 end:0x80C874F0
 
-network/Core/InstanceControl.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/InstanceControl.o:
 	.text       start:0x8002D9D0 end:0x8002DE00
 	.ctors      start:0x80B34860 end:0x80B34864
 	.data       start:0x80B5EAC8 end:0x80B5EB08
 	.bss        start:0x80C874F0 end:0x80C87530
 
-network/Core/InstanceTable.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/InstanceTable.o:
 	.text       start:0x8002DE00 end:0x8002DFA0
 
-network/Core/InstantiationContext.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/InstantiationContext.o:
 	.text       start:0x8002DFA0 end:0x8002E180
 
-network/Core/Job.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/Job.o:
 	.text       start:0x8002E180 end:0x8002EA70
 	.data       start:0x80B5EB08 end:0x80B5EBC0
 
-network/Core/JobQueue.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/JobQueue.o:
 	.text       start:0x8002EA70 end:0x8002EA70
 
-network/Core/MemoryStorageDevice.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/MemoryStorageDevice.o:
 	.text       start:0x8002EA70 end:0x8002EC50
 	.data       start:0x80B5EBC0 end:0x80B5EBE8
 
-network/Core/Operation.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/Operation.o:
 	.text       start:0x8002EC50 end:0x8002EDC0
 	.data       start:0x80B5EBE8 end:0x80B5EC70
 	.bss        start:0x80C87530 end:0x80C87538
 
-network/Core/OperationManager.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/OperationManager.o:
 	.text       start:0x8002EDC0 end:0x8002F4E0
 
-network/Core/PeriodicJob.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/PeriodicJob.o:
 	.text       start:0x8002F4E0 end:0x8002F560
 	.data       start:0x80B5EC70 end:0x80B5ECA0
 
-network/Core/PollForCompletionJob.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/PollForCompletionJob.o:
 	.text       start:0x8002F560 end:0x8002F570
 	.data       start:0x80B5ECA0 end:0x80B5ECE0
 
-network/Core/PseudoGlobalVariableList.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/PseudoGlobalVariableList.o:
 	.text       start:0x8002F570 end:0x8002F780
 	.data       start:0x80B5ECE0 end:0x80B5ED28
 	.bss        start:0x80C87538 end:0x80C87540
 
-network/Core/PseudoGlobalVariableRoot.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/PseudoGlobalVariableRoot.o:
 	.text       start:0x8002F780 end:0x8002F830
 	.ctors      start:0x80B34864 end:0x80B34868
 	.data       start:0x80B5ED28 end:0x80B5ED88
 	.bss        start:0x80C87540 end:0x80C87550
 
-network/Core/PseudoSingleton.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/PseudoSingleton.o:
 	.text       start:0x8002F830 end:0x8002F950
 	.data       start:0x80B5ED88 end:0x80B5EDD0
 	.sbss       start:0x80C79B18 end:0x80C79B20
 
-network/Core/Scheduler.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/Scheduler.o:
 	.text       start:0x8002F950 end:0x80032100
 	.ctors      start:0x80B34868 end:0x80B3486C
 	.data       start:0x80B5EDD0 end:0x80B5EF00
 	.sdata      start:0x80C78920 end:0x80C78928
 	.bss        start:0x80C87550 end:0x80C87570
 
-network/Core/SecurityContextManager.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/SecurityContextManager.o:
 	.text       start:0x80032100 end:0x80034A80
 	.data       start:0x80B5EF00 end:0x80B5EF70
 	.sdata      start:0x80C78928 end:0x80C78930
 
-network/Core/SingleThreadCallPolicy.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/SingleThreadCallPolicy.o:
 	.text       start:0x80034A80 end:0x80034B80
 	.data       start:0x80B5EF70 end:0x80B5EFE8
 
-network/Core/StateMachine.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/StateMachine.o:
 	.text       start:0x80034B80 end:0x80035A00
 	.data       start:0x80B5EFE8 end:0x80B5F0A8
 
-network/Core/StepSequenceJob.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/StepSequenceJob.o:
 	.text       start:0x80035A00 end:0x80035F40
 	.data       start:0x80B5F0A8 end:0x80B5F1B0
 
-network/Core/SystemComponent.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/SystemComponent.o:
 	.text       start:0x80035F40 end:0x80036C60
 	.data       start:0x80B5F1B0 end:0x80B5F3A0
 
-network/Core/SystemComponentGroup.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/SystemComponentGroup.o:
 	.text       start:0x80036C60 end:0x800376B0
 	.data       start:0x80B5F3A0 end:0x80B5F450
 
-network/Core/SystemComponents.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/SystemComponents.o:
 	.text       start:0x800376B0 end:0x80037800
 	.data       start:0x80B5F450 end:0x80B5F518
 
-network/Core/SystemSetting.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/SystemSetting.o:
 	.text       start:0x80037800 end:0x80037B60
 	.sbss       start:0x80C79B20 end:0x80C79B28
 	.bss        start:0x80C87570 end:0x80C87590
 
-network/Core/TimedSignal.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/TimedSignal.o:
 	.text       start:0x80037B60 end:0x80037E80
 	.data       start:0x80B5F518 end:0x80B5F570
 
-network/Core/WorkerThreads.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/WorkerThreads.o:
 	.text       start:0x80037E80 end:0x800385F0
 	.data       start:0x80B5F570 end:0x80B5F660
 
-network/Core/qBuffer.cpp:
+lib.a/hproj/band3_wii/network/src/Core/wii_release/qBuffer.o:
 	.text       start:0x800385F0 end:0x80039590
 	.data       start:0x80B5F660 end:0x80B5F6A8
 
-network/ddl/AdapterDeclaration.cpp:
+lib.a/hproj/band3_wii/network/src/ddl/wii_release/AdapterDeclaration.o:
 	.text       start:0x80039590 end:0x80039590
 
-network/ddl/DOClassDeclaration.cpp:
+lib.a/hproj/band3_wii/network/src/ddl/wii_release/DOClassDeclaration.o:
 	.text       start:0x80039590 end:0x80039660
 	.ctors      start:0x80B3486C end:0x80B34870
 	.bss        start:0x80C87590 end:0x80C875A8
 
-network/ddl/NameSpace.cpp:
+lib.a/hproj/band3_wii/network/src/ddl/wii_release/NameSpace.o:
 	.text       start:0x80039660 end:0x80039660
 
-network/ddl/ParseTree.cpp:
+lib.a/hproj/band3_wii/network/src/ddl/wii_release/ParseTree.o:
 	.text       start:0x80039660 end:0x80039660
 
-network/Plugins/HMACChecksum.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/HMACChecksum.o:
 	.text       start:0x80039660 end:0x800399A0
 	.data       start:0x80B5F6A8 end:0x80B5F7B8
 
-network/Plugins/ChecksumAlgorithm.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/ChecksumAlgorithm.o:
 	.text       start:0x800399A0 end:0x8003A430
 	.data       start:0x80B5F7B8 end:0x80B5F7E8
 
-network/Plugins/JobDeriveKey.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/JobDeriveKey.o:
 	.text       start:0x8003A430 end:0x8003A910
 	.data       start:0x80B5F7E8 end:0x80B5F860
 
-network/Plugins/KeyCache.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/KeyCache.o:
 	.text       start:0x8003A910 end:0x8003B990
 	.sdata      start:0x80C78930 end:0x80C78938
 
-network/Plugins/KeyedChecksumAlgorithm.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/KeyedChecksumAlgorithm.o:
 	.text       start:0x8003B990 end:0x8003BB80
 	.data       start:0x80B5F860 end:0x80B5F880
 
-network/Plugins/MD5.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/MD5.o:
 	.text       start:0x8003BB80 end:0x8003CAE0
 	.data       start:0x80B5F880 end:0x80B5F8C0
 
-network/Plugins/MD5Checksum.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/MD5Checksum.o:
 	.text       start:0x8003CAE0 end:0x8003CC20
 	.data       start:0x80B5F8C0 end:0x80B5F910
 
-network/Plugins/CompressionAlgorithm.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/CompressionAlgorithm.o:
 	.text       start:0x8003CC20 end:0x8003CF90
 	.data       start:0x80B5F910 end:0x80B5F980
 
-network/Plugins/ZLibCompression.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/ZLibCompression.o:
 	.text       start:0x8003CF90 end:0x8003D510
 	.rodata     start:0x80B34DC8 end:0x80B34DD8
 	.data       start:0x80B5F980 end:0x80B5F9F8
 
-network/Plugins/ZLibPlugin.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/ZLibPlugin.o:
 	.text       start:0x8003D510 end:0x8003D510
 
-network/Plugins/BitStream.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/BitStream.o:
 	.text       start:0x8003D510 end:0x8003DE90
 	.data       start:0x80B5F9F8 end:0x80B5FA28
 
-network/Plugins/Buffer.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/Buffer.o:
 	.text       start:0x8003DE90 end:0x8003EA50
 	.data       start:0x80B5FA28 end:0x80B5FA68
 
-network/Plugins/ByteStream.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/ByteStream.o:
 	.text       start:0x8003EA50 end:0x8003F6B0
 	.data       start:0x80B5FA68 end:0x80B5FA80
 
-network/Plugins/Key.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/Key.o:
 	.text       start:0x8003F6B0 end:0x8003FF40
 	.data       start:0x80B5FA80 end:0x80B5FAE8
 	.sdata      start:0x80C78938 end:0x80C78940
 
-network/Plugins/EncryptionAlgorithm.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/EncryptionAlgorithm.o:
 	.text       start:0x8003FF40 end:0x80040240
 	.data       start:0x80B5FAE8 end:0x80B5FB60
 
-network/Plugins/RC4Encryption.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/RC4Encryption.o:
 	.text       start:0x80040240 end:0x800409E0
 	.data       start:0x80B5FB60 end:0x80B5FBD8
 
-network/Plugins/SessionDescription.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/SessionDescription.o:
 	.text       start:0x800409E0 end:0x80042050
 	.data       start:0x80B5FBD8 end:0x80B5FBE0
 	.sdata      start:0x80C78940 end:0x80C78948
 
-network/Plugins/SessionDiscoveryProtocol.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/SessionDiscoveryProtocol.o:
 	.text       start:0x80042050 end:0x800420F0
 	.data       start:0x80B5FBE0 end:0x80B5FC50
 
-network/Plugins/SessionDiscoveryTable.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/SessionDiscoveryTable.o:
 	.text       start:0x800420F0 end:0x80042D90
 	.data       start:0x80B5FC50 end:0x80B5FC70
 
-network/Plugins/LANSessionDiscovery.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/LANSessionDiscovery.o:
 	.text       start:0x80042D90 end:0x80043E50
 	.ctors      start:0x80B34870 end:0x80B34874
 	.data       start:0x80B5FC70 end:0x80B5FD98
@@ -501,81 +501,81 @@ network/Plugins/LANSessionDiscovery.cpp:
 	.sbss       start:0x80C79B28 end:0x80C79B30
 	.bss        start:0x80C875A8 end:0x80C875B8
 
-network/Plugins/ConnectionManager.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/ConnectionManager.o:
 	.text       start:0x80043E50 end:0x80044D30
 	.data       start:0x80B5FD98 end:0x80B5FEF0
 	.sdata      start:0x80C78950 end:0x80C78958
 
-network/Plugins/ConnectionOrientedStream.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/ConnectionOrientedStream.o:
 	.text       start:0x80044D30 end:0x80045020
 	.data       start:0x80B5FEF0 end:0x80B5FFD0
 
-network/Plugins/ConnectivityManager.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/ConnectivityManager.o:
 	.text       start:0x80045020 end:0x800454A0
 
-network/Plugins/EmulationDevice.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/EmulationDevice.o:
 	.text       start:0x800454A0 end:0x800455B0
 	.data       start:0x80B5FFD0 end:0x80B60010
 
-network/Plugins/EndPoint.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/EndPoint.o:
 	.text       start:0x800455B0 end:0x800458F0
 	.data       start:0x80B60010 end:0x80B600B0
 
-network/Plugins/HighLevelStream.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/HighLevelStream.o:
 	.text       start:0x800458F0 end:0x80045C80
 	.data       start:0x80B600B0 end:0x80B60120
 
-network/Plugins/JobConnectEndPoint.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/JobConnectEndPoint.o:
 	.text       start:0x80045C80 end:0x80047BB0
 	.data       start:0x80B60120 end:0x80B606C0
 	.sdata      start:0x80C78958 end:0x80C78960
 	.sbss       start:0x80C79B30 end:0x80C79B38
 
-network/Plugins/JobGetPublicURL.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/JobGetPublicURL.o:
 	.text       start:0x80047BB0 end:0x80047BB0
 
-network/Plugins/Message.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/Message.o:
 	.text       start:0x80047BB0 end:0x800483F0
 	.data       start:0x80B606C0 end:0x80B606C8
 
-network/Plugins/NATRelayInterface.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/NATRelayInterface.o:
 	.text       start:0x800483F0 end:0x80048480
 	.data       start:0x80B606C8 end:0x80B60710
 
-network/Plugins/NATTraversalEngine.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/NATTraversalEngine.o:
 	.text       start:0x80048480 end:0x80049E60
 	.data       start:0x80B60710 end:0x80B607B8
 
-network/Plugins/NATTraversalStream.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/NATTraversalStream.o:
 	.text       start:0x80049E60 end:0x8004A050
 	.data       start:0x80B607B8 end:0x80B60818
 
-network/Plugins/Network.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/Network.o:
 	.text       start:0x8004A050 end:0x8004AC60
 	.ctors      start:0x80B34874 end:0x80B34878
 	.data       start:0x80B60818 end:0x80B60878
 	.sdata      start:0x80C78960 end:0x80C78968
 	.bss        start:0x80C875B8 end:0x80C875D8
 
-network/Plugins/RootTransport.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/RootTransport.o:
 	.text       start:0x8004AC60 end:0x8004B540
 	.ctors      start:0x80B34878 end:0x80B3487C
 	.data       start:0x80B60878 end:0x80B60A20
 	.sdata      start:0x80C78968 end:0x80C78970
 	.bss        start:0x80C875D8 end:0x80C87600
 
-network/Plugins/StationContactInfo.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/StationContactInfo.o:
 	.text       start:0x8004B540 end:0x8004BC20
 
-network/Plugins/StationProbe.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/StationProbe.o:
 	.text       start:0x8004BC20 end:0x8004C010
 
-network/Plugins/StationProbeList.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/StationProbeList.o:
 	.text       start:0x8004C010 end:0x8004D540
 	.data       start:0x80B60A20 end:0x80B60A78
 	.sdata      start:0x80C78970 end:0x80C78978
 
-network/Plugins/StationURL.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/StationURL.o:
 	.text       start:0x8004D540 end:0x800527E0
 	.ctors      start:0x80B3487C end:0x80B34880
 	.rodata     start:0x80B34DD8 end:0x80B34DE8
@@ -583,741 +583,741 @@ network/Plugins/StationURL.cpp:
 	.sdata      start:0x80C78978 end:0x80C78980
 	.bss        start:0x80C87600 end:0x80C87670
 
-network/Plugins/Stream.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/Stream.o:
 	.text       start:0x800527E0 end:0x80052E60
 	.ctors      start:0x80B34880 end:0x80B34884
 	.data       start:0x80B60B28 end:0x80B60BD0
 	.bss        start:0x80C87670 end:0x80C88180
 
-network/Plugins/StreamBundling.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/StreamBundling.o:
 	.text       start:0x80052E60 end:0x80053390
 	.data       start:0x80B60BD0 end:0x80B60C08
 
-network/Plugins/StreamSettings.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/StreamSettings.o:
 	.text       start:0x80053390 end:0x800535C0
 	.rodata     start:0x80B34DE8 end:0x80B34DF0
 	.data       start:0x80B60C08 end:0x80B60C10
 
-network/Plugins/StreamTable.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/StreamTable.o:
 	.text       start:0x800535C0 end:0x800537A0
 	.data       start:0x80B60C10 end:0x80B60C48
 
-network/Plugins/TransportAdapter.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/TransportAdapter.o:
 	.text       start:0x800537A0 end:0x80053DE0
 	.data       start:0x80B60C48 end:0x80B60CB0
 
-network/Plugins/TransportEventHandler.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/TransportEventHandler.o:
 	.text       start:0x80053DE0 end:0x80053E70
 	.data       start:0x80B60CB0 end:0x80B60CD0
 
-network/Plugins/TransportPerfCounters.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/TransportPerfCounters.o:
 	.text       start:0x80053E70 end:0x800540F0
 	.data       start:0x80B60CD0 end:0x80B60DC0
 
-network/Plugins/TransportSignatureGenerator.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/TransportSignatureGenerator.o:
 	.text       start:0x800540F0 end:0x800543C0
 	.data       start:0x80B60DC0 end:0x80B60DE0
 
-network/Plugins/TransportStreamManager.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/TransportStreamManager.o:
 	.text       start:0x800543C0 end:0x80055EB0
 	.data       start:0x80B60DE0 end:0x80B60E20
 
-network/Plugins/URLProbe.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/URLProbe.o:
 	.text       start:0x80055EB0 end:0x800560C0
 
-network/Plugins/URLProbeList.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/URLProbeList.o:
 	.text       start:0x800560C0 end:0x80056410
 	.data       start:0x80B60E20 end:0x80B60EA0
 
-network/Plugins/PacketDispatchQueue.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/PacketDispatchQueue.o:
 	.text       start:0x80056410 end:0x80057730
 	.ctors      start:0x80B34884 end:0x80B34888
 	.data       start:0x80B60EA0 end:0x80B60EB8
 	.sdata      start:0x80C78980 end:0x80C78988
 	.bss        start:0x80C88180 end:0x80C881C0
 
-network/Plugins/PRUDPEndPoint.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/PRUDPEndPoint.o:
 	.text       start:0x80057730 end:0x8005A130
 	.data       start:0x80B60EB8 end:0x80B61028
 
-network/Plugins/PRUDPStream.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/PRUDPStream.o:
 	.text       start:0x8005A130 end:0x8005DED0
 	.data       start:0x80B61028 end:0x80B61300
 	.sdata      start:0x80C78988 end:0x80C78990
 	.sbss       start:0x80C79B38 end:0x80C79B40
 
-network/Plugins/RTT.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/RTT.o:
 	.text       start:0x8005DED0 end:0x8005DF70
 
-network/Plugins/SlidingWindow.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/SlidingWindow.o:
 	.text       start:0x8005DF70 end:0x80061EC0
 	.ctors      start:0x80B34888 end:0x80B3488C
 	.data       start:0x80B61300 end:0x80B61460
 	.sdata      start:0x80C78990 end:0x80C78998
 	.bss        start:0x80C881C0 end:0x80C88288
 
-network/Plugins/TimeoutManager.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/TimeoutManager.o:
 	.text       start:0x80061EC0 end:0x80063180
 	.data       start:0x80B61460 end:0x80B61478
 	.sdata      start:0x80C78998 end:0x80C789A0
 
-network/Plugins/Router.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/Router.o:
 	.text       start:0x80063180 end:0x800640A0
 	.data       start:0x80B61478 end:0x80B61488
 	.sbss       start:0x80C79B40 end:0x80C79B48
 	.bss        start:0x80C88288 end:0x80C88318
 
-network/Plugins/RoutingAddressResolver.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/RoutingAddressResolver.o:
 	.text       start:0x800640A0 end:0x80065140
 	.sdata      start:0x80C789A0 end:0x80C789A8
 
-network/Plugins/RoutingStream.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/RoutingStream.o:
 	.text       start:0x80065140 end:0x800656A0
 	.data       start:0x80B61488 end:0x80B614E8
 
-network/Plugins/RoutingTable.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/RoutingTable.o:
 	.text       start:0x800656A0 end:0x80065E20
 	.sdata      start:0x80C789A8 end:0x80C789B0
 
-network/Plugins/UDPNetworkEmulator.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/UDPNetworkEmulator.o:
 	.text       start:0x80065E20 end:0x80066E00
 	.data       start:0x80B614E8 end:0x80B61650
 
-network/Plugins/Packet.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/Packet.o:
 	.text       start:0x80066E00 end:0x800672B0
 	.ctors      start:0x80B3488C end:0x80B34890
 	.data       start:0x80B61650 end:0x80B61760
 	.bss        start:0x80C88318 end:0x80C88358
 
-network/Plugins/PacketIn.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/PacketIn.o:
 	.text       start:0x800672B0 end:0x80067750
 	.data       start:0x80B61760 end:0x80B617C0
 
-network/Plugins/PacketOut.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/PacketOut.o:
 	.text       start:0x80067750 end:0x80067E90
 	.data       start:0x80B617C0 end:0x80B61820
 	.sdata      start:0x80C789B0 end:0x80C789B8
 
-network/Plugins/PacketQueue.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/PacketQueue.o:
 	.text       start:0x80067E90 end:0x800682D0
 
-network/Plugins/QueuingSocket.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/QueuingSocket.o:
 	.text       start:0x800682D0 end:0x800693E0
 	.data       start:0x80B61820 end:0x80B61838
 	.sdata      start:0x80C789B8 end:0x80C789C0
 
-network/Plugins/Timeout.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/Timeout.o:
 	.text       start:0x800693E0 end:0x800696A0
 
-network/Plugins/UDPTransport.cpp:
+lib.a/hproj/band3_wii/network/src/Plugins/wii_release/UDPTransport.o:
 	.text       start:0x800696A0 end:0x8006C7B0
 	.data       start:0x80B61838 end:0x80B61B50
 
-network/Protocol/CallProtocolMethodOperation.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/CallProtocolMethodOperation.o:
 	.text       start:0x8006C7B0 end:0x8006C900
 	.data       start:0x80B61B50 end:0x80B61BD8
 
-network/Protocol/ClientProtocol.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/ClientProtocol.o:
 	.text       start:0x8006C900 end:0x8006CE40
 	.data       start:0x80B61BD8 end:0x80B61BE8
 	.sdata      start:0x80C789C0 end:0x80C789C8
 
-network/Protocol/DynamicProtocol.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/DynamicProtocol.o:
 	.text       start:0x8006CE40 end:0x8006CF60
 	.data       start:0x80B61BE8 end:0x80B61C88
 
-network/Protocol/JobProcessProtocolEvent.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/JobProcessProtocolEvent.o:
 	.text       start:0x8006CF60 end:0x8006D060
 	.data       start:0x80B61C88 end:0x80B61D08
 
-network/Protocol/JobProcessProtocolMessage.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/JobProcessProtocolMessage.o:
 	.text       start:0x8006D060 end:0x8006D250
 	.ctors      start:0x80B34890 end:0x80B34894
 	.data       start:0x80B61D08 end:0x80B61DC8
 	.bss        start:0x80C88358 end:0x80C88398
 
-network/Protocol/LogToClientController.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/LogToClientController.o:
 	.text       start:0x8006D250 end:0x8006D4C0
 	.bss        start:0x80C88398 end:0x80C883A0
 
-network/Protocol/Protocol.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/Protocol.o:
 	.text       start:0x8006D4C0 end:0x8006DB30
 	.data       start:0x80B61DC8 end:0x80B61E40
 	.sdata      start:0x80C789C8 end:0x80C789D0
 
-network/Protocol/ProtocolCallContext.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/ProtocolCallContext.o:
 	.text       start:0x8006DB30 end:0x8006E280
 	.data       start:0x80B61E40 end:0x80B61EE0
 
-network/Protocol/ProtocolRequestBroker.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/ProtocolRequestBroker.o:
 	.text       start:0x8006E280 end:0x80070870
 	.data       start:0x80B61EE0 end:0x80B61FE0
 	.sdata      start:0x80C789D0 end:0x80C789D8
 	.sbss       start:0x80C79B48 end:0x80C79B50
 
-network/Protocol/ServerProtocol.cpp:
+lib.a/hproj/band3_wii/network/src/Protocol/wii_release/ServerProtocol.o:
 	.text       start:0x80070870 end:0x80070EF0
 	.ctors      start:0x80B34894 end:0x80B34898
 	.data       start:0x80B61FE0 end:0x80B620E0
 	.bss        start:0x80C883A0 end:0x80C88560
 
-network/ObjDup/ActiveDOCallContext.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/ActiveDOCallContext.o:
 	.text       start:0x80070EF0 end:0x800720B0
 	.data       start:0x80B620E0 end:0x80B62268
 
-network/ObjDup/AddToStoreOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/AddToStoreOperation.o:
 	.text       start:0x800720B0 end:0x80072200
 	.data       start:0x80B62268 end:0x80B62328
 
-network/ObjDup/Authentication.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/Authentication.o:
 	.text       start:0x80072200 end:0x80072670
 	.data       start:0x80B62328 end:0x80B62358
 	.sdata      start:0x80C789D8 end:0x80C789E0
 
-network/ObjDup/BundlingPolicy.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/BundlingPolicy.o:
 	.text       start:0x80072670 end:0x800729B0
 
-network/ObjDup/CallMethodOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/CallMethodOperation.o:
 	.text       start:0x800729B0 end:0x800730D0
 	.data       start:0x80B62358 end:0x80B624C8
 	.sdata      start:0x80C789E0 end:0x80C789E8
 
-network/ObjDup/CallRegister.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/CallRegister.o:
 	.text       start:0x800730D0 end:0x80076220
 	.data       start:0x80B624C8 end:0x80B62720
 	.sdata      start:0x80C789E8 end:0x80C789F0
 
-network/ObjDup/ChangeDupSetOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/ChangeDupSetOperation.o:
 	.text       start:0x80076220 end:0x80076490
 	.data       start:0x80B62720 end:0x80B627D0
 
-network/ObjDup/ChangeMasterStationOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/ChangeMasterStationOperation.o:
 	.text       start:0x80076490 end:0x80076750
 	.data       start:0x80B627D0 end:0x80B62890
 
-network/ObjDup/ConnectionInfo.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/ConnectionInfo.o:
 	.text       start:0x80076750 end:0x80076C90
 	.data       start:0x80B62890 end:0x80B62898
 
-network/ObjDup/ConnectionInfoDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/ConnectionInfoDDL.o:
 	.text       start:0x80076C90 end:0x80077020
 	.data       start:0x80B62898 end:0x80B62958
 	.sdata      start:0x80C789F0 end:0x80C789F8
 
-network/ObjDup/CreateMasterOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/CreateMasterOperation.o:
 	.text       start:0x80077020 end:0x80077190
 	.data       start:0x80B62958 end:0x80B629E8
 
-network/ObjDup/DDLDeclarations.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DDLDeclarations.o:
 	.text       start:0x80077190 end:0x80077300
 	.data       start:0x80B629E8 end:0x80B62A30
 	.bss        start:0x80C88560 end:0x80C88568
 
-network/ObjDup/DOCallContext.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOCallContext.o:
 	.text       start:0x80077300 end:0x800780B0
 	.data       start:0x80B62A30 end:0x80B62BC8
 
-network/ObjDup/DOClass.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOClass.o:
 	.text       start:0x800780B0 end:0x80079630
 	.data       start:0x80B62BC8 end:0x80B62CC8
 	.sdata      start:0x80C789F8 end:0x80C78A00
 
-network/ObjDup/DOClassesTable.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOClassesTable.o:
 	.text       start:0x80079630 end:0x80079A90
 	.data       start:0x80B62CC8 end:0x80B62CE0
 	.bss        start:0x80C88568 end:0x80C88570
 
-network/ObjDup/DOCore.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOCore.o:
 	.text       start:0x80079A90 end:0x8007A800
 	.ctors      start:0x80B34898 end:0x80B3489C
 	.data       start:0x80B62CE0 end:0x80B63108
 	.bss        start:0x80C88570 end:0x80C88588
 
-network/ObjDup/DOCoreDDF.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOCoreDDF.o:
 	.text       start:0x8007A800 end:0x8007A9C0
 	.ctors      start:0x80B3489C end:0x80B348A0
 	.data       start:0x80B63108 end:0x80B63158
 	.bss        start:0x80C88588 end:0x80C885D8
 
-network/ObjDup/DOCoreTypes.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOCoreTypes.o:
 	.text       start:0x8007A9C0 end:0x8007B150
 	.data       start:0x80B63158 end:0x80B63178
 
-network/ObjDup/DOFilter.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOFilter.o:
 	.text       start:0x8007B150 end:0x8007B210
 	.data       start:0x80B63178 end:0x80B631D0
 
-network/ObjDup/DOFilters.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOFilters.o:
 	.text       start:0x8007B210 end:0x8007C6A0
 	.data       start:0x80B631D0 end:0x80B63550
 
-network/ObjDup/DOHandle.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOHandle.o:
 	.text       start:0x8007C6A0 end:0x8007CB50
 	.data       start:0x80B63550 end:0x80B63568
 
-network/ObjDup/DOOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOOperation.o:
 	.text       start:0x8007CB50 end:0x8007CD60
 	.data       start:0x80B63568 end:0x80B63598
 
-network/ObjDup/DOProtocol.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOProtocol.o:
 	.text       start:0x8007CD60 end:0x8007CE10
 
-network/ObjDup/DOProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOProtocolDDL.o:
 	.text       start:0x8007CE10 end:0x8007DB10
 	.data       start:0x80B63598 end:0x80B63650
 
-network/ObjDup/DOProtocolServer.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOProtocolServer.o:
 	.text       start:0x8007DB10 end:0x8007E790
 	.data       start:0x80B63650 end:0x80B63718
 
-network/ObjDup/DORef.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DORef.o:
 	.text       start:0x8007E790 end:0x80080BD0
 
-network/ObjDup/DOSelections.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOSelections.o:
 	.text       start:0x80080BD0 end:0x800815A0
 	.data       start:0x80B63718 end:0x80B63738
 
-network/ObjDup/DOSubset.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DOSubset.o:
 	.text       start:0x800815A0 end:0x80081D70
 	.data       start:0x80B63738 end:0x80B637D0
 
-network/ObjDup/DataSet.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DataSet.o:
 	.text       start:0x80081D70 end:0x80081DD0
 
-network/ObjDup/DistanceComputationCache.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DistanceComputationCache.o:
 	.text       start:0x80081DD0 end:0x80081E60
 	.ctors      start:0x80B348A0 end:0x80B348A4
 	.rodata     start:0x80B34DF0 end:0x80B34DF8
 	.bss        start:0x80C885D8 end:0x80C885E0
 
-network/ObjDup/DuplicatedObject.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DuplicatedObject.o:
 	.text       start:0x80081E60 end:0x80089E50
 	.ctors      start:0x80B348A4 end:0x80B348A8
 	.data       start:0x80B637D0 end:0x80B63AC8
 	.bss        start:0x80C885E0 end:0x80C88B78
 
-network/ObjDup/DynamicRunTimeInterface.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/DynamicRunTimeInterface.o:
 	.text       start:0x80089E50 end:0x8008A0E0
 	.ctors      start:0x80B348A8 end:0x80B348AC
 	.data       start:0x80B63AC8 end:0x80B63B60
 	.bss        start:0x80C88B78 end:0x80C88B98
 
-network/ObjDup/ElectionTable.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/ElectionTable.o:
 	.text       start:0x8008A0E0 end:0x8008B460
 	.sdata      start:0x80C78A00 end:0x80C78A08
 
-network/ObjDup/FaultProcessingContext.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/FaultProcessingContext.o:
 	.text       start:0x8008B460 end:0x8008BEF0
 	.data       start:0x80B63B60 end:0x80B63BA0
 
-network/ObjDup/FaultRecoveryOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/FaultRecoveryOperation.o:
 	.text       start:0x8008BEF0 end:0x8008C050
 	.data       start:0x80B63BA0 end:0x80B63C30
 
-network/ObjDup/FetchContext.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/FetchContext.o:
 	.text       start:0x8008C050 end:0x8008C740
 	.data       start:0x80B63C30 end:0x80B63CB8
 
-network/ObjDup/IDGenerator.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/IDGenerator.o:
 	.text       start:0x8008C740 end:0x8008D2F0
 	.rodata     start:0x80B34DF8 end:0x80B34E00
 	.data       start:0x80B63CB8 end:0x80B63E28
 
-network/Extensions/ErrorToleranceFunction.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/ErrorToleranceFunction.o:
 	.rodata     start:0x80B34E00 end:0x80B34E08
 
-network/Extensions/PHBDRParameters.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/PHBDRParameters.o:
 	.rodata     start:0x80B34E08 end:0x80B34E18
 
-network/ObjDup/IDGeneratorDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/IDGeneratorDDL.o:
 	.text       start:0x8008D2F0 end:0x8008E0A0
 	.data       start:0x80B63E28 end:0x80B64130
 	.bss        start:0x80C88B98 end:0x80C88BA0
 
-network/ObjDup/IteratorOverDOs.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/IteratorOverDOs.o:
 	.text       start:0x8008E0A0 end:0x8008EE70
 
-network/ObjDup/JobChangeConnection.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobChangeConnection.o:
 	.text       start:0x8008EE70 end:0x8008EFD0
 	.data       start:0x80B64130 end:0x80B641B8
 
-network/ObjDup/JobConnectStation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobConnectStation.o:
 	.text       start:0x8008EFD0 end:0x80092490
 	.data       start:0x80B641B8 end:0x80B64940
 	.sdata      start:0x80C78A08 end:0x80C78A10
 	.sbss       start:0x80C79B50 end:0x80C79B58
 
-network/ObjDup/JobDisconnectStation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobDisconnectStation.o:
 	.text       start:0x80092490 end:0x800932C0
 	.data       start:0x80B64940 end:0x80B64BF8
 	.sdata      start:0x80C78A10 end:0x80C78A18
 
-network/ObjDup/JobExecuteDelayedOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobExecuteDelayedOperation.o:
 	.text       start:0x800932C0 end:0x80093430
 	.data       start:0x80B64BF8 end:0x80B64C78
 
-network/ObjDup/JobJoinSession.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobJoinSession.o:
 	.text       start:0x80093430 end:0x80095960
 	.data       start:0x80B64C78 end:0x80B652A0
 	.sdata      start:0x80C78A18 end:0x80C78A20
 
-network/ObjDup/JobListenOnWellKnown.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobListenOnWellKnown.o:
 	.text       start:0x80095960 end:0x80095C30
 	.data       start:0x80B652A0 end:0x80B65338
 
-network/ObjDup/JobProcessFault.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobProcessFault.o:
 	.text       start:0x80095C30 end:0x80097480
 	.data       start:0x80B65338 end:0x80B653C0
 	.sbss       start:0x80C79B58 end:0x80C79B60
 
-network/ObjDup/JobProcessJoinRequest.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobProcessJoinRequest.o:
 	.text       start:0x80097480 end:0x8009A270
 	.data       start:0x80B653C0 end:0x80B65A38
 	.sdata      start:0x80C78A20 end:0x80C78A28
 
-network/ObjDup/JobProcessMessage.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobProcessMessage.o:
 	.text       start:0x8009A270 end:0x8009A430
 	.ctors      start:0x80B348AC end:0x80B348B0
 	.data       start:0x80B65A38 end:0x80B65AD0
 	.bss        start:0x80C88BA0 end:0x80C88BE0
 
-network/ObjDup/JobTerminateDOCore.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JobTerminateDOCore.o:
 	.text       start:0x8009A430 end:0x8009C920
 	.data       start:0x80B65AD0 end:0x80B65E80
 
-network/ObjDup/JoinSessionOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/JoinSessionOperation.o:
 	.text       start:0x8009C920 end:0x8009CB50
 	.data       start:0x80B65E80 end:0x80B65F48
 
-network/ObjDup/LeaveSessionOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/LeaveSessionOperation.o:
 	.text       start:0x8009CB50 end:0x8009CD50
 	.data       start:0x80B65F48 end:0x80B65FC8
 
-network/ObjDup/MasterStationRef.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/MasterStationRef.o:
 	.text       start:0x8009CD50 end:0x8009CF20
 
-network/ObjDup/MessageBundle.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/MessageBundle.o:
 	.text       start:0x8009CF20 end:0x8009D420
 	.data       start:0x80B65FC8 end:0x80B65FD0
 
-network/ObjDup/MethodIDGenerator.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/MethodIDGenerator.o:
 	.text       start:0x8009D420 end:0x8009E2E0
 	.ctors      start:0x80B348B0 end:0x80B348B4
 	.sdata      start:0x80C78A28 end:0x80C78A30
 	.bss        start:0x80C88BE0 end:0x80C88C30
 
-network/ObjDup/MigrationContext.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/MigrationContext.o:
 	.text       start:0x8009E2E0 end:0x8009EC80
 	.data       start:0x80B65FD0 end:0x80B66170
 
-network/ObjDup/MulticastInterface.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/MulticastInterface.o:
 	.text       start:0x8009EC80 end:0x8009EF10
 	.ctors      start:0x80B348B4 end:0x80B348B8
 	.data       start:0x80B66170 end:0x80B66200
 	.bss        start:0x80C88C30 end:0x80C88C50
 
-network/ObjDup/ObjDupProtocol.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/ObjDupProtocol.o:
 	.text       start:0x8009EF10 end:0x800A38F0
 	.data       start:0x80B66200 end:0x80B665D0
 	.sdata      start:0x80C78A30 end:0x80C78A38
 
-network/ObjDup/ParticipationManager.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/ParticipationManager.o:
 	.text       start:0x800A38F0 end:0x800A40C0
 	.data       start:0x80B665D0 end:0x80B66630
 
-network/ObjDup/PromotionReferee.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/PromotionReferee.o:
 	.text       start:0x800A40C0 end:0x800A50F0
 	.data       start:0x80B66630 end:0x80B66750
 	.bss        start:0x80C88C50 end:0x80C88C58
 
-network/ObjDup/PromotionRefereeDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/PromotionRefereeDDL.o:
 	.text       start:0x800A50F0 end:0x800A5DE0
 	.data       start:0x80B66750 end:0x80B66BF0
 	.bss        start:0x80C88C58 end:0x80C88C60
 
-network/ObjDup/RMCContext.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/RMCContext.o:
 	.text       start:0x800A5DE0 end:0x800A6670
 	.data       start:0x80B66BF0 end:0x80B66CC0
 
-network/ObjDup/Range.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/Range.o:
 	.text       start:0x800A6670 end:0x800A6700
 
-network/ObjDup/RangeDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/RangeDDL.o:
 	.text       start:0x800A6700 end:0x800A6830
 	.data       start:0x80B66CC0 end:0x80B66CD8
 
-network/ObjDup/RemoveFromStoreOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/RemoveFromStoreOperation.o:
 	.text       start:0x800A6830 end:0x800A6960
 	.data       start:0x80B66CD8 end:0x80B66D68
 
-network/ObjDup/RootDO.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/RootDO.o:
 	.text       start:0x800A6960 end:0x800A6D20
 	.data       start:0x80B66D68 end:0x80B66DB8
 
-network/ObjDup/RootDODDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/RootDODDL.o:
 	.text       start:0x800A6D20 end:0x800A7580
 	.data       start:0x80B66DB8 end:0x80B66EC8
 	.bss        start:0x80C88C60 end:0x80C88C68
 
-network/ObjDup/SafetyExecutive.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SafetyExecutive.o:
 	.text       start:0x800A7580 end:0x800A7750
 
-network/ObjDup/Selection.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/Selection.o:
 	.text       start:0x800A7750 end:0x800A8DA0
 	.data       start:0x80B66EC8 end:0x80B66F00
 	.sdata      start:0x80C78A38 end:0x80C78A40
 
-network/ObjDup/Session.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/Session.o:
 	.text       start:0x800A8DA0 end:0x800AD640
 	.ctors      start:0x80B348B8 end:0x80B348BC
 	.data       start:0x80B66F00 end:0x80B670F0
 	.sbss       start:0x80C79B60 end:0x80C79B68
 	.bss        start:0x80C88C68 end:0x80C88CB0
 
-network/ObjDup/SessionDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SessionDDL.o:
 	.text       start:0x800AD640 end:0x800AF5D0
 	.data       start:0x80B670F0 end:0x80B67528
 	.bss        start:0x80C88CB0 end:0x80C88CB8
 
-network/ObjDup/SessionInfo.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SessionInfo.o:
 	.text       start:0x800AF5D0 end:0x800AF770
 
-network/ObjDup/SessionInfoDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SessionInfoDDL.o:
 	.text       start:0x800AF770 end:0x800AF8D0
 	.data       start:0x80B67528 end:0x80B67558
 
-network/ObjDup/SessionOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SessionOperation.o:
 	.text       start:0x800AF8D0 end:0x800AF9D0
 	.data       start:0x80B67558 end:0x80B67578
 
-network/ObjDup/SessionState.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SessionState.o:
 	.text       start:0x800AF9D0 end:0x800AFC60
 	.ctors      start:0x80B348BC end:0x80B348C0
 	.data       start:0x80B67578 end:0x80B67580
 	.bss        start:0x80C88CB8 end:0x80C88CD8
 
-network/ObjDup/SessionStateDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SessionStateDDL.o:
 	.text       start:0x800AFC60 end:0x800AFD10
 	.data       start:0x80B67580 end:0x80B67598
 
-network/ObjDup/SharedSessionDescription.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SharedSessionDescription.o:
 	.text       start:0x800AFD10 end:0x800AFF10
 
-network/ObjDup/SharedSessionDescriptionDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/SharedSessionDescriptionDDL.o:
 	.text       start:0x800AFF10 end:0x800AFFA0
 
-network/ObjDup/Station.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/Station.o:
 	.text       start:0x800AFFA0 end:0x800B2DB0
 	.ctors      start:0x80B348C0 end:0x80B348C4
 	.data       start:0x80B67598 end:0x80B67738
 	.sdata      start:0x80C78A40 end:0x80C78A48
 	.bss        start:0x80C88CD8 end:0x80C88CF8
 
-network/ObjDup/StationConnectionManager.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/StationConnectionManager.o:
 	.text       start:0x800B2DB0 end:0x800B3670
 	.data       start:0x80B67738 end:0x80B677A0
 	.sdata      start:0x80C78A48 end:0x80C78A50
 	.bss        start:0x80C88CF8 end:0x80C88D00
 
-network/ObjDup/StationDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/StationDDL.o:
 	.text       start:0x800B3670 end:0x800B51C0
 	.data       start:0x80B677A0 end:0x80B67C10
 	.bss        start:0x80C88D00 end:0x80C88D08
 
-network/ObjDup/StationIdentificationDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/StationIdentificationDDL.o:
 	.text       start:0x800B51C0 end:0x800B53A0
 	.data       start:0x80B67C10 end:0x80B67C60
 
-network/ObjDup/StationInfo.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/StationInfo.o:
 	.text       start:0x800B53A0 end:0x800B55B0
 
-network/ObjDup/StationInfoDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/StationInfoDDL.o:
 	.text       start:0x800B55B0 end:0x800B5700
 	.data       start:0x80B67C60 end:0x80B67C80
 
-network/ObjDup/StationManager.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/StationManager.o:
 	.text       start:0x800B5700 end:0x800B8E70
 	.data       start:0x80B67C80 end:0x80B67D48
 	.sdata      start:0x80C78A50 end:0x80C78A58
 
-network/ObjDup/StationState.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/StationState.o:
 	.text       start:0x800B8E70 end:0x800B9110
 
-network/ObjDup/StationStateDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/StationStateDDL.o:
 	.text       start:0x800B9110 end:0x800B91C0
 	.data       start:0x80B67D48 end:0x80B67D58
 
-network/ObjDup/UpdateContextMap.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/UpdateContextMap.o:
 	.text       start:0x800B91C0 end:0x800B9490
 
-network/ObjDup/UpdateDataSetOperation.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/UpdateDataSetOperation.o:
 	.text       start:0x800B9490 end:0x800B9640
 	.data       start:0x80B67D58 end:0x80B67DE8
 
-network/ObjDup/UpdatePolicy.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/UpdatePolicy.o:
 	.text       start:0x800B9640 end:0x800B9F10
 
-network/ObjDup/UserDefinedState.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/UserDefinedState.o:
 	.text       start:0x800B9F10 end:0x800B9F50
 
-network/ObjDup/UserDefinedStateDDL.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/UserDefinedStateDDL.o:
 	.text       start:0x800B9F50 end:0x800BA000
 	.data       start:0x80B67DE8 end:0x80B67E00
 
-network/ObjDup/WKHandle.cpp:
+lib.a/hproj/band3_wii/network/src/ObjDup/wii_release/WKHandle.o:
 	.text       start:0x800BA000 end:0x800BA2F0
 	.data       start:0x80B67E00 end:0x80B67E08
 	.bss        start:0x80C88D08 end:0x80C88D10
 
-network/Utility/Chrono.cpp:
+lib.a/hproj/band3_wii/network/src/Utility/wii_release/Chrono.o:
 	.text       start:0x800BA2F0 end:0x800BA540
 	.data       start:0x80B67E08 end:0x80B67E38
 
-network/Utility/LocalClock.cpp:
+lib.a/hproj/band3_wii/network/src/Utility/wii_release/LocalClock.o:
 	.text       start:0x800BA540 end:0x800BA7A0
 	.data       start:0x80B67E38 end:0x80B67E48
 	.bss        start:0x80C88D10 end:0x80C88D18
 
-network/Utility/Statistics.cpp:
+lib.a/hproj/band3_wii/network/src/Utility/wii_release/Statistics.o:
 	.text       start:0x800BA7A0 end:0x800BA820
 
-network/Utility/UtilitySubsystem.cpp:
+lib.a/hproj/band3_wii/network/src/Utility/wii_release/UtilitySubsystem.o:
 	.text       start:0x800BA820 end:0x800BA8C0
 	.bss        start:0x80C88D18 end:0x80C88D20
 
-network/ProductInfo/CoreInfo.cpp:
+lib.a/hproj/band3_wii/network/src/ProductInfo/wii_release/CoreInfo.o:
 	.text       start:0x800BA8C0 end:0x800BA9C0
 	.ctors      start:0x80B348C4 end:0x80B348C8
 	.data       start:0x80B67E48 end:0x80B67ED0
 	.bss        start:0x80C88D20 end:0x80C88FE0
 
-network/ProductInfo/ProductInfo.cpp:
+lib.a/hproj/band3_wii/network/src/ProductInfo/wii_release/ProductInfo.o:
 	.text       start:0x800BA9C0 end:0x800BAFF0
 	.data       start:0x80B67ED0 end:0x80B67F80
 	.sdata      start:0x80C78A58 end:0x80C78A60
 	.sbss       start:0x80C79B68 end:0x80C79B70
 	.bss        start:0x80C88FE0 end:0x80C89018
 
-network/Extensions/AnyExtDDF.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/AnyExtDDF.o:
 	.text       start:0x800BAFF0 end:0x800BB0D0
 	.ctors      start:0x80B348C8 end:0x80B348CC
 	.data       start:0x80B67F80 end:0x80B67FD0
 	.bss        start:0x80C89018 end:0x80C89038
 
-network/Extensions/SpeexCodec.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/SpeexCodec.o:
 	.text       start:0x800BB0D0 end:0x800BB710
 	.data       start:0x80B67FD0 end:0x80B68070
 
-network/Extensions/AVStreamsDDF.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/AVStreamsDDF.o:
 	.text       start:0x800BB710 end:0x800BB7F0
 	.ctors      start:0x80B348CC end:0x80B348D0
 	.data       start:0x80B68070 end:0x80B680C0
 	.bss        start:0x80C89038 end:0x80C89058
 
-network/Extensions/Codec.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/Codec.o:
 	.text       start:0x800BB7F0 end:0x800BB960
 	.data       start:0x80B680C0 end:0x80B68180
 
-network/Extensions/CodecManager.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/CodecManager.o:
 	.text       start:0x800BB960 end:0x800BC5C0
 	.ctors      start:0x80B348D0 end:0x80B348D4
 	.sdata      start:0x80C78A60 end:0x80C78A68
 	.bss        start:0x80C89058 end:0x80C89080
 
-network/Extensions/StreamingProtocol.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/StreamingProtocol.o:
 	.text       start:0x800BC5C0 end:0x800BD100
 	.data       start:0x80B68180 end:0x80B68288
 
-network/Extensions/DefaultCellDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/DefaultCellDDL.o:
 	.text       start:0x800BD100 end:0x800BDBD0
 	.data       start:0x80B68288 end:0x80B685B8
 	.bss        start:0x80C89080 end:0x80C89088
 
-network/Extensions/DefaultCellParameterDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/DefaultCellParameterDDL.o:
 	.text       start:0x800BDBD0 end:0x800BDC80
 	.data       start:0x80B685B8 end:0x80B685C8
 
-network/Extensions/DupSpaceExtDDF.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/DupSpaceExtDDF.o:
 	.text       start:0x800BDC80 end:0x800BDDB0
 	.ctors      start:0x80B348D4 end:0x80B348D8
 	.data       start:0x80B685C8 end:0x80B68618
 	.bss        start:0x80C89088 end:0x80C890A8
 
-network/Extensions/DupSpaceExtension.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/DupSpaceExtension.o:
 	.text       start:0x800BDDB0 end:0x800BE410
 	.data       start:0x80B68618 end:0x80B68868
 
-network/Extensions/DupSpaceOperation.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/DupSpaceOperation.o:
 	.text       start:0x800BE410 end:0x800BE590
 	.data       start:0x80B68868 end:0x80B688C8
 
-network/Extensions/DuplicationSpace.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/DuplicationSpace.o:
 	.text       start:0x800BE590 end:0x800C3230
 	.ctors      start:0x80B348D8 end:0x80B348DC
 	.data       start:0x80B688C8 end:0x80B68A28
 	.sdata      start:0x80C78A68 end:0x80C78A70
 	.bss        start:0x80C890A8 end:0x80C89108
 
-network/Extensions/DuplicationSpaceTable.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/DuplicationSpaceTable.o:
 	.text       start:0x800C3230 end:0x800C4CD0
 	.data       start:0x80B68A28 end:0x80B68B68
 	.sdata      start:0x80C78A70 end:0x80C78A78
 
-network/Extensions/MatchOperation.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/MatchOperation.o:
 	.text       start:0x800C4CD0 end:0x800C50F0
 	.data       start:0x80B68B68 end:0x80B68C00
 
-network/Extensions/MatchOperationTriggers.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/MatchOperationTriggers.o:
 	.text       start:0x800C50F0 end:0x800C5270
 
-network/Extensions/SessionSpace.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/SessionSpace.o:
 	.text       start:0x800C5270 end:0x800C5430
 	.data       start:0x80B68C00 end:0x80B68CA8
 
-network/Extensions/SessionSpaceDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/SessionSpaceDDL.o:
 	.text       start:0x800C5430 end:0x800C54A0
 	.ctors      start:0x80B348DC end:0x80B348E0
 	.data       start:0x80B68CA8 end:0x80B68CB8
 	.bss        start:0x80C89108 end:0x80C89178
 
-network/Extensions/GlobalDiscovery.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/GlobalDiscovery.o:
 	.text       start:0x800C54A0 end:0x800C6420
 	.data       start:0x80B68CB8 end:0x80B68D00
 
-network/Extensions/GlobalDiscoveryExtension.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/GlobalDiscoveryExtension.o:
 	.text       start:0x800C6420 end:0x800C66C0
 	.data       start:0x80B68D00 end:0x80B68DF0
 
-network/Extensions/PHBDRVar.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/PHBDRVar.o:
 	.text       start:0x800C66C0 end:0x800C6800
 	.ctors      start:0x80B348E0 end:0x80B348E4
 	.rodata     start:0x80B34E18 end:0x80B34E38
 	.bss        start:0x80C89178 end:0x80C89218
 
-network/Extensions/RemoteLogDeviceProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/RemoteLogDeviceProtocolDDL.o:
 	.text       start:0x800C6800 end:0x800C68F0
 	.data       start:0x80B68DF0 end:0x80B68E58
 
-network/Extensions/RemoteLogDeviceServer.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/RemoteLogDeviceServer.o:
 	.text       start:0x800C68F0 end:0x800C6A30
 	.data       start:0x80B68E58 end:0x80B68F20
 
-network/Extensions/SessionClockExtDDF.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/SessionClockExtDDF.o:
 	.text       start:0x800C6A30 end:0x800C6B90
 	.ctors      start:0x80B348E4 end:0x80B348E8
 	.data       start:0x80B68F20 end:0x80B68F78
 	.bss        start:0x80C89218 end:0x80C89250
 
-network/Extensions/SessionClockDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/SessionClockDDL.o:
 	.text       start:0x800C6B90 end:0x800C7510
 	.data       start:0x80B68F78 end:0x80B693F0
 	.bss        start:0x80C89250 end:0x80C89258
 
-network/Extensions/SessionClockExtension.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/SessionClockExtension.o:
 	.text       start:0x800C7510 end:0x800C7860
 	.data       start:0x80B693F0 end:0x80B694D8
 
-network/Extensions/SessionClock.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/SessionClock.o:
 	.text       start:0x800C7860 end:0x800C9620
 	.ctors      start:0x80B348E8 end:0x80B348EC
 	.data       start:0x80B694D8 end:0x80B698B8
@@ -1325,501 +1325,501 @@ network/Extensions/SessionClock.cpp:
 	.sbss       start:0x80C79B70 end:0x80C79B78
 	.bss        start:0x80C89258 end:0x80C89278
 
-network/Extensions/STLExtDDF.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/STLExtDDF.o:
 	.text       start:0x800C9620 end:0x800C9700
 	.ctors      start:0x80B348EC end:0x80B348F0
 	.data       start:0x80B698B8 end:0x80B69908
 	.bss        start:0x80C89278 end:0x80C89298
 
-network/Extensions/ChannelInfo.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/ChannelInfo.o:
 	.text       start:0x800C9700 end:0x800C97B0
 
-network/Extensions/ChannelInfoDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/ChannelInfoDDL.o:
 	.text       start:0x800C97B0 end:0x800C99C0
 	.data       start:0x80B69908 end:0x80B69960
 
-network/Extensions/ChannelMemberSink.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/ChannelMemberSink.o:
 	.text       start:0x800C99C0 end:0x800C99C0
 
-network/Extensions/ChannelMembers.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/ChannelMembers.o:
 	.text       start:0x800C99C0 end:0x800C9BC0
 
-network/Extensions/ChannelMembersDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/ChannelMembersDDL.o:
 	.text       start:0x800C9BC0 end:0x800C9CB0
 	.data       start:0x80B69960 end:0x80B69970
 
-network/Extensions/DemuxEventHandler.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/DemuxEventHandler.o:
 	.text       start:0x800C9CB0 end:0x800CA1B0
 	.data       start:0x80B69970 end:0x80B69A20
 
-network/Extensions/VoiceChannel.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/VoiceChannel.o:
 	.text       start:0x800CA1B0 end:0x800CBC30
 	.data       start:0x80B69A20 end:0x80B69BA0
 
-network/Extensions/VoiceChannelDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/VoiceChannelDDL.o:
 	.text       start:0x800CBC30 end:0x800CD750
 	.data       start:0x80B69BA0 end:0x80B6A2D0
 	.bss        start:0x80C89298 end:0x80C892A0
 
-network/Extensions/VoiceChannelMember.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/VoiceChannelMember.o:
 	.text       start:0x800CD750 end:0x800CD7F0
 	.data       start:0x80B6A2D0 end:0x80B6A318
 
-network/Extensions/VoiceChannelMemberDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/VoiceChannelMemberDDL.o:
 	.text       start:0x800CD7F0 end:0x800CD8B0
 
-network/Extensions/VoiceChatExtDDF.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/VoiceChatExtDDF.o:
 	.text       start:0x800CD8B0 end:0x800CD9D0
 	.ctors      start:0x80B348F0 end:0x80B348F4
 	.data       start:0x80B6A318 end:0x80B6A368
 	.bss        start:0x80C892A0 end:0x80C892C0
 
-network/Extensions/VoiceStream.cpp:
+lib.a/hproj/band3_wii/network/src/Extensions/wii_release/VoiceStream.o:
 	.text       start:0x800CD9D0 end:0x800CDB40
 
-network/Services/AccountManagementClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/AccountManagementClient.o:
 	.text       start:0x800CDB40 end:0x800CF0B0
 	.data       start:0x80B6A368 end:0x80B6A528
 
-network/Services/AccountManagementCommand.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/AccountManagementCommand.o:
 	.text       start:0x800CF0B0 end:0x800CF180
 	.data       start:0x80B6A528 end:0x80B6A570
 
-network/Services/GuestCreateAccountCommand.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/GuestCreateAccountCommand.o:
 	.text       start:0x800CF180 end:0x800CF3D0
 	.data       start:0x80B6A570 end:0x80B6A5C0
 
-network/Services/GuestCustomCreateAccountCommand.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/GuestCustomCreateAccountCommand.o:
 	.text       start:0x800CF3D0 end:0x800CF560
 	.data       start:0x80B6A5C0 end:0x80B6A620
 
-network/Services/JobCreateAccount.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobCreateAccount.o:
 	.text       start:0x800CF560 end:0x800D0A60
 	.data       start:0x80B6A620 end:0x80B6AA20
 
-network/Services/JobLoginOrCreateAccount.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobLoginOrCreateAccount.o:
 	.text       start:0x800D0A60 end:0x800D18E0
 	.data       start:0x80B6AA20 end:0x80B6AC68
 	.sdata      start:0x80C78A80 end:0x80C78A88
 
-network/Services/JobManageAccount.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobManageAccount.o:
 	.text       start:0x800D18E0 end:0x800D3E80
 	.data       start:0x80B6AC68 end:0x80B6B118
 
-network/Services/LookupOrCreateAccountCommand.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/LookupOrCreateAccountCommand.o:
 	.text       start:0x800D3E80 end:0x800D4040
 	.data       start:0x80B6B118 end:0x80B6B170
 
-network/Services/AccountDataDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/AccountDataDDL.o:
 	.text       start:0x800D4040 end:0x800D4160
 
-network/Services/AccountManagementProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/AccountManagementProtocolDDL.o:
 	.text       start:0x800D4160 end:0x800D7710
 	.data       start:0x80B6B170 end:0x80B6B428
 	.bss        start:0x80C892C0 end:0x80C892C8
 
-network/Services/BasicAccountInfoDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/BasicAccountInfoDDL.o:
 	.text       start:0x800D7710 end:0x800D7760
 
-network/Services/PrivateDataDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/PrivateDataDDL.o:
 	.text       start:0x800D7760 end:0x800D7760
 	.data       start:0x80B6B428 end:0x80B6B480
 
-network/Services/AuthenticationClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/AuthenticationClient.o:
 	.text       start:0x800D7760 end:0x800D7B40
 	.data       start:0x80B6B480 end:0x80B6B500
 
-network/Services/JobTicketManagerAcquireTicket.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobTicketManagerAcquireTicket.o:
 	.text       start:0x800D7B40 end:0x800D8330
 	.data       start:0x80B6B500 end:0x80B6B628
 
-network/Services/JobTicketManagerLogin.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobTicketManagerLogin.o:
 	.text       start:0x800D8330 end:0x800D91A0
 	.data       start:0x80B6B628 end:0x80B6B878
 	.sdata      start:0x80C78A88 end:0x80C78A90
 
-network/Services/KerberosAuthentication.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/KerberosAuthentication.o:
 	.text       start:0x800D91A0 end:0x800D95F0
 	.data       start:0x80B6B878 end:0x80B6B8A0
 
-network/Services/TicketManager.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/TicketManager.o:
 	.text       start:0x800D95F0 end:0x800DA5B0
 	.data       start:0x80B6B8A0 end:0x80B6B8B8
 	.sdata      start:0x80C78A90 end:0x80C78A98
 
-network/Services/RVConnectionDataDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/RVConnectionDataDDL.o:
 	.text       start:0x800DA5B0 end:0x800DA6D0
 
-network/Services/Ticket.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/Ticket.o:
 	.text       start:0x800DA6D0 end:0x800DA910
 	.data       start:0x80B6B8B8 end:0x80B6B8F8
 
-network/Services/TicketGrantingProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/TicketGrantingProtocolDDL.o:
 	.text       start:0x800DA910 end:0x800DB960
 	.data       start:0x80B6B8F8 end:0x80B6BA48
 
-network/Services/CompetitionClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/CompetitionClient.o:
 	.text       start:0x800DB960 end:0x800DBCB0
 	.data       start:0x80B6BA48 end:0x80B6BD28
 
-network/Services/Competition.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/Competition.o:
 	.text       start:0x800DBCB0 end:0x800DBF40
 	.data       start:0x80B6BD28 end:0x80B6BD50
 
-network/Services/CompetitionDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/CompetitionDDL.o:
 	.text       start:0x800DBF40 end:0x800DC530
 	.data       start:0x80B6BD50 end:0x80B6BE28
 	.bss        start:0x80C892C8 end:0x80C892D0
 
-network/Services/CompetitionProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/CompetitionProtocolDDL.o:
 	.text       start:0x800DC530 end:0x800DCAC0
 	.data       start:0x80B6BE28 end:0x80B6BEE8
 
-network/Services/RankingDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/RankingDDL.o:
 	.text       start:0x800DCAC0 end:0x800DCBF0
 	.data       start:0x80B6BEE8 end:0x80B6BF00
 
-network/Services/TournamentDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/TournamentDDL.o:
 	.text       start:0x800DCBF0 end:0x800DCD20
 	.data       start:0x80B6BF00 end:0x80B6BF20
 
-network/Services/ClientStreamManager.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/ClientStreamManager.o:
 	.text       start:0x800DCD20 end:0x800DCFD0
 	.data       start:0x80B6BF20 end:0x80B6BFC8
 
-network/Services/Credentials.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/Credentials.o:
 	.text       start:0x800DCFD0 end:0x800DD430
 	.data       start:0x80B6BFC8 end:0x80B6C018
 
-network/Services/ServiceClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/ServiceClient.o:
 	.text       start:0x800DD430 end:0x800DDFD0
 	.data       start:0x80B6C018 end:0x80B6C038
 
-network/Services/AnyDataAdapter.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/AnyDataAdapter.o:
 	.text       start:0x800DDFD0 end:0x800DE6C0
 	.ctors      start:0x80B348F4 end:0x80B348F8
 	.data       start:0x80B6C038 end:0x80B6C0C8
 	.bss        start:0x80C892D0 end:0x80C892E8
 
-network/Services/Data.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/Data.o:
 	.text       start:0x800DE6C0 end:0x800DE710
 	.data       start:0x80B6C0C8 end:0x80B6C0F0
 
-network/Services/DataDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/DataDDL.o:
 	.text       start:0x800DE710 end:0x800DE7F0
 	.data       start:0x80B6C0F0 end:0x80B6C108
 
-network/Services/MessageRecipientDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MessageRecipientDDL.o:
 	.text       start:0x800DE7F0 end:0x800DE850
 
-network/Services/NotificationEvent.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NotificationEvent.o:
 	.text       start:0x800DE850 end:0x800DE850
 
-network/Services/NotificationEventDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NotificationEventDDL.o:
 	.text       start:0x800DE850 end:0x800DE8E0
 
-network/Services/NotificationEventManager.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NotificationEventManager.o:
 	.text       start:0x800DE8E0 end:0x800DEE90
 	.data       start:0x80B6C108 end:0x80B6C268
 
-network/Services/NotificationProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NotificationProtocolDDL.o:
 	.text       start:0x800DEE90 end:0x800DF070
 	.data       start:0x80B6C268 end:0x80B6C2F0
 
-network/Services/ProtocolFoundationDDF.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/ProtocolFoundationDDF.o:
 	.text       start:0x800DF070 end:0x800DF180
 	.ctors      start:0x80B348F8 end:0x80B348FC
 	.data       start:0x80B6C2F0 end:0x80B6C348
 	.bss        start:0x80C892E8 end:0x80C89308
 
-network/Services/ResultRangeDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/ResultRangeDDL.o:
 	.text       start:0x800DF180 end:0x800DF1E0
 
-network/Services/UserMessage.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/UserMessage.o:
 	.text       start:0x800DF1E0 end:0x800DF1E0
 
-network/Services/UserMessageDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/UserMessageDDL.o:
 	.text       start:0x800DF1E0 end:0x800DF9B0
 	.data       start:0x80B6C348 end:0x80B6C438
 	.sdata      start:0x80C78A98 end:0x80C78AA0
 
-network/Services/KerberosEncryption.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/KerberosEncryption.o:
 	.text       start:0x800DF9B0 end:0x800DFE80
 	.ctors      start:0x80B348FC end:0x80B34900
 	.data       start:0x80B6C438 end:0x80B6C440
 	.bss        start:0x80C89308 end:0x80C89328
 
-network/Services/MD5KeyDerivation.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MD5KeyDerivation.o:
 	.text       start:0x800DFE80 end:0x800E0260
 	.data       start:0x80B6C440 end:0x80B6C4F0
 
-network/Services/StreamManager.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/StreamManager.o:
 	.text       start:0x800E0260 end:0x800E0A40
 	.ctors      start:0x80B34900 end:0x80B34904
 	.data       start:0x80B6C4F0 end:0x80B6C540
 	.sdata      start:0x80C78AA0 end:0x80C78AA8
 	.bss        start:0x80C89328 end:0x80C893D0
 
-network/Services/BackEndServices.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/BackEndServices.o:
 	.text       start:0x800E0A40 end:0x800E2A40
 	.ctors      start:0x80B34904 end:0x80B34908
 	.data       start:0x80B6C540 end:0x80B6C828
 	.bss        start:0x80C893D0 end:0x80C893E8
 
-network/Services/JobBackEndServicesLogin.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobBackEndServicesLogin.o:
 	.text       start:0x800E2A40 end:0x800E42A0
 	.data       start:0x80B6C828 end:0x80B6CE28
 	.sdata      start:0x80C78AA8 end:0x80C78AB0
 
-network/Services/JobBackEndServicesLogout.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobBackEndServicesLogout.o:
 	.text       start:0x800E42A0 end:0x800E4FC0
 	.data       start:0x80B6CE28 end:0x80B6D2F0
 
-network/Services/JobBackEndServicesTerminate.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobBackEndServicesTerminate.o:
 	.text       start:0x800E4FC0 end:0x800E5430
 	.data       start:0x80B6D2F0 end:0x80B6D460
 
-network/Services/RendezVous.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/RendezVous.o:
 	.text       start:0x800E5430 end:0x800E5540
 	.data       start:0x80B6D460 end:0x80B6D4A8
 
-network/Services/SandboxConnectionInfo.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/SandboxConnectionInfo.o:
 	.text       start:0x800E5540 end:0x800E5750
 	.data       start:0x80B6D4A8 end:0x80B6D4D8
 
-network/Services/FriendsClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/FriendsClient.o:
 	.text       start:0x800E5750 end:0x800E58B0
 	.data       start:0x80B6D4D8 end:0x80B6D530
 
-network/Services/FriendDataDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/FriendDataDDL.o:
 	.text       start:0x800E58B0 end:0x800E5940
 
-network/Services/FriendsProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/FriendsProtocolDDL.o:
 	.text       start:0x800E5940 end:0x800E61A0
 	.data       start:0x80B6D530 end:0x80B6D698
 
-network/Services/MatchMakingClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MatchMakingClient.o:
 	.text       start:0x800E61A0 end:0x800E6C80
 	.data       start:0x80B6D698 end:0x80B6DA00
 
-network/Services/AnyGatheringAdapter.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/AnyGatheringAdapter.o:
 	.text       start:0x800E6C80 end:0x800E78C0
 	.ctors      start:0x80B34908 end:0x80B3490C
 	.data       start:0x80B6DA00 end:0x80B6DAA8
 	.bss        start:0x80C893E8 end:0x80C89430
 
-network/Services/DeletionEntryDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/DeletionEntryDDL.o:
 	.text       start:0x800E78C0 end:0x800E7930
 
-network/Services/DynamicGatheringDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/DynamicGatheringDDL.o:
 	.text       start:0x800E7930 end:0x800E7B00
 	.data       start:0x80B6DAA8 end:0x80B6DB00
 
-network/Services/GameSessionDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/GameSessionDDL.o:
 	.text       start:0x800E7B00 end:0x800E7C30
 	.data       start:0x80B6DB00 end:0x80B6DB20
 
-network/Services/Gathering.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/Gathering.o:
 	.text       start:0x800E7C30 end:0x800E7D80
 	.data       start:0x80B6DB20 end:0x80B6DB48
 
-network/Services/GatheringDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/GatheringDDL.o:
 	.text       start:0x800E7D80 end:0x800E81F0
 	.data       start:0x80B6DB48 end:0x80B6DB88
 
-network/Services/GatheringStatsDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/GatheringStatsDDL.o:
 	.text       start:0x800E81F0 end:0x800E8320
 
-network/Services/GatheringURLsDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/GatheringURLsDDL.o:
 	.text       start:0x800E8320 end:0x800E8450
 
-network/Services/InvitationDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/InvitationDDL.o:
 	.text       start:0x800E8450 end:0x800E84C0
 
-network/Services/MatchMakingProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MatchMakingProtocolDDL.o:
 	.text       start:0x800E84C0 end:0x800EDD80
 	.data       start:0x80B6DB88 end:0x80B6DE80
 
-network/Services/MatchMakingProtocolExtDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MatchMakingProtocolExtDDL.o:
 	.text       start:0x800EDD80 end:0x800EE980
 	.data       start:0x80B6DE80 end:0x80B6DFC8
 
-network/Services/MatchMakingServiceDDF.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MatchMakingServiceDDF.o:
 	.text       start:0x800EE980 end:0x800EEA90
 	.ctors      start:0x80B3490C end:0x80B34910
 	.data       start:0x80B6DFC8 end:0x80B6E020
 	.bss        start:0x80C89430 end:0x80C89450
 
-network/Services/ParticipantDetailsDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/ParticipantDetailsDDL.o:
 	.text       start:0x800EEA90 end:0x800EEAF0
 
-network/Services/MessageDeliveryServer.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MessageDeliveryServer.o:
 	.text       start:0x800EEAF0 end:0x800EEF80
 	.data       start:0x80B6E020 end:0x80B6E170
 
-network/Services/MessagingClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MessagingClient.o:
 	.text       start:0x800EEF80 end:0x800EF6D0
 	.data       start:0x80B6E170 end:0x80B6E340
 
-network/Services/MessageDeliveryProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MessageDeliveryProtocolDDL.o:
 	.text       start:0x800EF6D0 end:0x800EFAD0
 	.data       start:0x80B6E340 end:0x80B6E408
 
-network/Services/MessagingProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/MessagingProtocolDDL.o:
 	.text       start:0x800EFAD0 end:0x800F12B0
 	.data       start:0x80B6E408 end:0x80B6E4C8
 
-network/Services/TextMessageDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/TextMessageDDL.o:
 	.text       start:0x800F12B0 end:0x800F1510
 	.data       start:0x80B6E4C8 end:0x80B6E510
 
-network/Services/JobWaitForProbes.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobWaitForProbes.o:
 	.text       start:0x800F1510 end:0x800F17A0
 	.data       start:0x80B6E510 end:0x80B6E588
 
-network/Services/NATTraversalClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NATTraversalClient.o:
 	.text       start:0x800F17A0 end:0x800F1E90
 	.data       start:0x80B6E588 end:0x80B6E610
 
-network/Services/NATTraversalRelayClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NATTraversalRelayClient.o:
 	.text       start:0x800F1E90 end:0x800F1FA0
 	.data       start:0x80B6E610 end:0x80B6E7A8
 
-network/Services/RVConnectivityTester.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/RVConnectivityTester.o:
 	.text       start:0x800F1FA0 end:0x800F2350
 	.data       start:0x80B6E7A8 end:0x80B6E848
 
-network/Services/RVNATEcho.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/RVNATEcho.o:
 	.text       start:0x800F2350 end:0x800F2400
 	.data       start:0x80B6E848 end:0x80B6E888
 
-network/Services/RVNATRelay.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/RVNATRelay.o:
 	.text       start:0x800F2400 end:0x800F2590
 	.data       start:0x80B6E888 end:0x80B6E8D0
 
-network/Services/NATEchoStream.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NATEchoStream.o:
 	.text       start:0x800F2590 end:0x800F2650
 	.data       start:0x80B6E8D0 end:0x80B6E8E8
 
-network/Services/NATTraversalProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NATTraversalProtocolDDL.o:
 	.text       start:0x800F2650 end:0x800F3000
 	.data       start:0x80B6E8E8 end:0x80B6E9B0
 
-network/Services/NATTraversalRelayProtocol.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/NATTraversalRelayProtocol.o:
 	.text       start:0x800F3000 end:0x800F3220
 	.data       start:0x80B6E9B0 end:0x80B6EA40
 
-network/Services/PersistentStoreClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/PersistentStoreClient.o:
 	.text       start:0x800F3220 end:0x800F3390
 	.data       start:0x80B6EA40 end:0x80B6EAA0
 
-network/Services/PersistentStoreProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/PersistentStoreProtocolDDL.o:
 	.text       start:0x800F3390 end:0x800F3C90
 	.data       start:0x80B6EAA0 end:0x80B6EB68
 
-network/Services/SecureConnectionClient.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/SecureConnectionClient.o:
 	.text       start:0x800F3C90 end:0x800F40B0
 	.data       start:0x80B6EB68 end:0x80B6EBD0
 	.sbss       start:0x80C79B78 end:0x80C79B80
 
-network/Services/ConnectionDataDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/ConnectionDataDDL.o:
 	.text       start:0x800F40B0 end:0x800F4100
 
-network/Services/SecureConnectionProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/SecureConnectionProtocolDDL.o:
 	.text       start:0x800F4100 end:0x800F5390
 	.data       start:0x80B6EBD0 end:0x80B6ED18
 
-network/Services/JobConnectSecureEndPoint.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/JobConnectSecureEndPoint.o:
 	.text       start:0x800F5390 end:0x800F61E0
 	.data       start:0x80B6ED18 end:0x80B6EF50
 	.sdata      start:0x80C78AB0 end:0x80C78AB8
 
-network/Services/SecureEndPoint.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/SecureEndPoint.o:
 	.text       start:0x800F61E0 end:0x800F6C00
 	.data       start:0x80B6EF50 end:0x80B6F060
 	.sdata      start:0x80C78AB8 end:0x80C78AC0
 
-network/Services/SecureStream.cpp:
+lib.a/hproj/band3_wii/network/src/Services/wii_release/SecureStream.o:
 	.text       start:0x800F6C00 end:0x800F7190
 	.data       start:0x80B6F060 end:0x80B6F160
 
-network/RVPackages/JobNintendoLogin.cpp:
+lib.a/hproj/band3_wii/network/src/RVPackages/wii_release/JobNintendoLogin.o:
 	.text       start:0x800F7190 end:0x800F7C30
 	.data       start:0x80B6F160 end:0x80B6F5F8
 
-network/RVPackages/JobNintendoTerminate.cpp:
+lib.a/hproj/band3_wii/network/src/RVPackages/wii_release/JobNintendoTerminate.o:
 	.text       start:0x800F7C30 end:0x800F7E90
 	.data       start:0x80B6F5F8 end:0x80B6F6B8
 	.sdata      start:0x80C78AC0 end:0x80C78AC8
 
-network/RVPackages/JobNintendoUpdateNameByGuest.cpp:
+lib.a/hproj/band3_wii/network/src/RVPackages/wii_release/JobNintendoUpdateNameByGuest.o:
 	.text       start:0x800F7E90 end:0x800F7EF0
 
-network/RVPackages/NintendoClient.cpp:
+lib.a/hproj/band3_wii/network/src/RVPackages/wii_release/NintendoClient.o:
 	.text       start:0x800F7EF0 end:0x800F8970
 	.ctors      start:0x80B34910 end:0x80B34914
 	.data       start:0x80B6F6B8 end:0x80B6F738
 	.bss        start:0x80C89450 end:0x80C89460
 
-network/RVPackages/NintendoTokenDDL.cpp:
+lib.a/hproj/band3_wii/network/src/RVPackages/wii_release/NintendoTokenDDL.o:
 	.text       start:0x800F8970 end:0x800F8B50
 	.data       start:0x80B6F738 end:0x80B6F780
 
-network/RVPackages/NintendoManagementProtocolDDL.cpp:
+lib.a/hproj/band3_wii/network/src/RVPackages/wii_release/NintendoManagementProtocolDDL.o:
 	.text       start:0x800F8B50 end:0x800F9060
 	.data       start:0x80B6F780 end:0x80B6F848
 
-network/Products/JobTerminateFacade.cpp:
+lib.a/hproj/band3_wii/network/src/Products/wii_release/JobTerminateFacade.o:
 	.text       start:0x800F9060 end:0x800FA0C0
 	.data       start:0x80B6F848 end:0x80B6FB40
 
-network/Products/ProductFacade.cpp:
+lib.a/hproj/band3_wii/network/src/Products/wii_release/ProductFacade.o:
 	.text       start:0x800FA0C0 end:0x800FB490
 	.ctors      start:0x80B34914 end:0x80B34918
 	.data       start:0x80B6FB40 end:0x80B6FBE0
 	.bss        start:0x80C89460 end:0x80C89490
 
-network/Products/ProductSpecifics.cpp:
+lib.a/hproj/band3_wii/network/src/Products/wii_release/ProductSpecifics.o:
 	.text       start:0x800FB490 end:0x800FB4E0
 	.data       start:0x80B6FBE0 end:0x80B6FC28
 
-network/Products/NetZ.cpp:
+lib.a/hproj/band3_wii/network/src/Products/wii_release/NetZ.o:
 	.text       start:0x800FB4E0 end:0x800FB5C0
 	.data       start:0x80B6FC28 end:0x80B6FC80
 
-network/Products/NetZSpecifics.cpp:
+lib.a/hproj/band3_wii/network/src/Products/wii_release/NetZSpecifics.o:
 	.text       start:0x800FB5C0 end:0x800FB720
 	.ctors      start:0x80B34918 end:0x80B3491C
 	.data       start:0x80B6FC80 end:0x80B6FCD0
 	.bss        start:0x80C89490 end:0x80C89750
 
-network/Products/NetZProductInfo.cpp:
+lib.a/hproj/band3_wii/network/src/Products/wii_release/NetZProductInfo.o:
 	.text       start:0x800FB720 end:0x800FB800
 	.data       start:0x80B6FCD0 end:0x80B6FD40
 
-network/Products/RendezVousProductInfo.cpp:
+lib.a/hproj/band3_wii/network/src/Products/wii_release/RendezVousProductInfo.o:
 	.text       start:0x800FB800 end:0x800FB910
 	.data       start:0x80B6FD40 end:0x80B6FDC8
 	.sbss       start:0x80C79B80 end:0x80C79B88
 	.bss        start:0x80C89750 end:0x80C89A10
 
-network/net/Jobs_RV.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/Jobs_RV.o:
 	.text       start:0x800FB910 end:0x800FCB10
 	.data       start:0x80B6FDC8 end:0x80B6FFB0
 	.sbss       start:0x80C79B88 end:0x80C79B90
 	.bss        start:0x80C89A10 end:0x80C89A50
 
-network/net/JsonUtils.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/JsonUtils.o:
 	.text       start:0x800FCB10 end:0x800FD670
 	.data       start:0x80B6FFB0 end:0x80B70140
 
-network/net/MatchmakingSettings.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/MatchmakingSettings.o:
 	.text       start:0x800FD670 end:0x800FE720
 	.data       start:0x80B70140 end:0x80B70398
 	.sbss       start:0x80C79B90 end:0x80C79B98
 	.bss        start:0x80C89A50 end:0x80C89A68
 
-network/net/MessageBroker.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/MessageBroker.o:
 	.text       start:0x800FE720 end:0x801001E0
 	.ctors      start:0x80B3491C end:0x80B34920
 	.data       start:0x80B70398 end:0x80B70768
@@ -1827,116 +1827,116 @@ network/net/MessageBroker.cpp:
 	.sbss       start:0x80C79B98 end:0x80C79BA0
 	.bss        start:0x80C89A68 end:0x80C89B18
 
-network/net/Net.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/Net.o:
 	.text       start:0x801001E0 end:0x80101530
 	.ctors      start:0x80B34920 end:0x80B34924
 	.data       start:0x80B70768 end:0x80B70A10
 	.bss        start:0x80C89B18 end:0x80C89EA0
 
-network/net/NetLog.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/NetLog.o:
 	.text       start:0x80101530 end:0x80101580
 	.ctors      start:0x80B34924 end:0x80B34928
 	.data       start:0x80B70A10 end:0x80B70A20
 	.bss        start:0x80C89EA0 end:0x80C89ED0
 
-network/net/NetMessage.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/NetMessage.o:
 	.text       start:0x80101580 end:0x80101BB0
 	.ctors      start:0x80B34928 end:0x80B3492C
 	.data       start:0x80B70A20 end:0x80B70AF0
 	.bss        start:0x80C89ED0 end:0x80C89EE8
 
-network/net/NetMessenger.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/NetMessenger.o:
 	.text       start:0x80101BB0 end:0x80102410
 	.ctors      start:0x80B3492C end:0x80B34930
 	.data       start:0x80B70AF0 end:0x80B70B60
 	.sbss       start:0x80C79BA0 end:0x80C79BA8
 	.bss        start:0x80C89EE8 end:0x80C89F28
 
-network/net/NetSearchResult.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/NetSearchResult.o:
 	.text       start:0x80102410 end:0x80102A00
 	.data       start:0x80B70B60 end:0x80B70C30
 
-network/net/NetSession.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/NetSession.o:
 	.text       start:0x80102A00 end:0x8010D9F0
 	.ctors      start:0x80B34930 end:0x80B34934
 	.data       start:0x80B70C30 end:0x80B71C48
 	.sbss       start:0x80C79BA8 end:0x80C79BC8
 	.bss        start:0x80C89F28 end:0x80C8A078
 
-network/net/NetSession_RV.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/NetSession_RV.o:
 	.text       start:0x8010D9F0 end:0x8010F270
 	.data       start:0x80B71C48 end:0x80B71F90
 	.sbss       start:0x80C79BC8 end:0x80C79BD0
 	.bss        start:0x80C8A078 end:0x80C8A080
 
-network/net/NetworkEmulator.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/NetworkEmulator.o:
 	.text       start:0x8010F270 end:0x8010FFF0
 	.data       start:0x80B71F90 end:0x80B72080
 
-network/net/Server.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/Server.o:
 	.text       start:0x8010FFF0 end:0x80110C00
 	.data       start:0x80B72080 end:0x80B72338
 	.sbss       start:0x80C79BD0 end:0x80C79BD8
 	.bss        start:0x80C8A080 end:0x80C8A098
 
-network/net/SessionSearcher.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/SessionSearcher.o:
 	.text       start:0x80110C00 end:0x80112450
 	.data       start:0x80B72338 end:0x80B724C8
 	.sbss       start:0x80C79BD8 end:0x80C79BE0
 	.bss        start:0x80C8A098 end:0x80C8A0A0
 
-network/net/SessionSearcher_RV.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/SessionSearcher_RV.o:
 	.text       start:0x80112450 end:0x80113480
 	.data       start:0x80B724C8 end:0x80B725F8
 	.sdata      start:0x80C78AD0 end:0x80C78AD8
 	.sbss       start:0x80C79BE0 end:0x80C79BE8
 	.bss        start:0x80C8A0A0 end:0x80C8A0F8
 
-network/net/SessionMessages.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/SessionMessages.o:
 	.text       start:0x80113480 end:0x80115E20
 	.data       start:0x80B725F8 end:0x80B72D88
 	.sdata      start:0x80C78AD8 end:0x80C78AE0
 
-network/net/Synchronize.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/Synchronize.o:
 	.text       start:0x80115E20 end:0x801165C0
 	.data       start:0x80B72D88 end:0x80B72E28
 
-network/net/SyncStore.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/SyncStore.o:
 	.text       start:0x801165C0 end:0x801174E0
 	.data       start:0x80B72E28 end:0x80B73090
 	.sdata      start:0x80C78AE0 end:0x80C78AE8
 	.bss        start:0x80C8A0F8 end:0x80C8A100
 
-network/net/QuazalSession.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/QuazalSession.o:
 	.text       start:0x801174E0 end:0x801181D0
 	.data       start:0x80B73090 end:0x80B731A8
 	.bss        start:0x80C8A100 end:0x80C8A108
 
-network/net/VoiceChatMgr.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/VoiceChatMgr.o:
 	.text       start:0x801181D0 end:0x801195B0
 	.data       start:0x80B731A8 end:0x80B73380
 	.bss        start:0x80C8A108 end:0x80C8A110
 
-network/net/CustomMatchMakingDDL_Wii.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/CustomMatchMakingDDL_Wii.o:
 	.text       start:0x801195B0 end:0x80119BB0
 	.data       start:0x80B73380 end:0x80B73440
 
-network/net/HarmonixGameDDF_Wii.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/HarmonixGameDDF_Wii.o:
 	.text       start:0x80119BB0 end:0x80119D40
 	.ctors      start:0x80B34934 end:0x80B34938
 	.data       start:0x80B73440 end:0x80B73490
 	.bss        start:0x80C8A110 end:0x80C8A160
 
-network/net/HarmonixGatheringDDL_Wii.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/HarmonixGatheringDDL_Wii.o:
 	.text       start:0x80119D40 end:0x8011A190
 	.data       start:0x80B73490 end:0x80B734E8
 
-network/net/MessageBrokerDDL_Wii.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/MessageBrokerDDL_Wii.o:
 	.text       start:0x8011A190 end:0x8011A820
 	.data       start:0x80B734E8 end:0x80B736A8
 	.bss        start:0x80C8A160 end:0x80C8A168
 
-network/net/Server_Wii.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/Server_Wii.o:
 	.text       start:0x8011A820 end:0x8011E6F0
 	.ctors      start:0x80B34938 end:0x80B3493C
 	.rodata     start:0x80B34E38 end:0x80B34E40
@@ -1944,7 +1944,7 @@ network/net/Server_Wii.cpp:
 	.sbss       start:0x80C79BE8 end:0x80C79BF8
 	.bss        start:0x80C8A168 end:0x80C8A340
 
-network/net/WiiFriendMgr.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/WiiFriendMgr.o:
 	.text       start:0x8011E6F0 end:0x801229A0
 	.ctors      start:0x80B3493C end:0x80B34940
 	.rodata     start:0x80B34E40 end:0x80B34E48
@@ -1952,41 +1952,41 @@ network/net/WiiFriendMgr.cpp:
 	.sbss       start:0x80C79BF8 end:0x80C79C00
 	.bss        start:0x80C8A340 end:0x80C8E498
 
-network/net/Jobs_Wii.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/Jobs_Wii.o:
 	.text       start:0x801229A0 end:0x80125FE0
 	.data       start:0x80B74070 end:0x80B75058
 
-network/net/WiiMessenger.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/WiiMessenger.o:
 	.text       start:0x80125FE0 end:0x801279E0
 	.ctors      start:0x80B34940 end:0x80B34944
 	.data       start:0x80B75058 end:0x80B752D0
 	.sbss       start:0x80C79C00 end:0x80C79C08
 	.bss        start:0x80C8E498 end:0x80C8E890
 
-network/net/arraylist.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/arraylist.o:
 	.text       start:0x801279E0 end:0x80127C50
 
-network/net/debug.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/debug.o:
 	.text       start:0x80127C50 end:0x80127C50
 
-network/net/json_object.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/json_object.o:
 	.text       start:0x80127C50 end:0x801289E0
 	.data       start:0x80B752D0 end:0x80B75350
 
-network/net/json_tokener.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/json_tokener.o:
 	.text       start:0x801289E0 end:0x8012A590
 	.data       start:0x80B75350 end:0x80B756E0
 
-network/net/linkhash.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/linkhash.o:
 	.text       start:0x8012A590 end:0x8012AD30
 	.rodata     start:0x80B34E48 end:0x80B34E50
 	.data       start:0x80B756E0 end:0x80B75700
 
-network/net/printbuf.cpp:
+lib.a/hproj/band3_wii/network/src/net/wii_release/printbuf.o:
 	.text       start:0x8012AD30 end:0x8012B140
 	.sbss       start:0x80C79C08 end:0x80C79C10
 
-band3/bandtrack/Gem.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/Gem.o:
 	.text       start:0x8012B140 end:0x8012E490
 	.rodata     start:0x80B34E50 end:0x80B34E58
 	.data       start:0x80B75700 end:0x80B759A8
@@ -1994,7 +1994,7 @@ band3/bandtrack/Gem.cpp:
 	.sbss       start:0x80C79C10 end:0x80C79C18
 	.bss        start:0x80C8E890 end:0x80C8E8B0
 
-band3/bandtrack/GemManager.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/GemManager.o:
 	.text       start:0x8012E490 end:0x80137F90
 	.rodata     start:0x80B34E58 end:0x80B34E70
 	.data       start:0x80B759A8 end:0x80B76388
@@ -2002,17 +2002,17 @@ band3/bandtrack/GemManager.cpp:
 	.sbss       start:0x80C79C18 end:0x80C79C20
 	.bss        start:0x80C8E8B0 end:0x80C8E8C8
 
-band3/bandtrack/GemRepTemplate.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/GemRepTemplate.o:
 	.text       start:0x80137F90 end:0x8013AD60
 	.data       start:0x80B76388 end:0x80B766A8
 	.sbss       start:0x80C79C20 end:0x80C79C28
 	.bss        start:0x80C8E8C8 end:0x80C8E8D0
 
-band3/bandtrack/GemSmasher.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/GemSmasher.o:
 	.text       start:0x8013AD60 end:0x8013BE40
 	.data       start:0x80B766A8 end:0x80B768E0
 
-band3/bandtrack/GemTrack.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/GemTrack.o:
 	.text       start:0x8013BE40 end:0x80141A10
 	.rodata     start:0x80B34E70 end:0x80B34E78
 	.data       start:0x80B768E0 end:0x80B77218
@@ -2020,43 +2020,43 @@ band3/bandtrack/GemTrack.cpp:
 	.sbss       start:0x80C79C28 end:0x80C79C38
 	.bss        start:0x80C8E8D0 end:0x80C8E908
 
-band3/bandtrack/GraphicsUtl.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/GraphicsUtl.o:
 	.text       start:0x80141A10 end:0x80141AC0
 
-band3/bandtrack/Lyric.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/Lyric.o:
 	.text       start:0x80141AC0 end:0x80142DC0
 	.rodata     start:0x80B34E78 end:0x80B34E80
 	.data       start:0x80B77218 end:0x80B773E0
 	.sbss       start:0x80C79C38 end:0x80C79C40
 	.bss        start:0x80C8E908 end:0x80C8E918
 
-band3/bandtrack/NowBar.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/NowBar.o:
 	.text       start:0x80142DC0 end:0x80143BF0
 	.data       start:0x80B773E0 end:0x80B77488
 
-band3/bandtrack/Tail.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/Tail.o:
 	.text       start:0x80143BF0 end:0x80146610
 	.data       start:0x80B77488 end:0x80B776E8
 	.sbss       start:0x80C79C40 end:0x80C79C48
 	.bss        start:0x80C8E918 end:0x80C8E920
 
-band3/bandtrack/Track.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/Track.o:
 	.text       start:0x80146610 end:0x801482D0
 	.data       start:0x80B776E8 end:0x80B77AB0
 	.sbss       start:0x80C79C48 end:0x80C79C50
 
-band3/bandtrack/TrackConfig.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/TrackConfig.o:
 	.text       start:0x801482D0 end:0x80148640
 	.data       start:0x80B77AB0 end:0x80B77B48
 
-band3/bandtrack/TrackPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/TrackPanel.o:
 	.text       start:0x80148640 end:0x8014E0E0
 	.rodata     start:0x80B34E80 end:0x80B34E98
 	.data       start:0x80B77B48 end:0x80B78570
 	.sbss       start:0x80C79C50 end:0x80C79C58
 	.bss        start:0x80C8E920 end:0x80C8E940
 
-band3/bandtrack/VocalTrack.cpp:
+lib.a/hproj/band3_wii/band3/src/bandtrack/wii_release/VocalTrack.o:
 	.text       start:0x8014E0E0 end:0x8015CFC0
 	.ctors      start:0x80B34944 end:0x80B34948
 	.rodata     start:0x80B34E98 end:0x80B34ED0
@@ -2064,34 +2064,34 @@ band3/bandtrack/VocalTrack.cpp:
 	.sbss       start:0x80C79C58 end:0x80C79C68
 	.bss        start:0x80C8E940 end:0x80C8E998
 
-band3/game/AccuracyTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/AccuracyTracker.o:
 	.text       start:0x8015CFC0 end:0x8015D950
 	.data       start:0x80B79D28 end:0x80B79DF0
 
-band3/game/Band.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Band.o:
 	.text       start:0x8015D950 end:0x80160890
 	.data       start:0x80B79DF0 end:0x80B7A100
 	.sbss       start:0x80C79C68 end:0x80C79C70
 	.bss        start:0x80C8E998 end:0x80C8E9B0
 
-band3/game/BandPerformer.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/BandPerformer.o:
 	.text       start:0x80160890 end:0x80161CC0
 	.data       start:0x80B7A100 end:0x80B7A308
 
-band3/game/BandUser.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/BandUser.o:
 	.text       start:0x80161CC0 end:0x80167060
 	.data       start:0x80B7A308 end:0x80B7ABC8
 	.sdata      start:0x80C78B00 end:0x80C78B08
 	.sbss       start:0x80C79C70 end:0x80C79C78
 	.bss        start:0x80C8E9B0 end:0x80C8E9B8
 
-band3/game/BandUserMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/BandUserMgr.o:
 	.text       start:0x80167060 end:0x8016A7A0
 	.data       start:0x80B7ABC8 end:0x80B7AF10
 	.sbss       start:0x80C79C78 end:0x80C79C80
 	.bss        start:0x80C8E9B8 end:0x80C8E9C0
 
-band3/game/ChordbookPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/ChordbookPanel.o:
 	.text       start:0x8016A7A0 end:0x8016F180
 	.rodata     start:0x80B34ED0 end:0x80B34ED8
 	.data       start:0x80B7AF10 end:0x80B7B570
@@ -2099,7 +2099,7 @@ band3/game/ChordbookPanel.cpp:
 	.sbss       start:0x80C79C80 end:0x80C79C90
 	.bss        start:0x80C8E9C0 end:0x80C8EAA8
 
-band3/game/ChordPreview.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/ChordPreview.o:
 	.text       start:0x8016F180 end:0x8016F590
 	.rodata     start:0x80B34ED8 end:0x80B34EE0
 	.data       start:0x80B7B570 end:0x80B7B6C0
@@ -2107,36 +2107,36 @@ band3/game/ChordPreview.cpp:
 	.sbss       start:0x80C79C90 end:0x80C79C98
 	.bss        start:0x80C8EAA8 end:0x80C8EAB0
 
-band3/game/CommonPhraseCapturer.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/CommonPhraseCapturer.o:
 	.text       start:0x8016F590 end:0x80170DF0
 	.data       start:0x80B7B6C0 end:0x80B7B770
 	.sbss       start:0x80C79C98 end:0x80C79CA0
 	.bss        start:0x80C8EAB0 end:0x80C8EAD8
 
-band3/game/CrowdRating.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/CrowdRating.o:
 	.text       start:0x80170DF0 end:0x80171AC0
 	.data       start:0x80B7B770 end:0x80B7BA08
 
-band3/game/Defines.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Defines.o:
 	.text       start:0x80171AC0 end:0x801733F0
 	.data       start:0x80B7BA08 end:0x80B7BCB8
 
-band3/game/DirectInstrument.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/DirectInstrument.o:
 	.text       start:0x801733F0 end:0x80173F30
 	.data       start:0x80B7BCB8 end:0x80B7BD40
 
-band3/game/DeployCountTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/DeployCountTracker.o:
 	.text       start:0x80173F30 end:0x80175420
 	.data       start:0x80B7BD40 end:0x80B7BE08
 	.sdata      start:0x80C78B18 end:0x80C78B20
 
-band3/game/FadePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/FadePanel.o:
 	.text       start:0x80175420 end:0x801760F0
 	.data       start:0x80B7BE08 end:0x80B7BF78
 	.sbss       start:0x80C79CA0 end:0x80C79CA8
 	.bss        start:0x80C8EAD8 end:0x80C8EAF0
 
-band3/game/FocusTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/FocusTracker.o:
 	.text       start:0x801760F0 end:0x80179930
 	.rodata     start:0x80B34EE0 end:0x80B34EE8
 	.data       start:0x80B7BF78 end:0x80B7C228
@@ -2144,32 +2144,32 @@ band3/game/FocusTracker.cpp:
 	.sbss       start:0x80C79CA8 end:0x80C79CB0
 	.bss        start:0x80C8EAF0 end:0x80C8EB08
 
-band3/game/FreestylePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/FreestylePanel.o:
 	.text       start:0x80179930 end:0x8017B640
 	.rodata     start:0x80B34EE8 end:0x80B34EF0
 	.data       start:0x80B7C228 end:0x80B7C4E8
 	.sbss       start:0x80C79CB0 end:0x80C79CB8
 	.bss        start:0x80C8EB08 end:0x80C8EB18
 
-band3/game/FretHand.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/FretHand.o:
 	.text       start:0x8017B640 end:0x8017BCD0
 	.data       start:0x80B7C4E8 end:0x80B7C538
 	.sdata      start:0x80C78B28 end:0x80C78B30
 
-band3/game/Game.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Game.o:
 	.text       start:0x8017BCD0 end:0x80185470
 	.rodata     start:0x80B34EF0 end:0x80B34F68
 	.data       start:0x80B7C538 end:0x80B7D0F8
 	.sbss       start:0x80C79CB8 end:0x80C79CC8
 	.bss        start:0x80C8EB18 end:0x80C8EB60
 
-band3/game/GameConfig.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/GameConfig.o:
 	.text       start:0x80185470 end:0x80188430
 	.rodata     start:0x80B34F68 end:0x80B34FE0
 	.data       start:0x80B7D0F8 end:0x80B7D2D0
 	.bss        start:0x80C8EB60 end:0x80C8EB68
 
-band3/game/GameMic.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/GameMic.o:
 	.text       start:0x80188430 end:0x80189060
 	.rodata     start:0x80B34FE0 end:0x80B34FE8
 	.data       start:0x80B7D2D0 end:0x80B7D358
@@ -2177,7 +2177,7 @@ band3/game/GameMic.cpp:
 	.sbss       start:0x80C79CC8 end:0x80C79CD0
 	.bss        start:0x80C8EB68 end:0x80C8EB78
 
-band3/game/GameMicManager.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/GameMicManager.o:
 	.text       start:0x80189060 end:0x8018B1B0
 	.ctors      start:0x80B34948 end:0x80B3494C
 	.rodata     start:0x80B34FE8 end:0x80B34FF0
@@ -2185,13 +2185,13 @@ band3/game/GameMicManager.cpp:
 	.sbss       start:0x80C79CD0 end:0x80C79CD8
 	.bss        start:0x80C8EB78 end:0x80C8EBA0
 
-band3/game/GameMode.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/GameMode.o:
 	.text       start:0x8018B1B0 end:0x8018C3A0
 	.data       start:0x80B7D690 end:0x80B7D8F0
 	.sbss       start:0x80C79CD8 end:0x80C79CE0
 	.bss        start:0x80C8EBA0 end:0x80C8EBC0
 
-band3/game/GamePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/GamePanel.o:
 	.text       start:0x8018C3A0 end:0x80191400
 	.ctors      start:0x80B3494C end:0x80B34950
 	.rodata     start:0x80B34FF0 end:0x80B35008
@@ -2199,7 +2199,7 @@ band3/game/GamePanel.cpp:
 	.sbss       start:0x80C79CE0 end:0x80C79CF0
 	.bss        start:0x80C8EBC0 end:0x80C8EC18
 
-band3/game/GemPlayer.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/GemPlayer.o:
 	.text       start:0x80191400 end:0x801A1D70
 	.rodata     start:0x80B35008 end:0x80B35020
 	.data       start:0x80B7DCA0 end:0x80B7E890
@@ -2207,7 +2207,7 @@ band3/game/GemPlayer.cpp:
 	.sbss       start:0x80C79CF0 end:0x80C79D08
 	.bss        start:0x80C8EC18 end:0x80C8EDA8
 
-band3/game/GemTrainerPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/GemTrainerPanel.o:
 	.text       start:0x801A1D70 end:0x801A6C30
 	.rodata     start:0x80B35020 end:0x80B35028
 	.data       start:0x80B7E890 end:0x80B7ED08
@@ -2215,250 +2215,250 @@ band3/game/GemTrainerPanel.cpp:
 	.sbss       start:0x80C79D08 end:0x80C79D10
 	.bss        start:0x80C8EDA8 end:0x80C8EDE8
 
-band3/game/GuitarFx.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/GuitarFx.o:
 	.text       start:0x801A6C30 end:0x801A8E80
 	.rodata     start:0x80B35028 end:0x80B35030
 	.data       start:0x80B7ED08 end:0x80B7EE98
 
-band3/game/HeldNote.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/HeldNote.o:
 	.text       start:0x801A8E80 end:0x801A9540
 	.data       start:0x80B7EE98 end:0x80B7EF20
 
-band3/game/HitTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/HitTracker.o:
 	.text       start:0x801A9540 end:0x801A9A30
 	.data       start:0x80B7EF20 end:0x80B7F178
 
-band3/game/KeysFx.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/KeysFx.o:
 	.text       start:0x801A9A30 end:0x801AB0C0
 	.rodata     start:0x80B35030 end:0x80B35038
 	.data       start:0x80B7F178 end:0x80B7F270
 	.sbss       start:0x80C79D10 end:0x80C79D18
 	.bss        start:0x80C8EDE8 end:0x80C8EDF0
 
-band3/game/Metronome.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Metronome.o:
 	.text       start:0x801AB0C0 end:0x801AB5E0
 	.rodata     start:0x80B35038 end:0x80B35040
 	.data       start:0x80B7F270 end:0x80B7F2C0
 
-band3/game/MultiplayerAnalyzer.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/MultiplayerAnalyzer.o:
 	.text       start:0x801AB5E0 end:0x801AE2F0
 	.data       start:0x80B7F2C0 end:0x80B7F4B8
 
-band3/game/NetGameMsgs.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/NetGameMsgs.o:
 	.text       start:0x801AE2F0 end:0x801B3F40
 	.data       start:0x80B7F4B8 end:0x80B7FF50
 	.sbss       start:0x80C79D18 end:0x80C79D20
 	.bss        start:0x80C8EDF0 end:0x80C8EE78
 
-band3/game/OverdriveTimeTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/OverdriveTimeTracker.o:
 	.text       start:0x801B3F40 end:0x801B48D0
 	.data       start:0x80B7FF50 end:0x80B80008
 
-band3/game/OverdriveTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/OverdriveTracker.o:
 	.text       start:0x801B48D0 end:0x801B65B0
 	.data       start:0x80B80008 end:0x80B80118
 	.sdata      start:0x80C78B48 end:0x80C78B50
 	.sbss       start:0x80C79D20 end:0x80C79D28
 	.bss        start:0x80C8EE78 end:0x80C8EE90
 
-band3/game/PerfectOverdriveTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/PerfectOverdriveTracker.o:
 	.text       start:0x801B65B0 end:0x801B8950
 	.data       start:0x80B80118 end:0x80B80228
 	.sdata      start:0x80C78B50 end:0x80C78B58
 
-band3/game/PerfectSectionTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/PerfectSectionTracker.o:
 	.text       start:0x801B8950 end:0x801BCE50
 	.data       start:0x80B80228 end:0x80B803B8
 	.sdata      start:0x80C78B58 end:0x80C78B68
 	.sbss       start:0x80C79D28 end:0x80C79D30
 	.bss        start:0x80C8EE90 end:0x80C8EEA8
 
-band3/game/Performer.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Performer.o:
 	.text       start:0x801BCE50 end:0x801C0B60
 	.rodata     start:0x80B35040 end:0x80B35050
 	.data       start:0x80B803B8 end:0x80B806B0
 
-band3/game/Player.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Player.o:
 	.text       start:0x801C0B60 end:0x801C7380
 	.rodata     start:0x80B35050 end:0x80B35058
 	.data       start:0x80B806B0 end:0x80B80BE0
 	.sbss       start:0x80C79D30 end:0x80C79D38
 	.bss        start:0x80C8EEA8 end:0x80C8EF38
 
-band3/game/PlayerBehavior.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/PlayerBehavior.o:
 	.text       start:0x801C7380 end:0x801C7470
 	.data       start:0x80B80BE0 end:0x80B80BE8
 
-band3/game/PracticePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/PracticePanel.o:
 	.text       start:0x801C7470 end:0x801CA310
 	.rodata     start:0x80B35058 end:0x80B35060
 	.data       start:0x80B80BE8 end:0x80B80E58
 	.sbss       start:0x80C79D38 end:0x80C79D40
 	.bss        start:0x80C8EF38 end:0x80C8EF80
 
-band3/game/PracticeSectionProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/PracticeSectionProvider.o:
 	.text       start:0x801CA310 end:0x801CBD00
 	.data       start:0x80B80E58 end:0x80B810C0
 
-band3/game/RealGuitarGemPlayer.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/RealGuitarGemPlayer.o:
 	.text       start:0x801CBD00 end:0x801CCAC0
 	.data       start:0x80B810C0 end:0x80B81500
 	.sbss       start:0x80C79D40 end:0x80C79D48
 
-band3/game/RGTrainerPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/RGTrainerPanel.o:
 	.text       start:0x801CCAC0 end:0x801D1FA0
 	.rodata     start:0x80B35060 end:0x80B35068
 	.data       start:0x80B81500 end:0x80B81B28
 	.sbss       start:0x80C79D48 end:0x80C79D58
 	.bss        start:0x80C8EF80 end:0x80C8F030
 
-band3/game/RGTutor.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/RGTutor.o:
 	.text       start:0x801D1FA0 end:0x801D2A30
 	.data       start:0x80B81B28 end:0x80B81B30
 	.sdata      start:0x80C78B68 end:0x80C78B70
 
-band3/game/RKTrainerPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/RKTrainerPanel.o:
 	.text       start:0x801D2A30 end:0x801D31B0
 	.data       start:0x80B81B30 end:0x80B81CD8
 	.sbss       start:0x80C79D58 end:0x80C79D60
 	.bss        start:0x80C8F030 end:0x80C8F038
 
-band3/game/ScoreTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/ScoreTracker.o:
 	.text       start:0x801D31B0 end:0x801D3590
 	.data       start:0x80B81CD8 end:0x80B81D78
 
-band3/game/ScoreUtl.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/ScoreUtl.o:
 	.text       start:0x801D3590 end:0x801D35E0
 
-band3/game/Scoring.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Scoring.o:
 	.text       start:0x801D35E0 end:0x801D6120
 	.data       start:0x80B81D78 end:0x80B82178
 	.bss        start:0x80C8F038 end:0x80C8F040
 
-band3/game/Shuttle.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Shuttle.o:
 	.text       start:0x801D6120 end:0x801D6230
 
-band3/game/Singer.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Singer.o:
 	.text       start:0x801D6230 end:0x801DB290
 	.ctors      start:0x80B34950 end:0x80B34954
 	.rodata     start:0x80B35068 end:0x80B35078
 	.data       start:0x80B82178 end:0x80B82530
 	.bss        start:0x80C8F040 end:0x80C8F048
 
-band3/game/SongDB.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/SongDB.o:
 	.text       start:0x801DB290 end:0x801E1CA0
 	.data       start:0x80B82530 end:0x80B82940
 	.sdata      start:0x80C78B70 end:0x80C78B78
 	.bss        start:0x80C8F048 end:0x80C8F050
 
-band3/game/StatCollector.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/StatCollector.o:
 	.text       start:0x801E1CA0 end:0x801E2070
 
-band3/game/StatMemberTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/StatMemberTracker.o:
 	.text       start:0x801E2070 end:0x801E2A30
 	.data       start:0x80B82940 end:0x80B82A98
 	.sdata      start:0x80C78B78 end:0x80C78B80
 
-band3/game/Stats.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Stats.o:
 	.text       start:0x801E2A30 end:0x801E8080
 	.data       start:0x80B82A98 end:0x80B82E98
 
-band3/game/StreakTracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/StreakTracker.o:
 	.text       start:0x801E8080 end:0x801E9AF0
 	.data       start:0x80B82E98 end:0x80B82F58
 	.sdata      start:0x80C78B80 end:0x80C78B88
 
-band3/game/SyncGameStartPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/SyncGameStartPanel.o:
 	.text       start:0x801E9AF0 end:0x801EB160
 	.data       start:0x80B82F58 end:0x80B831C0
 	.sbss       start:0x80C79D60 end:0x80C79D68
 	.bss        start:0x80C8F050 end:0x80C8F060
 
-band3/game/TambourineDetector.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TambourineDetector.o:
 	.text       start:0x801EB160 end:0x801EB490
 	.ctors      start:0x80B34954 end:0x80B34958
 	.data       start:0x80B831C0 end:0x80B83248
 	.bss        start:0x80C8F060 end:0x80C8F068
 
-band3/game/TambourineManager.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TambourineManager.o:
 	.text       start:0x801EB490 end:0x801EDF70
 	.data       start:0x80B83248 end:0x80B83498
 	.sbss       start:0x80C79D68 end:0x80C79D70
 	.bss        start:0x80C8F068 end:0x80C8F0A8
 
-band3/game/Tracker.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/Tracker.o:
 	.text       start:0x801EDF70 end:0x801EFF10
 	.data       start:0x80B83498 end:0x80B835C0
 	.sbss       start:0x80C79D70 end:0x80C79D78
 	.bss        start:0x80C8F0A8 end:0x80C8F0D0
 
-band3/game/TrackerDisplay.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TrackerDisplay.o:
 	.text       start:0x801EFF10 end:0x801F3CD0
 	.rodata     start:0x80B35078 end:0x80B35080
 	.data       start:0x80B835C0 end:0x80B83728
 	.sbss       start:0x80C79D78 end:0x80C79D98
 	.bss        start:0x80C8F0D0 end:0x80C8F2D8
 
-band3/game/TrackerManager.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TrackerManager.o:
 	.text       start:0x801F3CD0 end:0x801F5E50
 	.data       start:0x80B83728 end:0x80B83F00
 	.sdata      start:0x80C78B88 end:0x80C78BD0
 
-band3/game/TrackerSource.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TrackerSource.o:
 	.text       start:0x801F5E50 end:0x801F6C90
 	.data       start:0x80B83F00 end:0x80B84060
 
-band3/game/TrackerUtils.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TrackerUtils.o:
 	.text       start:0x801F6C90 end:0x801F8A20
 	.data       start:0x80B84060 end:0x80B84188
 	.sdata      start:0x80C78BD0 end:0x80C78BD8
 
-band3/game/TrainerGemTab.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TrainerGemTab.o:
 	.text       start:0x801F8A20 end:0x801FF180
 	.rodata     start:0x80B35080 end:0x80B35090
 	.data       start:0x80B84188 end:0x80B84838
 
-band3/game/TrainerPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TrainerPanel.o:
 	.text       start:0x801FF180 end:0x80203300
 	.data       start:0x80B84838 end:0x80B84BC0
 	.sdata      start:0x80C78BD8 end:0x80C78BE0
 	.sbss       start:0x80C79D98 end:0x80C79DA0
 	.bss        start:0x80C8F2D8 end:0x80C8F2F0
 
-band3/game/TrainerProgressMeter.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/TrainerProgressMeter.o:
 	.text       start:0x80203300 end:0x80204350
 	.rodata     start:0x80B35090 end:0x80B35098
 	.data       start:0x80B84BC0 end:0x80B84D00
 	.sdata      start:0x80C78BE0 end:0x80C78BE8
 
-band3/game/UISyncNetMsgs.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/UISyncNetMsgs.o:
 	.text       start:0x80204350 end:0x80205BA0
 	.data       start:0x80B84D00 end:0x80B850B0
 	.sbss       start:0x80C79DA0 end:0x80C79DA8
 	.bss        start:0x80C8F2F0 end:0x80C8F338
 
-band3/game/UITransitionNetMsgs.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/UITransitionNetMsgs.o:
 	.text       start:0x80205BA0 end:0x80206670
 	.data       start:0x80B850B0 end:0x80B85468
 
-band3/game/VocalGuidePitch.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/VocalGuidePitch.o:
 	.text       start:0x80206670 end:0x80207710
 	.rodata     start:0x80B35098 end:0x80B350A0
 	.data       start:0x80B85468 end:0x80B854D8
 
-band3/game/VocalOverlay.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/VocalOverlay.o:
 	.text       start:0x80207710 end:0x80208740
 	.ctors      start:0x80B34958 end:0x80B3495C
 	.data       start:0x80B854D8 end:0x80B855F8
 	.bss        start:0x80C8F338 end:0x80C8F340
 
-band3/game/VocalPart.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/VocalPart.o:
 	.text       start:0x80208740 end:0x8020BB20
 	.rodata     start:0x80B350A0 end:0x80B350D8
 	.data       start:0x80B855F8 end:0x80B85910
 	.sbss       start:0x80C79DA8 end:0x80C79DB0
 
-band3/game/VocalPlayer.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/VocalPlayer.o:
 	.text       start:0x8020BB20 end:0x80218310
 	.ctors      start:0x80B3495C end:0x80B34960
 	.rodata     start:0x80B350D8 end:0x80B350F0
@@ -2467,193 +2467,193 @@ band3/game/VocalPlayer.cpp:
 	.sbss       start:0x80C79DB0 end:0x80C79DB8
 	.bss        start:0x80C8F340 end:0x80C8F390
 
-band3/game/VocalScoreHistory.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/VocalScoreHistory.o:
 	.text       start:0x80218310 end:0x80218690
 	.data       start:0x80B86890 end:0x80B868E8
 
-band3/game/VocalTrainerPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/VocalTrainerPanel.o:
 	.text       start:0x80218690 end:0x8021C350
 	.data       start:0x80B868E8 end:0x80B86ED0
 	.sbss       start:0x80C79DB8 end:0x80C79DC0
 	.bss        start:0x80C8F390 end:0x80C8F3A8
 
-band3/game/PresenceMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/game/wii_release/PresenceMgr.o:
 	.text       start:0x8021C350 end:0x8021D9F0
 	.ctors      start:0x80B34960 end:0x80B34964
 	.data       start:0x80B86ED0 end:0x80B87050
 	.sbss       start:0x80C79DC0 end:0x80C79DC8
 	.bss        start:0x80C8F3A8 end:0x80C8F400
 
-band3/meta_band/AccomplishmentManager.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentManager.o:
 	.text       start:0x8021D9F0 end:0x8022F430
 	.data       start:0x80B87050 end:0x80B87BA0
 	.sdata      start:0x80C78C60 end:0x80C78C88
 	.bss        start:0x80C8F400 end:0x80C8F408
 
-band3/meta_band/AccomplishmentOneShot.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentOneShot.o:
 	.text       start:0x8022F430 end:0x8022FDE0
 	.data       start:0x80B87BA0 end:0x80B87CB8
 
-band3/meta_band/AccomplishmentPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentPanel.o:
 	.text       start:0x8022FDE0 end:0x80240AE0
 	.rodata     start:0x80B350F0 end:0x80B35108
 	.data       start:0x80B87CB8 end:0x80B88EB0
 	.sbss       start:0x80C79DC8 end:0x80C79DE0
 	.bss        start:0x80C8F408 end:0x80C8F560
 
-band3/meta_band/AccomplishmentProgress.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentProgress.o:
 	.text       start:0x80240AE0 end:0x80246870
 	.data       start:0x80B88EB0 end:0x80B89370
 	.sbss       start:0x80C79DE0 end:0x80C79DE8
 	.bss        start:0x80C8F560 end:0x80C8F568
 
-band3/meta_band/Accomplishment.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/Accomplishment.o:
 	.text       start:0x80246870 end:0x80248570
 	.data       start:0x80B89370 end:0x80B895B8
 	.sdata      start:0x80C78C88 end:0x80C78C90
 
-band3/meta_band/AccomplishmentCategory.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentCategory.o:
 	.text       start:0x80248570 end:0x802487B0
 	.data       start:0x80B895B8 end:0x80B89650
 
-band3/meta_band/AccomplishmentConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentConditional.o:
 	.text       start:0x802487B0 end:0x802490A0
 	.data       start:0x80B89650 end:0x80B897B0
 
-band3/meta_band/AccomplishmentDiscSongConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentDiscSongConditional.o:
 	.text       start:0x802490A0 end:0x80249DE0
 	.data       start:0x80B897B0 end:0x80B898E0
 
-band3/meta_band/AccomplishmentGroup.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentGroup.o:
 	.text       start:0x80249DE0 end:0x8024A110
 	.data       start:0x80B898E0 end:0x80B89A20
 
-band3/meta_band/AccomplishmentLessonSongListConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentLessonSongListConditional.o:
 	.text       start:0x8024A110 end:0x8024A4A0
 	.data       start:0x80B89A20 end:0x80B89C18
 
-band3/meta_band/AccomplishmentLessonDiscSongConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentLessonDiscSongConditional.o:
 	.text       start:0x8024A4A0 end:0x8024A7E0
 	.data       start:0x80B89C18 end:0x80B89DC8
 
-band3/meta_band/AccomplishmentPlayerConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentPlayerConditional.o:
 	.text       start:0x8024A7E0 end:0x8024C700
 	.data       start:0x80B89DC8 end:0x80B89F50
 
-band3/meta_band/AccomplishmentSetlist.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentSetlist.o:
 	.text       start:0x8024C700 end:0x8024CA20
 	.data       start:0x80B89F50 end:0x80B89FD8
 
-band3/meta_band/AccomplishmentSongConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentSongConditional.o:
 	.text       start:0x8024CA20 end:0x8024DCB0
 	.data       start:0x80B89FD8 end:0x80B8A208
 
-band3/meta_band/AccomplishmentSongFilterConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentSongFilterConditional.o:
 	.text       start:0x8024DCB0 end:0x8024EED0
 	.data       start:0x80B8A208 end:0x80B8A350
 
-band3/meta_band/AccomplishmentSongListConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentSongListConditional.o:
 	.text       start:0x8024EED0 end:0x8024F420
 	.data       start:0x80B8A350 end:0x80B8A400
 
-band3/meta_band/AccomplishmentTourConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentTourConditional.o:
 	.text       start:0x8024F420 end:0x8024FF30
 	.data       start:0x80B8A400 end:0x80B8A5E8
 
-band3/meta_band/AccomplishmentTrainerConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentTrainerConditional.o:
 	.text       start:0x8024FF30 end:0x80250480
 	.data       start:0x80B8A5E8 end:0x80B8A708
 
-band3/meta_band/AccomplishmentTrainerListConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentTrainerListConditional.o:
 	.text       start:0x80250480 end:0x802508B0
 	.data       start:0x80B8A708 end:0x80B8A808
 
-band3/meta_band/AccomplishmentTrainerCategoryConditional.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AccomplishmentTrainerCategoryConditional.o:
 	.text       start:0x802508B0 end:0x80251210
 	.data       start:0x80B8A808 end:0x80B8A968
 
-band3/meta_band/AppInlineHelp.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AppInlineHelp.o:
 	.text       start:0x80251210 end:0x802530D0
 	.data       start:0x80B8A968 end:0x80B8AD58
 	.sbss       start:0x80C79DE8 end:0x80C79DF0
 	.bss        start:0x80C8F568 end:0x80C8F578
 
-band3/meta_band/AppLabel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AppLabel.o:
 	.text       start:0x802530D0 end:0x80257FF0
 	.data       start:0x80B8AD58 end:0x80B8B460
 	.sbss       start:0x80C79DF0 end:0x80C79DF8
 	.bss        start:0x80C8F578 end:0x80C8F580
 
-band3/meta_band/AppMiniLeaderboardDisplay.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AppMiniLeaderboardDisplay.o:
 	.text       start:0x80257FF0 end:0x80259A80
 	.data       start:0x80B8B460 end:0x80B8B9C0
 	.sbss       start:0x80C79DF8 end:0x80C79E00
 	.bss        start:0x80C8F580 end:0x80C8F588
 
-band3/meta_band/AppScoreDisplay.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AppScoreDisplay.o:
 	.text       start:0x80259A80 end:0x8025A0C0
 	.data       start:0x80B8B9C0 end:0x80B8BC90
 	.sbss       start:0x80C79E00 end:0x80C79E08
 	.bss        start:0x80C8F588 end:0x80C8F590
 
-band3/meta_band/Asset.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/Asset.o:
 	.text       start:0x8025A0C0 end:0x8025A6B0
 	.data       start:0x80B8BC90 end:0x80B8BD50
 
-band3/meta_band/AssetMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AssetMgr.o:
 	.text       start:0x8025A6B0 end:0x8025D230
 	.data       start:0x80B8BD50 end:0x80B8C028
 	.sdata      start:0x80C78C90 end:0x80C78C98
 	.bss        start:0x80C8F590 end:0x80C8F598
 
-band3/meta_band/AssetOffer.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AssetOffer.o:
 	.text       start:0x8025D230 end:0x8025D290
 
-band3/meta_band/AssetProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AssetProvider.o:
 	.text       start:0x8025D290 end:0x8025F300
 	.data       start:0x80B8C028 end:0x80B8C238
 
-band3/meta_band/AssetStore.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AssetStore.o:
 	.text       start:0x8025F300 end:0x8025F300
 
-band3/meta_band/AssetTypes.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/AssetTypes.o:
 	.text       start:0x8025F300 end:0x8025FC40
 	.data       start:0x80B8C238 end:0x80B8C4C0
 
-band3/meta_band/Award.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/Award.o:
 	.text       start:0x8025FC40 end:0x80260960
 	.data       start:0x80B8C4C0 end:0x80B8C668
 
-band3/meta_band/BandNetGameData.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandNetGameData.o:
 	.text       start:0x80260960 end:0x80261F80
 	.rodata     start:0x80B35108 end:0x80B35110
 	.data       start:0x80B8C668 end:0x80B8C8F8
 
-band3/meta_band/BandPreloadPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandPreloadPanel.o:
 	.text       start:0x80261F80 end:0x80262CA0
 	.data       start:0x80B8C8F8 end:0x80B8CB18
 	.sbss       start:0x80C79E08 end:0x80C79E10
 	.bss        start:0x80C8F598 end:0x80C8F5A8
 
-band3/meta_band/BandProfile.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandProfile.o:
 	.text       start:0x80262CA0 end:0x802694E0
 	.data       start:0x80B8CB18 end:0x80B8D640
 	.sdata      start:0x80C78C98 end:0x80C78CA0
 	.sbss       start:0x80C79E10 end:0x80C79E18
 	.bss        start:0x80C8F5A8 end:0x80C8F608
 
-band3/meta_band/BandScreen.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandScreen.o:
 	.text       start:0x802694E0 end:0x80269E10
 	.data       start:0x80B8D640 end:0x80B8D788
 	.sbss       start:0x80C79E18 end:0x80C79E20
 	.bss        start:0x80C8F608 end:0x80C8F610
 
-band3/meta_band/BandSongMetadata.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandSongMetadata.o:
 	.text       start:0x80269E10 end:0x8026F5D0
 	.data       start:0x80B8D788 end:0x80B8D950
 	.sdata      start:0x80C78CA0 end:0x80C78CA8
 
-band3/meta_band/BandSongMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandSongMgr.o:
 	.text       start:0x8026F5D0 end:0x80277E30
 	.ctors      start:0x80B34964 end:0x80B34968
 	.rodata     start:0x80B35110 end:0x80B35238
@@ -2662,80 +2662,80 @@ band3/meta_band/BandSongMgr.cpp:
 	.sbss       start:0x80C79E20 end:0x80C79E28
 	.bss        start:0x80C8F610 end:0x80C8F790
 
-band3/meta_band/BandStoreOffer.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandStoreOffer.o:
 	.text       start:0x80277E30 end:0x80278670
 	.data       start:0x80B8E0A8 end:0x80B8E178
 
-band3/meta_band/BandStorePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandStorePanel.o:
 	.text       start:0x80278670 end:0x8027C610
 	.data       start:0x80B8E178 end:0x80B8E5D0
 	.sbss       start:0x80C79E28 end:0x80C79E30
 	.bss        start:0x80C8F790 end:0x80C8F7E0
 
-band3/meta_band/BandStoreUIPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandStoreUIPanel.o:
 	.text       start:0x8027C610 end:0x8027CE70
 	.data       start:0x80B8E5D0 end:0x80B8E778
 	.sbss       start:0x80C79E30 end:0x80C79E38
 	.bss        start:0x80C8F7E0 end:0x80C8F7E8
 
-band3/meta_band/BandUI.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandUI.o:
 	.text       start:0x8027CE70 end:0x802833E0
 	.ctors      start:0x80B34968 end:0x80B3496C
 	.data       start:0x80B8E778 end:0x80B8F180
 	.sbss       start:0x80C79E38 end:0x80C79E50
 	.bss        start:0x80C8F7E8 end:0x80C8FA40
 
-band3/meta_band/Campaign.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/Campaign.o:
 	.text       start:0x802833E0 end:0x8028A6A0
 	.data       start:0x80B8F180 end:0x80B8F770
 	.sdata      start:0x80C78CB8 end:0x80C78CC0
 	.sbss       start:0x80C79E50 end:0x80C79E58
 	.bss        start:0x80C8FA40 end:0x80C8FA68
 
-band3/meta_band/CampaignKey.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CampaignKey.o:
 	.text       start:0x8028A6A0 end:0x8028A7F0
 	.data       start:0x80B8F770 end:0x80B8F7C0
 
-band3/meta_band/CampaignLeaderboards.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CampaignLeaderboards.o:
 	.text       start:0x8028A7F0 end:0x8028AF10
 	.data       start:0x80B8F7C0 end:0x80B8FA58
 
-band3/meta_band/CampaignSongInfoPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CampaignSongInfoPanel.o:
 	.text       start:0x8028AF10 end:0x8028D650
 	.data       start:0x80B8FA58 end:0x80B8FE28
 	.sbss       start:0x80C79E58 end:0x80C79E60
 	.bss        start:0x80C8FA68 end:0x80C8FA70
 
-band3/meta_band/CalibrationPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CalibrationPanel.o:
 	.text       start:0x8028D650 end:0x80295F10
 	.rodata     start:0x80B35238 end:0x80B352A8
 	.data       start:0x80B8FE28 end:0x80B907F8
 	.sbss       start:0x80C79E60 end:0x80C79E70
 	.bss        start:0x80C8FA70 end:0x80C8FAD0
 
-band3/meta_band/CampaignLevel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CampaignLevel.o:
 	.text       start:0x80295F10 end:0x80296290
 	.data       start:0x80B907F8 end:0x80B90880
 
-band3/meta_band/CampaignGoalsLeaderboardPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CampaignGoalsLeaderboardPanel.o:
 	.text       start:0x80296290 end:0x80297FD0
 	.data       start:0x80B90880 end:0x80B90AE0
 	.sbss       start:0x80C79E70 end:0x80C79E78
 	.bss        start:0x80C8FAD0 end:0x80C8FB00
 
-band3/meta_band/CampaignCareerLeaderboardPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CampaignCareerLeaderboardPanel.o:
 	.text       start:0x80297FD0 end:0x80299990
 	.data       start:0x80B90AE0 end:0x80B90D40
 	.sbss       start:0x80C79E78 end:0x80C79E80
 	.bss        start:0x80C8FB00 end:0x80C8FB30
 
-band3/meta_band/CampaignGoalsLeaderboardChoicePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CampaignGoalsLeaderboardChoicePanel.o:
 	.text       start:0x80299990 end:0x8029C600
 	.data       start:0x80B90D40 end:0x80B91230
 	.sbss       start:0x80C79E80 end:0x80C79E88
 	.bss        start:0x80C8FB30 end:0x80C8FB50
 
-band3/meta_band/CharacterCreatorPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CharacterCreatorPanel.o:
 	.text       start:0x8029C600 end:0x802A2420
 	.rodata     start:0x80B352A8 end:0x80B352B0
 	.data       start:0x80B91230 end:0x80B919E8
@@ -2743,233 +2743,233 @@ band3/meta_band/CharacterCreatorPanel.cpp:
 	.sbss       start:0x80C79E88 end:0x80C79E90
 	.bss        start:0x80C8FB50 end:0x80C8FB98
 
-band3/meta_band/CharCache.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CharCache.o:
 	.text       start:0x802A2420 end:0x802A3CF0
 	.data       start:0x80B919E8 end:0x80B91CE8
 	.bss        start:0x80C8FB98 end:0x80C8FBA0
 
-band3/meta_band/CharData.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CharData.o:
 	.text       start:0x802A3CF0 end:0x802A4A00
 	.data       start:0x80B91CE8 end:0x80B91F28
 	.sbss       start:0x80C79E90 end:0x80C79E98
 	.bss        start:0x80C8FBA0 end:0x80C8FBB0
 
-band3/meta_band/CharSync.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CharSync.o:
 	.text       start:0x802A4A00 end:0x802A67E0
 	.data       start:0x80B91F28 end:0x80B920B8
 	.sbss       start:0x80C79E98 end:0x80C79EA0
 	.bss        start:0x80C8FBB0 end:0x80C8FBB8
 
-band3/meta_band/CharProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CharProvider.o:
 	.text       start:0x802A67E0 end:0x802A96E0
 	.data       start:0x80B920B8 end:0x80B92330
 
-band3/meta_band/ChooseColorPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ChooseColorPanel.o:
 	.text       start:0x802A96E0 end:0x802AAD00
 	.data       start:0x80B92330 end:0x80B92538
 	.sdata      start:0x80C78CC8 end:0x80C78CD0
 	.sbss       start:0x80C79EA0 end:0x80C79EA8
 	.bss        start:0x80C8FBB8 end:0x80C8FBC0
 
-band3/meta_band/ClosetMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ClosetMgr.o:
 	.text       start:0x802AAD00 end:0x802ADCD0
 	.data       start:0x80B92538 end:0x80B92A18
 	.sbss       start:0x80C79EA8 end:0x80C79EB0
 	.bss        start:0x80C8FBC0 end:0x80C8FBF8
 
-band3/meta_band/ClosetPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ClosetPanel.o:
 	.text       start:0x802ADCD0 end:0x802AF170
 	.data       start:0x80B92A18 end:0x80B92C38
 	.sbss       start:0x80C79EB0 end:0x80C79EB8
 	.bss        start:0x80C8FBF8 end:0x80C8FC00
 
-band3/meta_band/ContentDeletePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ContentDeletePanel.o:
 	.text       start:0x802AF170 end:0x802B0240
 	.data       start:0x80B92C38 end:0x80B92E00
 	.sbss       start:0x80C79EB8 end:0x80C79EC0
 	.bss        start:0x80C8FC00 end:0x80C8FC08
 
-band3/meta_band/ContentLoadingPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ContentLoadingPanel.o:
 	.text       start:0x802B0240 end:0x802B1AB0
 	.data       start:0x80B92E00 end:0x80B930A8
 	.sbss       start:0x80C79EC0 end:0x80C79EC8
 	.bss        start:0x80C8FC08 end:0x80C8FC10
 
-band3/meta_band/ContextChecker.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ContextChecker.o:
 	.text       start:0x802B1AB0 end:0x802B3970
 	.ctors      start:0x80B3496C end:0x80B34970
 	.data       start:0x80B930A8 end:0x80B93318
 	.sbss       start:0x80C79EC8 end:0x80C79EE0
 	.bss        start:0x80C8FC10 end:0x80C900B0
 
-band3/meta_band/CriticalUserListener.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CriticalUserListener.o:
 	.text       start:0x802B3970 end:0x802B47E0
 	.data       start:0x80B93318 end:0x80B93400
 	.sbss       start:0x80C79EE0 end:0x80C79EE8
 	.bss        start:0x80C900B0 end:0x80C900C8
 
-band3/meta_band/CurrentOutfitProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CurrentOutfitProvider.o:
 	.text       start:0x802B47E0 end:0x802B5310
 	.data       start:0x80B93400 end:0x80B935E0
 
-band3/meta_band/CustomizePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CustomizePanel.o:
 	.text       start:0x802B5310 end:0x802BAFE0
 	.rodata     start:0x80B352B0 end:0x80B352C8
 	.data       start:0x80B935E0 end:0x80B94108
 	.sbss       start:0x80C79EE8 end:0x80C79EF0
 	.bss        start:0x80C900C8 end:0x80C90110
 
-band3/meta_band/CymbalSelectionProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/CymbalSelectionProvider.o:
 	.text       start:0x802BAFE0 end:0x802BB860
 	.data       start:0x80B94108 end:0x80B94280
 
-band3/meta_band/EditSetlistPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/EditSetlistPanel.o:
 	.text       start:0x802BB860 end:0x802BE5A0
 	.data       start:0x80B94280 end:0x80B94620
 	.sbss       start:0x80C79EF0 end:0x80C79EF8
 	.bss        start:0x80C90110 end:0x80C90130
 
-band3/meta_band/EventDialogPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/EventDialogPanel.o:
 	.text       start:0x802BE5A0 end:0x802BF510
 	.data       start:0x80B94620 end:0x80B947B0
 	.sbss       start:0x80C79EF8 end:0x80C79F00
 	.bss        start:0x80C90130 end:0x80C90138
 
-band3/meta_band/EyebrowsProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/EyebrowsProvider.o:
 	.text       start:0x802BF510 end:0x802BFB00
 	.data       start:0x80B947B0 end:0x80B94940
 
-band3/meta_band/FaceHairProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/FaceHairProvider.o:
 	.text       start:0x802BFB00 end:0x802C0080
 	.data       start:0x80B94940 end:0x80B94AB0
 
-band3/meta_band/FaceTypeProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/FaceTypeProvider.o:
 	.text       start:0x802C0080 end:0x802C04A0
 	.data       start:0x80B94AB0 end:0x80B94C18
 
-band3/meta_band/GameplayOptions.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/GameplayOptions.o:
 	.text       start:0x802C04A0 end:0x802C0E90
 	.data       start:0x80B94C18 end:0x80B94D30
 
-band3/meta_band/GameTimePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/GameTimePanel.o:
 	.text       start:0x802C0E90 end:0x802C14D0
 	.data       start:0x80B94D30 end:0x80B94E60
 	.sbss       start:0x80C79F00 end:0x80C79F08
 	.bss        start:0x80C90138 end:0x80C90140
 
-band3/meta_band/HeaderPerformanceProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/HeaderPerformanceProvider.o:
 	.text       start:0x802C14D0 end:0x802C28E0
 	.data       start:0x80B94E60 end:0x80B954D0
 	.sdata      start:0x80C78CD0 end:0x80C78CD8
 
-band3/meta_band/InputMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/InputMgr.o:
 	.text       start:0x802C28E0 end:0x802C5240
 	.data       start:0x80B954D0 end:0x80B95668
 	.sbss       start:0x80C79F08 end:0x80C79F10
 	.bss        start:0x80C90140 end:0x80C90170
 
-band3/meta_band/Instarank.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/Instarank.o:
 	.text       start:0x802C5240 end:0x802C6940
 	.data       start:0x80B95668 end:0x80B95720
 
-band3/meta_band/InstrumentFinishProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/InstrumentFinishProvider.o:
 	.text       start:0x802C6940 end:0x802C6DB0
 	.data       start:0x80B95720 end:0x80B958A0
 
-band3/meta_band/InterstitialMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/InterstitialMgr.o:
 	.text       start:0x802C6DB0 end:0x802C9AC0
 	.data       start:0x80B958A0 end:0x80B95A38
 	.sdata      start:0x80C78CD8 end:0x80C78CE8
 	.sbss       start:0x80C79F10 end:0x80C79F18
 	.bss        start:0x80C90170 end:0x80C90188
 
-band3/meta_band/InterstitialPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/InterstitialPanel.o:
 	.text       start:0x802C9AC0 end:0x802CAD30
 	.data       start:0x80B95A38 end:0x80B95CF8
 	.sbss       start:0x80C79F18 end:0x80C79F20
 	.bss        start:0x80C90188 end:0x80C90198
 
-band3/meta_band/JoinInvitePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/JoinInvitePanel.o:
 	.text       start:0x802CAD30 end:0x802CC5C0
 	.data       start:0x80B95CF8 end:0x80B96190
 	.sbss       start:0x80C79F20 end:0x80C79F28
 	.bss        start:0x80C90198 end:0x80C901C0
 
-band3/meta_band/Leaderboard.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/Leaderboard.o:
 	.text       start:0x802CC5C0 end:0x802CFAF0
 	.rodata     start:0x80B352C8 end:0x80B352D0
 	.data       start:0x80B96190 end:0x80B965F0
 
-band3/meta_band/LessonMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/LessonMgr.o:
 	.text       start:0x802CFAF0 end:0x802D1380
 	.data       start:0x80B965F0 end:0x80B96768
 	.sdata      start:0x80C78CE8 end:0x80C78CF0
 	.bss        start:0x80C901C0 end:0x80C901C8
 
-band3/meta_band/LessonProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/LessonProvider.o:
 	.text       start:0x802D1380 end:0x802D2230
 	.data       start:0x80B96768 end:0x80B969A0
 
-band3/meta_band/LicenseMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/LicenseMgr.o:
 	.text       start:0x802D2230 end:0x802D26A0
 	.data       start:0x80B969A0 end:0x80B96A70
 
-band3/meta_band/LockStepMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/LockStepMgr.o:
 	.text       start:0x802D26A0 end:0x802D5110
 	.data       start:0x80B96A70 end:0x80B96EA8
 	.sbss       start:0x80C79F28 end:0x80C79F30
 	.bss        start:0x80C901C8 end:0x80C90210
 
-band3/meta_band/BandMachine.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandMachine.o:
 	.text       start:0x802D5110 end:0x802D6830
 	.data       start:0x80B96EA8 end:0x80B97060
 
-band3/meta_band/BandMachineMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandMachineMgr.o:
 	.text       start:0x802D6830 end:0x802D9DF0
 	.data       start:0x80B97060 end:0x80B973F8
 	.sdata      start:0x80C78CF0 end:0x80C78CF8
 	.sbss       start:0x80C79F30 end:0x80C79F38
 	.bss        start:0x80C90210 end:0x80C90270
 
-band3/meta_band/MakeupProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MakeupProvider.o:
 	.text       start:0x802D9DF0 end:0x802DA6F0
 	.data       start:0x80B973F8 end:0x80B975F8
 
-band3/meta_band/MainHubMessageProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MainHubMessageProvider.o:
 	.text       start:0x802DA6F0 end:0x802DB790
 	.data       start:0x80B975F8 end:0x80B97950
 
-band3/meta_band/MainHubPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MainHubPanel.o:
 	.text       start:0x802DB790 end:0x802E0760
 	.data       start:0x80B97950 end:0x80B97E18
 	.sbss       start:0x80C79F38 end:0x80C79F48
 	.bss        start:0x80C90270 end:0x80C90328
 
-band3/meta_band/ManageBandPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ManageBandPanel.o:
 	.text       start:0x802E0760 end:0x802E3220
 	.data       start:0x80B97E18 end:0x80B981E8
 	.sbss       start:0x80C79F48 end:0x80C79F50
 	.bss        start:0x80C90328 end:0x80C90358
 
-band3/meta_band/Matchmaker.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/Matchmaker.o:
 	.text       start:0x802E3220 end:0x802E67D0
 	.data       start:0x80B981E8 end:0x80B98820
 	.sbss       start:0x80C79F50 end:0x80C79F58
 	.bss        start:0x80C90358 end:0x80C903C0
 
-band3/meta_band/MetaNetMsgs.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MetaNetMsgs.o:
 	.text       start:0x802E67D0 end:0x802E7720
 	.data       start:0x80B98820 end:0x80B98BD8
 	.sbss       start:0x80C79F58 end:0x80C79F60
 	.bss        start:0x80C903C0 end:0x80C903D8
 
-band3/meta_band/MetaPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MetaPanel.o:
 	.text       start:0x802E7720 end:0x802EB950
 	.data       start:0x80B98BD8 end:0x80B99200
 	.sbss       start:0x80C79F60 end:0x80C79F88
 	.bss        start:0x80C903D8 end:0x80C90468
 
-band3/meta_band/MetaPerformer.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MetaPerformer.o:
 	.text       start:0x802EB950 end:0x802F6D40
 	.ctors      start:0x80B34970 end:0x80B34974
 	.rodata     start:0x80B352D0 end:0x80B352E0
@@ -2978,101 +2978,101 @@ band3/meta_band/MetaPerformer.cpp:
 	.sbss       start:0x80C79F88 end:0x80C79F90
 	.bss        start:0x80C90468 end:0x80C904A8
 
-band3/meta_band/ModifierMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ModifierMgr.o:
 	.text       start:0x802F6D40 end:0x802F8480
 	.data       start:0x80B99AE0 end:0x80B99CF0
 	.bss        start:0x80C904A8 end:0x80C904B0
 
-band3/meta_band/MultiSelectListPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MultiSelectListPanel.o:
 	.text       start:0x802F8480 end:0x802F9CA0
 	.data       start:0x80B99CF0 end:0x80B99E78
 	.sbss       start:0x80C79F90 end:0x80C79F98
 	.bss        start:0x80C904B0 end:0x80C904B8
 
-band3/meta_band/MusicLibrary.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MusicLibrary.o:
 	.text       start:0x802F9CA0 end:0x803062B0
 	.data       start:0x80B99E78 end:0x80B9AD10
 	.sbss       start:0x80C79F98 end:0x80C79FA0
 	.bss        start:0x80C904B8 end:0x80C90530
 
-band3/meta_band/MusicLibraryNetSetlists.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/MusicLibraryNetSetlists.o:
 	.text       start:0x803062B0 end:0x80308770
 	.data       start:0x80B9AD10 end:0x80B9B130
 
-band3/meta_band/NameGenerator.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/NameGenerator.o:
 	.text       start:0x80308770 end:0x80309010
 	.data       start:0x80B9B130 end:0x80B9B278
 	.bss        start:0x80C90530 end:0x80C90538
 
-band3/meta_band/NetSync.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/NetSync.o:
 	.text       start:0x80309010 end:0x8030C7F0
 	.data       start:0x80B9B278 end:0x80B9B498
 	.sbss       start:0x80C79FA0 end:0x80C79FA8
 	.bss        start:0x80C90538 end:0x80C90550
 
-band3/meta_band/NewAssetProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/NewAssetProvider.o:
 	.text       start:0x8030C7F0 end:0x8030D130
 	.data       start:0x80B9B498 end:0x80B9B668
 
-band3/meta_band/NewAwardPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/NewAwardPanel.o:
 	.text       start:0x8030D130 end:0x8030EB60
 	.data       start:0x80B9B668 end:0x80B9BAC8
 	.sbss       start:0x80C79FA8 end:0x80C79FB0
 	.bss        start:0x80C90550 end:0x80C90568
 
-band3/meta_band/NextSongPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/NextSongPanel.o:
 	.text       start:0x8030EB60 end:0x803178D0
 	.rodata     start:0x80B352E0 end:0x80B352E8
 	.data       start:0x80B9BAC8 end:0x80B9BDD8
 	.sbss       start:0x80C79FB0 end:0x80C79FB8
 	.bss        start:0x80C90568 end:0x80C905D8
 
-band3/meta_band/OutfitProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/OutfitProvider.o:
 	.text       start:0x803178D0 end:0x80317BD0
 	.data       start:0x80B9BDD8 end:0x80B9BF30
 
-band3/meta_band/OvershellPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/OvershellPanel.o:
 	.text       start:0x80317BD0 end:0x803224C0
 	.ctors      start:0x80B34974 end:0x80B34978
 	.data       start:0x80B9BF30 end:0x80B9C670
 	.sbss       start:0x80C79FB8 end:0x80C79FC8
 	.bss        start:0x80C905D8 end:0x80C906B0
 
-band3/meta_band/OvershellPartSelectProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/OvershellPartSelectProvider.o:
 	.text       start:0x803224C0 end:0x803235B0
 	.data       start:0x80B9C670 end:0x80B9C8E8
 
-band3/meta_band/OvershellSlot.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/OvershellSlot.o:
 	.text       start:0x803235B0 end:0x80331AA0
 	.ctors      start:0x80B34978 end:0x80B3497C
 	.data       start:0x80B9C8E8 end:0x80B9D108
 	.sbss       start:0x80C79FC8 end:0x80C79FE8
 	.bss        start:0x80C906B0 end:0x80C908F8
 
-band3/meta_band/OvershellSlotState.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/OvershellSlotState.o:
 	.text       start:0x80331AA0 end:0x80332A40
 	.data       start:0x80B9D108 end:0x80B9D228
 
-band3/meta_band/ParentalControlPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ParentalControlPanel.o:
 	.text       start:0x80332A40 end:0x80332E90
 	.data       start:0x80B9D228 end:0x80B9D310
 	.sbss       start:0x80C79FE8 end:0x80C79FF0
 	.bss        start:0x80C908F8 end:0x80C90900
 
-band3/meta_band/PassiveMessagesPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/PassiveMessagesPanel.o:
 	.text       start:0x80332E90 end:0x803341E0
 	.data       start:0x80B9D310 end:0x80B9D4A8
 	.sbss       start:0x80C79FF0 end:0x80C79FF8
 	.bss        start:0x80C90900 end:0x80C90908
 
-band3/meta_band/PassiveMessenger.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/PassiveMessenger.o:
 	.text       start:0x803341E0 end:0x80338DC0
 	.rodata     start:0x80B352E8 end:0x80B352F0
 	.data       start:0x80B9D4A8 end:0x80B9D778
 	.sbss       start:0x80C79FF8 end:0x80C7A000
 	.bss        start:0x80C90908 end:0x80C90990
 
-band3/meta_band/PatchPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/PatchPanel.o:
 	.text       start:0x80338DC0 end:0x8033E9C0
 	.rodata     start:0x80B352F0 end:0x80B35318
 	.data       start:0x80B9D778 end:0x80B9E580
@@ -3080,31 +3080,31 @@ band3/meta_band/PatchPanel.cpp:
 	.sbss       start:0x80C7A000 end:0x80C7A008
 	.bss        start:0x80C90990 end:0x80C90998
 
-band3/meta_band/PatchSelectPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/PatchSelectPanel.o:
 	.text       start:0x8033E9C0 end:0x80340940
 	.data       start:0x80B9E580 end:0x80B9E8F0
 	.sbss       start:0x80C7A008 end:0x80C7A010
 	.bss        start:0x80C90998 end:0x80C909A0
 
-band3/meta_band/PerformanceData.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/PerformanceData.o:
 	.text       start:0x80340940 end:0x803444C0
 	.data       start:0x80B9E8F0 end:0x80B9F088
 
-band3/meta_band/PlayerLeaderboards.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/PlayerLeaderboards.o:
 	.text       start:0x803444C0 end:0x80344D40
 	.data       start:0x80B9F088 end:0x80B9F408
 
-band3/meta_band/PrefabMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/PrefabMgr.o:
 	.text       start:0x80344D40 end:0x80348080
 	.data       start:0x80B9F408 end:0x80B9F718
 	.sbss       start:0x80C7A010 end:0x80C7A018
 	.bss        start:0x80C909A0 end:0x80C909A8
 
-band3/meta_band/ProfileAssets.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ProfileAssets.o:
 	.text       start:0x80348080 end:0x80348AB0
 	.data       start:0x80B9F718 end:0x80B9F810
 
-band3/meta_band/ProfileMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ProfileMgr.o:
 	.text       start:0x80348AB0 end:0x80350880
 	.ctors      start:0x80B3497C end:0x80B34980
 	.rodata     start:0x80B35318 end:0x80B35368
@@ -3112,294 +3112,294 @@ band3/meta_band/ProfileMgr.cpp:
 	.sbss       start:0x80C7A018 end:0x80C7A028
 	.bss        start:0x80C909A8 end:0x80C91060
 
-band3/meta_band/RetryAudioPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/RetryAudioPanel.o:
 	.text       start:0x80350880 end:0x80351120
 	.data       start:0x80B9FF48 end:0x80BA0160
 	.sbss       start:0x80C7A028 end:0x80C7A030
 	.bss        start:0x80C91060 end:0x80C91068
 
-band3/meta_band/SavedSetlist.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SavedSetlist.o:
 	.text       start:0x80351120 end:0x80352FC0
 	.data       start:0x80BA0160 end:0x80BA04D8
 	.sbss       start:0x80C7A030 end:0x80C7A038
 	.bss        start:0x80C91068 end:0x80C91080
 
-band3/meta_band/SaveLoadManager.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SaveLoadManager.o:
 	.text       start:0x80352FC0 end:0x8035C0F0
 	.data       start:0x80BA04D8 end:0x80BA1B28
 	.sbss       start:0x80C7A038 end:0x80C7A040
 	.bss        start:0x80C91080 end:0x80C910A8
 
-band3/meta_band/SaveLoadStatusPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SaveLoadStatusPanel.o:
 	.text       start:0x8035C0F0 end:0x8035CDC0
 	.data       start:0x80BA1B28 end:0x80BA1C88
 	.sbss       start:0x80C7A040 end:0x80C7A048
 	.bss        start:0x80C910A8 end:0x80C910B0
 
-band3/meta_band/SelectDifficultyPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SelectDifficultyPanel.o:
 	.text       start:0x8035CDC0 end:0x8035ECC0
 	.data       start:0x80BA1C88 end:0x80BA1F30
 	.sbss       start:0x80C7A048 end:0x80C7A050
 	.bss        start:0x80C910B0 end:0x80C91130
 
-band3/meta_band/SessionMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SessionMgr.o:
 	.text       start:0x8035ECC0 end:0x803625A0
 	.data       start:0x80BA1F30 end:0x80BA20E8
 	.sbss       start:0x80C7A050 end:0x80C7A058
 	.bss        start:0x80C91130 end:0x80C91170
 
-band3/meta_band/SessionUsersProviders.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SessionUsersProviders.o:
 	.text       start:0x803625A0 end:0x80363550
 	.data       start:0x80BA20E8 end:0x80BA23E0
 	.sbss       start:0x80C7A058 end:0x80C7A060
 	.bss        start:0x80C91170 end:0x80C91178
 
-band3/meta_band/SetlistMergePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SetlistMergePanel.o:
 	.text       start:0x80363550 end:0x80366940
 	.data       start:0x80BA23E0 end:0x80BA2BD8
 	.sbss       start:0x80C7A060 end:0x80C7A068
 	.bss        start:0x80C91178 end:0x80C911A8
 
-band3/meta_band/SetlistSortByLocation.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SetlistSortByLocation.o:
 	.text       start:0x80366940 end:0x80367750
 	.data       start:0x80BA2BD8 end:0x80BA2EC0
 
-band3/meta_band/SetlistSortByLength.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SetlistSortByLength.o:
 	.text       start:0x80367750 end:0x80367750
 
-band3/meta_band/SetlistToStorePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SetlistToStorePanel.o:
 	.text       start:0x80367750 end:0x803686A0
 	.data       start:0x80BA2EC0 end:0x80BA30F8
 	.sbss       start:0x80C7A068 end:0x80C7A070
 	.bss        start:0x80C911A8 end:0x80C911B0
 
-band3/meta_band/ShellInputInterceptor.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ShellInputInterceptor.o:
 	.text       start:0x803686A0 end:0x80369600
 	.data       start:0x80BA30F8 end:0x80BA31E8
 	.sbss       start:0x80C7A070 end:0x80C7A078
 	.bss        start:0x80C911B0 end:0x80C911D8
 
-band3/meta_band/SigninScreen.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SigninScreen.o:
 	.text       start:0x80369600 end:0x8036A9B0
 	.data       start:0x80BA31E8 end:0x80BA33C8
 	.sbss       start:0x80C7A078 end:0x80C7A080
 	.bss        start:0x80C911D8 end:0x80C911E0
 
-band3/meta_band/SongRecord.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongRecord.o:
 	.text       start:0x8036A9B0 end:0x8036CBE0
 	.data       start:0x80BA33C8 end:0x80BA3510
 
-band3/meta_band/SongSelectPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSelectPanel.o:
 	.text       start:0x8036CBE0 end:0x8036EE40
 	.data       start:0x80BA3510 end:0x80BA3760
 	.sbss       start:0x80C7A080 end:0x80C7A088
 	.bss        start:0x80C911E0 end:0x80C91248
 
-band3/meta_band/SongSetlistProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSetlistProvider.o:
 	.text       start:0x8036EE40 end:0x8036F1E0
 	.data       start:0x80BA3760 end:0x80BA3870
 
-band3/meta_band/SongSort.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSort.o:
 	.text       start:0x8036F1E0 end:0x80371500
 	.data       start:0x80BA3870 end:0x80BA3BC8
 
-band3/meta_band/SongSortByArtist.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortByArtist.o:
 	.text       start:0x80371500 end:0x803720F0
 	.data       start:0x80BA3BC8 end:0x80BA3DE8
 
-band3/meta_band/SongSortByDiff.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortByDiff.o:
 	.text       start:0x803720F0 end:0x80372830
 	.data       start:0x80BA3DE8 end:0x80BA3F98
 
-band3/meta_band/SongSortByPlays.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortByPlays.o:
 	.text       start:0x80372830 end:0x80372DC0
 	.data       start:0x80BA3F98 end:0x80BA4150
 
-band3/meta_band/SongSortByRank.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortByRank.o:
 	.text       start:0x80372DC0 end:0x803747D0
 	.data       start:0x80BA4150 end:0x80BA43C0
 	.sdata      start:0x80C78D08 end:0x80C78D10
 
-band3/meta_band/SongSortByRecent.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortByRecent.o:
 	.text       start:0x803747D0 end:0x803750E0
 	.data       start:0x80BA43C0 end:0x80BA45A0
 
-band3/meta_band/SongSortByReview.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortByReview.o:
 	.text       start:0x803750E0 end:0x80375890
 	.data       start:0x80BA45A0 end:0x80BA4788
 
-band3/meta_band/SongSortBySong.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortBySong.o:
 	.text       start:0x80375890 end:0x80375FB0
 	.data       start:0x80BA4788 end:0x80BA4950
 
-band3/meta_band/SongSortByStars.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortByStars.o:
 	.text       start:0x80375FB0 end:0x803768F0
 	.data       start:0x80BA4950 end:0x80BA4B38
 
-band3/meta_band/SongSortMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortMgr.o:
 	.text       start:0x803768F0 end:0x8037C670
 	.data       start:0x80BA4B38 end:0x80BA4E00
 	.sdata      start:0x80C78D10 end:0x80C78D18
 	.bss        start:0x80C91248 end:0x80C91250
 
-band3/meta_band/SongSortNode.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongSortNode.o:
 	.text       start:0x8037C670 end:0x80381500
 	.data       start:0x80BA4E00 end:0x80BA5428
 
-band3/meta_band/SongStatusMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongStatusMgr.o:
 	.text       start:0x80381500 end:0x803864C0
 	.data       start:0x80BA5428 end:0x80BA56F8
 	.sbss       start:0x80C7A088 end:0x80C7A090
 	.bss        start:0x80C91250 end:0x80C912A8
 
-band3/meta_band/SongUpgradeMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/SongUpgradeMgr.o:
 	.text       start:0x803864C0 end:0x80388C90
 	.data       start:0x80BA56F8 end:0x80BA5970
 	.sdata      start:0x80C78D18 end:0x80C78D20
 	.sbss       start:0x80C7A090 end:0x80C7A098
 	.bss        start:0x80C912A8 end:0x80C912B0
 
-band3/meta_band/StandIn.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StandIn.o:
 	.text       start:0x80388C90 end:0x80389040
 	.data       start:0x80BA5970 end:0x80BA59C0
 
-band3/meta_band/StandInProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StandInProvider.o:
 	.text       start:0x80389040 end:0x80389340
 	.data       start:0x80BA59C0 end:0x80BA5B00
 
-band3/meta_band/StoreInfoPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StoreInfoPanel.o:
 	.text       start:0x80389340 end:0x8038B230
 	.data       start:0x80BA5B00 end:0x80BA5E28
 	.sbss       start:0x80C7A098 end:0x80C7A0A0
 	.bss        start:0x80C912B0 end:0x80C912B8
 
-band3/meta_band/StoreMainPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StoreMainPanel.o:
 	.text       start:0x8038B230 end:0x8038D690
 	.data       start:0x80BA5E28 end:0x80BA6118
 	.sbss       start:0x80C7A0A0 end:0x80C7A0A8
 	.bss        start:0x80C912B8 end:0x80C912C0
 
-band3/meta_band/StoreMenuPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StoreMenuPanel.o:
 	.text       start:0x8038D690 end:0x8038EC40
 	.data       start:0x80BA6118 end:0x80BA62C8
 	.sbss       start:0x80C7A0A8 end:0x80C7A0B0
 	.bss        start:0x80C912C0 end:0x80C912C8
 
-band3/meta_band/StoreMenuProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StoreMenuProvider.o:
 	.text       start:0x8038EC40 end:0x8038F920
 	.data       start:0x80BA62C8 end:0x80BA6478
 
-band3/meta_band/StoreOfferProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StoreOfferProvider.o:
 	.text       start:0x8038F920 end:0x80392970
 	.data       start:0x80BA6478 end:0x80BA66F0
 
-band3/meta_band/StoreRootPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StoreRootPanel.o:
 	.text       start:0x80392970 end:0x80393480
 	.data       start:0x80BA66F0 end:0x80BA68C8
 	.sbss       start:0x80C7A0B0 end:0x80C7A0B8
 	.bss        start:0x80C912C8 end:0x80C912D0
 
-band3/meta_band/StoreSongSortNode.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StoreSongSortNode.o:
 	.text       start:0x80393480 end:0x80393BD0
 	.data       start:0x80BA68C8 end:0x80BA6A20
 
-band3/meta_band/TabInterfacePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/TabInterfacePanel.o:
 	.text       start:0x80393BD0 end:0x80393BD0
 	.data       start:0x80BA6A20 end:0x80BA6AE8
 
-band3/meta_band/TexLoadPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/TexLoadPanel.o:
 	.text       start:0x80393BD0 end:0x80395420
 	.data       start:0x80BA6AE8 end:0x80BA6DB8
 	.sbss       start:0x80C7A0B8 end:0x80C7A0C0
 	.bss        start:0x80C912D0 end:0x80C912D8
 
-band3/meta_band/TokenRedemptionPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/TokenRedemptionPanel.o:
 	.text       start:0x80395420 end:0x803981C0
 	.data       start:0x80BA6DB8 end:0x80BA7128
 	.sbss       start:0x80C7A0C0 end:0x80C7A0C8
 	.bss        start:0x80C912D8 end:0x80C91380
 
-band3/meta_band/TrainerProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/TrainerProvider.o:
 	.text       start:0x803981C0 end:0x80398710
 	.data       start:0x80BA7128 end:0x80BA7288
 
-band3/meta_band/TrainingMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/TrainingMgr.o:
 	.text       start:0x80398710 end:0x8039A290
 	.data       start:0x80BA7288 end:0x80BA7398
 	.bss        start:0x80C91380 end:0x80C91388
 
-band3/meta_band/TrainingPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/TrainingPanel.o:
 	.text       start:0x8039A290 end:0x8039B6E0
 	.data       start:0x80BA7398 end:0x80BA7540
 	.sbss       start:0x80C7A0C8 end:0x80C7A0D0
 	.bss        start:0x80C91388 end:0x80C913A0
 
-band3/meta_band/VoiceMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/VoiceMgr.o:
 	.text       start:0x8039B6E0 end:0x8039B6E0
 
-band3/meta_band/UGCPurchasePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/UGCPurchasePanel.o:
 	.text       start:0x8039B6E0 end:0x8039CD20
 	.data       start:0x80BA7540 end:0x80BA7720
 	.sbss       start:0x80C7A0D0 end:0x80C7A0D8
 	.bss        start:0x80C913A0 end:0x80C913D0
 
-band3/meta_band/UIEvent.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/UIEvent.o:
 	.text       start:0x8039CD20 end:0x8039DF50
 	.data       start:0x80BA7720 end:0x80BA7980
 	.sbss       start:0x80C7A0D8 end:0x80C7A0E0
 	.bss        start:0x80C913D0 end:0x80C913F8
 
-band3/meta_band/UIEventMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/UIEventMgr.o:
 	.text       start:0x8039DF50 end:0x8039F9D0
 	.data       start:0x80BA7980 end:0x80BA7B10
 	.bss        start:0x80C913F8 end:0x80C91400
 
-band3/meta_band/UIStats.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/UIStats.o:
 	.text       start:0x8039F9D0 end:0x803A1990
 	.ctors      start:0x80B34980 end:0x80B34984
 	.data       start:0x80BA7B10 end:0x80BA7CD8
 	.sbss       start:0x80C7A0E0 end:0x80C7A0E8
 	.bss        start:0x80C91400 end:0x80C91500
 
-band3/meta_band/UploadErrorMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/UploadErrorMgr.o:
 	.text       start:0x803A1990 end:0x803A1F80
 	.data       start:0x80BA7CD8 end:0x80BA7DB0
 	.bss        start:0x80C91500 end:0x80C91508
 
-band3/meta_band/Utl.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/Utl.o:
 	.text       start:0x803A1F80 end:0x803A3060
 	.data       start:0x80BA7DB0 end:0x80BA8010
 	.sbss       start:0x80C7A0E8 end:0x80C7A0F0
 	.bss        start:0x80C91508 end:0x80C91520
 
-band3/meta_band/ViewSetting.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/ViewSetting.o:
 	.text       start:0x803A3060 end:0x803A6B30
 	.data       start:0x80BA8010 end:0x80BA8698
 
-band3/meta_band/VoiceoverPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/VoiceoverPanel.o:
 	.text       start:0x803A6B30 end:0x803A7FD0
 	.data       start:0x80BA8698 end:0x80BA88F0
 	.sbss       start:0x80C7A0F0 end:0x80C7A0F8
 	.bss        start:0x80C91520 end:0x80C91528
 
-band3/meta_band/WaitingUserGate.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/WaitingUserGate.o:
 	.text       start:0x803A7FD0 end:0x803AA120
 	.data       start:0x80BA88F0 end:0x80BA8C40
 
-band3/meta_band/OvershellProfileProvider_Wii.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/OvershellProfileProvider_Wii.o:
 	.text       start:0x803AA120 end:0x803ABEC0
 	.data       start:0x80BA8C40 end:0x80BA8EC8
 
-band3/meta_band/WiiBufStreamMgr.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/WiiBufStreamMgr.o:
 	.text       start:0x803ABEC0 end:0x803ABFE0
 	.ctors      start:0x80B34984 end:0x80B34988
 	.data       start:0x80BA8EC8 end:0x80BA8EF0
 
-band3/meta_band/BandMemcardAction_Wii.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/BandMemcardAction_Wii.o:
 	.text       start:0x803ABFE0 end:0x803ACB90
 	.data       start:0x80BA8EF0 end:0x80BA90D8
 
-band3/meta_band/WiiFriendsProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/WiiFriendsProvider.o:
 	.text       start:0x803ACB90 end:0x803B2020
 	.ctors      start:0x80B34988 end:0x80B3498C
 	.rodata     start:0x80B35368 end:0x80B35370
@@ -3408,167 +3408,167 @@ band3/meta_band/WiiFriendsProvider.cpp:
 	.sbss       start:0x80C7A0F8 end:0x80C7A100
 	.bss        start:0x80C91528 end:0x80C91640
 
-band3/meta_band/WiiProfilePanel.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/WiiProfilePanel.o:
 	.text       start:0x803B2020 end:0x803B38C0
 	.data       start:0x80BA9510 end:0x80BA96A8
 	.sbss       start:0x80C7A100 end:0x80C7A108
 	.bss        start:0x80C91640 end:0x80C91658
 
-band3/meta_band/WiiFriendsList.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/WiiFriendsList.o:
 	.text       start:0x803B38C0 end:0x803B4B90
 	.data       start:0x80BA96A8 end:0x80BA9918
 	.sbss       start:0x80C7A108 end:0x80C7A110
 	.bss        start:0x80C91658 end:0x80C91668
 
-band3/meta_band/StoreOfferContentsProvider.cpp:
+lib.a/hproj/band3_wii/band3/src/meta_band/wii_release/StoreOfferContentsProvider.o:
 	.text       start:0x803B4B90 end:0x803B6630
 	.data       start:0x80BA9918 end:0x80BA9AE8
 
-band3/tour/FixedSetlist.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/FixedSetlist.o:
 	.text       start:0x803B6630 end:0x803B6C60
 	.data       start:0x80BA9AE8 end:0x80BA9BB8
 
-band3/tour/GigFilter.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/GigFilter.o:
 	.text       start:0x803B6C60 end:0x803B7830
 	.data       start:0x80BA9BB8 end:0x80BA9C70
 
-band3/tour/Quest.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/Quest.o:
 	.text       start:0x803B7830 end:0x803B80E0
 	.data       start:0x80BA9C70 end:0x80BA9CF0
 
-band3/tour/QuestJournal.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/QuestJournal.o:
 	.text       start:0x803B80E0 end:0x803B83D0
 	.data       start:0x80BA9CF0 end:0x80BA9D40
 
-band3/tour/QuestManager.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/QuestManager.o:
 	.text       start:0x803B83D0 end:0x803BA4D0
 	.ctors      start:0x80B3498C end:0x80B34990
 	.data       start:0x80BA9D40 end:0x80BA9E68
 	.sdata      start:0x80C78D28 end:0x80C78D38
 	.bss        start:0x80C91668 end:0x80C916C0
 
-band3/tour/QuestFilterPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/QuestFilterPanel.o:
 	.text       start:0x803BA4D0 end:0x803BDC20
 	.data       start:0x80BA9E68 end:0x80BAA4E8
 	.sbss       start:0x80C7A110 end:0x80C7A118
 	.bss        start:0x80C916C0 end:0x80C916D8
 
-band3/tour/Tour.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/Tour.o:
 	.text       start:0x803BDC20 end:0x803C4940
 	.data       start:0x80BAA4E8 end:0x80BAAF40
 	.sdata      start:0x80C78D38 end:0x80C78D40
 	.sbss       start:0x80C7A118 end:0x80C7A120
 	.bss        start:0x80C916D8 end:0x80C916F8
 
-band3/tour/TourBand.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourBand.o:
 	.text       start:0x803C4940 end:0x803C5510
 	.data       start:0x80BAAF40 end:0x80BAB0A8
 	.sbss       start:0x80C7A120 end:0x80C7A128
 	.bss        start:0x80C916F8 end:0x80C91710
 
-band3/tour/TourChallengeResultsPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourChallengeResultsPanel.o:
 	.text       start:0x803C5510 end:0x803C6BA0
 	.data       start:0x80BAB0A8 end:0x80BAB278
 	.sbss       start:0x80C7A128 end:0x80C7A130
 	.bss        start:0x80C91710 end:0x80C91718
 
-band3/tour/TourChar.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourChar.o:
 	.text       start:0x803C6BA0 end:0x803C7680
 	.rodata     start:0x80B35370 end:0x80B35378
 	.data       start:0x80BAB278 end:0x80BAB3D0
 
-band3/tour/TourCharLocal.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourCharLocal.o:
 	.text       start:0x803C7680 end:0x803C80C0
 	.data       start:0x80BAB3D0 end:0x80BAB4F0
 
-band3/tour/TourCharRemote.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourCharRemote.o:
 	.text       start:0x803C80C0 end:0x803C86E0
 	.data       start:0x80BAB4F0 end:0x80BAB640
 
-band3/tour/TourCondition.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourCondition.o:
 	.text       start:0x803C86E0 end:0x803C9350
 	.data       start:0x80BAB640 end:0x80BAB700
 	.sbss       start:0x80C7A130 end:0x80C7A140
 	.bss        start:0x80C91718 end:0x80C91748
 
-band3/tour/TourDesc.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourDesc.o:
 	.text       start:0x803C9350 end:0x803CAB90
 	.data       start:0x80BAB700 end:0x80BAB910
 	.sdata      start:0x80C78D40 end:0x80C78D60
 
-band3/tour/TourDescPanel.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourDescPanel.o:
 	.text       start:0x803CAB90 end:0x803D05A0
 	.data       start:0x80BAB910 end:0x80BAC400
 	.sdata      start:0x80C78D60 end:0x80C78D78
 	.sbss       start:0x80C7A140 end:0x80C7A148
 	.bss        start:0x80C91748 end:0x80C91760
 
-band3/tour/TourGameModifier.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourGameModifier.o:
 	.text       start:0x803D05A0 end:0x803D0750
 	.data       start:0x80BAC400 end:0x80BAC428
 
-band3/tour/TourGameRules.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourGameRules.o:
 	.text       start:0x803D0750 end:0x803D0C10
 	.data       start:0x80BAC428 end:0x80BAC528
 
-band3/tour/TourPerformer.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourPerformer.o:
 	.text       start:0x803D0C10 end:0x803D2F40
 	.ctors      start:0x80B34990 end:0x80B34994
 	.data       start:0x80BAC528 end:0x80BAC6A0
 	.bss        start:0x80C91760 end:0x80C917B0
 
-band3/tour/TourPerformerLocal.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourPerformerLocal.o:
 	.text       start:0x803D2F40 end:0x803D62E0
 	.data       start:0x80BAC6A0 end:0x80BAC9C0
 
-band3/tour/TourPerformerRemote.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourPerformerRemote.o:
 	.text       start:0x803D62E0 end:0x803D68F0
 	.data       start:0x80BAC9C0 end:0x80BACAD0
 	.sdata      start:0x80C78D78 end:0x80C78D80
 
-band3/tour/TourProgress.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourProgress.o:
 	.text       start:0x803D68F0 end:0x803D94F0
 	.data       start:0x80BACAD0 end:0x80BACCD8
 
-band3/tour/TourProperty.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourProperty.o:
 	.text       start:0x803D94F0 end:0x803D9780
 	.rodata     start:0x80B35378 end:0x80B35380
 	.data       start:0x80BACCD8 end:0x80BACD20
 
-band3/tour/TourPropertyCollection.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourPropertyCollection.o:
 	.text       start:0x803D9780 end:0x803DA020
 	.data       start:0x80BACD20 end:0x80BACE18
 
-band3/tour/TourQuestGameRules.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourQuestGameRules.o:
 	.text       start:0x803DA020 end:0x803DA180
 	.data       start:0x80BACE18 end:0x80BACE78
 
-band3/tour/TourReward.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourReward.o:
 	.text       start:0x803DA180 end:0x803DAB30
 	.data       start:0x80BACE78 end:0x80BACF60
 	.sbss       start:0x80C7A148 end:0x80C7A150
 	.bss        start:0x80C917B0 end:0x80C917C8
 
-band3/tour/TourSavable.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourSavable.o:
 	.text       start:0x803DAB30 end:0x803DB0E0
 	.data       start:0x80BACF60 end:0x80BAD010
 
-band3/tour/TourWeightManager.cpp:
+lib.a/hproj/band3_wii/band3/src/tour/wii_release/TourWeightManager.o:
 	.text       start:0x803DB0E0 end:0x803DB480
 	.data       start:0x80BAD010 end:0x80BAD098
 
-band3/net_band/ContextWrapper.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/ContextWrapper.o:
 	.text       start:0x803DB480 end:0x803DC000
 	.ctors      start:0x80B34994 end:0x80B34998
 	.data       start:0x80BAD098 end:0x80BAD130
 	.bss        start:0x80C917C8 end:0x80C917F0
 
-band3/net_band/DataResults.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/DataResults.o:
 	.text       start:0x803DC000 end:0x803DD380
 	.data       start:0x80BAD130 end:0x80BAD378
 	.sdata      start:0x80C78D80 end:0x80C78D88
 
-band3/net_band/RockCentral.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/RockCentral.o:
 	.text       start:0x803DD380 end:0x803EF0F0
 	.ctors      start:0x80B34998 end:0x80B3499C
 	.rodata     start:0x80B35380 end:0x80B354D8
@@ -3577,170 +3577,170 @@ band3/net_band/RockCentral.cpp:
 	.sbss       start:0x80C7A150 end:0x80C7A178
 	.bss        start:0x80C917F0 end:0x80C92048
 
-band3/net_band/RockCentralJobs.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/RockCentralJobs.o:
 	.text       start:0x803EF0F0 end:0x803F08D0
 	.data       start:0x80BAF090 end:0x80BAF330
 
-band3/net_band/EntityUploader.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/EntityUploader.o:
 	.text       start:0x803F08D0 end:0x803F3680
 	.data       start:0x80BAF330 end:0x80BAF508
 
-band3/net_band/EntityUploader_Wii.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/EntityUploader_Wii.o:
 	.text       start:0x803F3680 end:0x803F5A20
 	.ctors      start:0x80B3499C end:0x80B349A0
 	.data       start:0x80BAF508 end:0x80BAF678
 	.bss        start:0x80C92048 end:0x80C920C8
 
-band3/net_band/RockBandDDF_Wii.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/RockBandDDF_Wii.o:
 	.text       start:0x803F5A20 end:0x803F5B90
 	.ctors      start:0x80B349A0 end:0x80B349A4
 	.data       start:0x80BAF678 end:0x80BAF6D8
 	.bss        start:0x80C920C8 end:0x80C920E8
 
-band3/net_band/RBTestDDL_Wii.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/RBTestDDL_Wii.o:
 	.text       start:0x803F5B90 end:0x803F5C60
 	.data       start:0x80BAF6D8 end:0x80BAF790
 
-band3/net_band/RBDataDDL_Wii.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/RBDataDDL_Wii.o:
 	.text       start:0x803F5C60 end:0x803F6180
 	.data       start:0x80BAF790 end:0x80BAF848
 
-band3/net_band/RBBinaryDataDDL_Wii.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/RBBinaryDataDDL_Wii.o:
 	.text       start:0x803F6180 end:0x803F6840
 	.data       start:0x80BAF848 end:0x80BAF900
 
-band3/net_band/RBBinaryBufferDDL_Wii.cpp:
+lib.a/hproj/band3_wii/band3/src/net_band/wii_release/RBBinaryBufferDDL_Wii.o:
 	.text       start:0x803F6840 end:0x803F6980
 
-system/math/Sqrt_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Sqrt_Wii.o:
 	.text       start:0x803F6980 end:0x803F69C0
 
-system/math/SHA1.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/SHA1.o:
 	.text       start:0x803F69C0 end:0x803F86A0
 	.data       start:0x80BAF900 end:0x80BAF930
 
-system/math/Sort.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Sort.o:
 	.text       start:0x803F86A0 end:0x803F86E0
 
-system/math/Geo.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Geo.o:
 	.text       start:0x803F86E0 end:0x803FDCB0
 	.rodata     start:0x80B354D8 end:0x80B354E8
 	.data       start:0x80BAF930 end:0x80BAFBA0
 	.bss        start:0x80C920E8 end:0x80C920F0
 
-system/math/Color.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Color.o:
 	.text       start:0x803FDCB0 end:0x803FE050
 	.ctors      start:0x80B349A4 end:0x80B349A8
 	.rodata     start:0x80B354E8 end:0x80B354F0
 	.data       start:0x80BAFBA0 end:0x80BAFC28
 	.bss        start:0x80C920F0 end:0x80C92120
 
-system/math/Interp.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Interp.o:
 	.text       start:0x803FE050 end:0x803FEA70
 	.rodata     start:0x80B354F0 end:0x80B354F8
 	.data       start:0x80BAFC28 end:0x80BAFDE8
 
-system/math/Rand.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Rand.o:
 	.text       start:0x803FEA70 end:0x803FF170
 	.ctors      start:0x80B349A8 end:0x80B349AC
 	.data       start:0x80BAFDE8 end:0x80BAFE10
 	.bss        start:0x80C92120 end:0x80C92530
 
-system/math/Rand2.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Rand2.o:
 	.text       start:0x803FF170 end:0x803FF210
 
-system/math/Rot.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Rot.o:
 	.text       start:0x803FF210 end:0x80401770
 	.rodata     start:0x80B354F8 end:0x80B35510
 	.data       start:0x80BAFE10 end:0x80BAFE38
 
-system/math/Adjacency.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Adjacency.o:
 	.text       start:0x80401770 end:0x80401FD0
 
-system/math/FileChecksum.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/FileChecksum.o:
 	.text       start:0x80401FD0 end:0x804025C0
 	.ctors      start:0x80B349AC end:0x80B349B0
 	.data       start:0x80BAFE38 end:0x80BAFE78
 	.bss        start:0x80C92530 end:0x80C92548
 
-system/math/CustomArray.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/CustomArray.o:
 	.text       start:0x804025C0 end:0x80402B50
 
-system/math/Decibels.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Decibels.o:
 	.text       start:0x80402B50 end:0x80402C60
 	.rodata     start:0x80B35510 end:0x80B35518
 	.data       start:0x80BAFE78 end:0x80BAFE98
 
-system/math/Primes.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Primes.o:
 	.text       start:0x80402C60 end:0x80402CB0
 	.data       start:0x80BAFE98 end:0x80BAFF90
 
-system/math/RevisitedRadix.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/RevisitedRadix.o:
 	.text       start:0x80402CB0 end:0x804036F0
 
-system/math/StreamChecksum.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/StreamChecksum.o:
 	.text       start:0x804036F0 end:0x80403BD0
 	.data       start:0x80BAFF90 end:0x80BB00A0
 
-system/math/Striper.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Striper.o:
 	.text       start:0x80403BD0 end:0x80405030
 	.data       start:0x80BB00A0 end:0x80BB0100
 
-system/math/Trig.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Trig.o:
 	.text       start:0x80405030 end:0x80405690
 	.rodata     start:0x80B35518 end:0x80B35530
 	.data       start:0x80BB0100 end:0x80BB0120
 	.bss        start:0x80C92548 end:0x80C92D48
 
-system/math/Key.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/Key.o:
 	.text       start:0x80405690 end:0x804063A0
 	.data       start:0x80BB0120 end:0x80BB0168
 
-system/math/vec.cpp:
+lib.a/hproj/band3_wii/system/src/math/wii_release/vec.o:
 	.text       start:0x804063A0 end:0x80406460
 	.ctors      start:0x80B349B0 end:0x80B349B4
 	.bss        start:0x80C92D48 end:0x80C92DC8
 
-system/os/AppChild.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/AppChild.o:
 	.text       start:0x80406460 end:0x804069A0
 	.data       start:0x80BB0168 end:0x80BB01E0
 	.bss        start:0x80C92DC8 end:0x80C92DD0
 
-system/os/Archive.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Archive.o:
 	.text       start:0x804069A0 end:0x80409FE0
 	.rodata     start:0x80B35530 end:0x80B35538
 	.data       start:0x80BB01E0 end:0x80BB0628
 	.sbss       start:0x80C7A178 end:0x80C7A180
 	.bss        start:0x80C92DD0 end:0x80C92DD8
 
-system/os/ArkFile.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/ArkFile.o:
 	.text       start:0x80409FE0 end:0x8040A7D0
 	.data       start:0x80BB0628 end:0x80BB0758
 
-system/os/AsyncFile.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/AsyncFile.o:
 	.text       start:0x8040A7D0 end:0x8040B8E0
 	.data       start:0x80BB0758 end:0x80BB08F8
 
-system/os/AsyncFileCNT.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/AsyncFileCNT.o:
 	.text       start:0x8040B8E0 end:0x8040C010
 	.data       start:0x80BB08F8 end:0x80BB0AC8
 
-system/os/AsyncFile_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/AsyncFile_Wii.o:
 	.text       start:0x8040C010 end:0x8040C6F0
 	.ctors      start:0x80B349B4 end:0x80B349B8
 	.data       start:0x80BB0AC8 end:0x80BB0BD8
 	.sdata      start:0x80C78D98 end:0x80C78DA0
 	.bss        start:0x80C92DD8 end:0x80C92E08
 
-system/os/AsyncFileHolmes.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/AsyncFileHolmes.o:
 	.text       start:0x8040C6F0 end:0x8040C9D0
 	.data       start:0x80BB0BD8 end:0x80BB0CA0
 
-system/os/AsyncTask.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/AsyncTask.o:
 	.text       start:0x8040C9D0 end:0x8040CB10
 	.data       start:0x80BB0CA0 end:0x80BB0CB8
 
-system/os/BlockMgr.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/BlockMgr.o:
 	.text       start:0x8040CB10 end:0x8040E040
 	.ctors      start:0x80B349B8 end:0x80B349BC
 	.rodata     start:0x80B35538 end:0x80B35548
@@ -3748,13 +3748,13 @@ system/os/BlockMgr.cpp:
 	.sbss       start:0x80C7A180 end:0x80C7A188
 	.bss        start:0x80C92E08 end:0x80C92EA8
 
-system/os/CDReader.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/CDReader.o:
 	.text       start:0x8040E040 end:0x8040F990
 	.ctors      start:0x80B349BC end:0x80B349C0
 	.data       start:0x80BB0E10 end:0x80BB0E80
 	.bss        start:0x80C92EA8 end:0x80C92ED8
 
-system/os/CommerceMgr_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/CommerceMgr_Wii.o:
 	.text       start:0x8040F990 end:0x804151E0
 	.ctors      start:0x80B349C0 end:0x80B349C4
 	.rodata     start:0x80B35548 end:0x80B35550
@@ -3763,12 +3763,12 @@ system/os/CommerceMgr_Wii.cpp:
 	.sbss       start:0x80C7A188 end:0x80C7A190
 	.bss        start:0x80C92ED8 end:0x80C971E0
 
-system/os/ContentMgr.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/ContentMgr.o:
 	.text       start:0x804151E0 end:0x80417570
 	.data       start:0x80BB18F8 end:0x80BB1BE8
 	.sdata      start:0x80C78DA8 end:0x80C78DB0
 
-system/os/ContentMgr_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/ContentMgr_Wii.o:
 	.text       start:0x80417570 end:0x8041D840
 	.ctors      start:0x80B349C4 end:0x80B349C8
 	.rodata     start:0x80B35550 end:0x80B35578
@@ -3777,16 +3777,16 @@ system/os/ContentMgr_Wii.cpp:
 	.sbss       start:0x80C7A190 end:0x80C7A198
 	.bss        start:0x80C971E0 end:0x80C97398
 
-system/os/CritSec.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/CritSec.o:
 	.text       start:0x8041D840 end:0x8041D980
 
-system/os/DateTime.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/DateTime.o:
 	.text       start:0x8041D980 end:0x8041E320
 	.data       start:0x80BB26D8 end:0x80BB2838
 	.sbss       start:0x80C7A198 end:0x80C7A1A0
 	.bss        start:0x80C97398 end:0x80C973C8
 
-system/os/Debug.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Debug.o:
 	.text       start:0x8041E320 end:0x8041FA20
 	.ctors      start:0x80B349C8 end:0x80B349CC
 	.rodata     start:0x80B35578 end:0x80B35588
@@ -3794,31 +3794,31 @@ system/os/Debug.cpp:
 	.sbss       start:0x80C7A1A0 end:0x80C7A1A8
 	.bss        start:0x80C973C8 end:0x80C97688
 
-system/os/File.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/File.o:
 	.text       start:0x8041FA20 end:0x80422560
 	.ctors      start:0x80B349CC end:0x80B349D0
 	.data       start:0x80BB2AD0 end:0x80BB2ED0
 	.sbss       start:0x80C7A1A8 end:0x80C7A1B0
 	.bss        start:0x80C97688 end:0x80C980D0
 
-system/os/File_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/File_Wii.o:
 	.text       start:0x80422560 end:0x80422890
 	.data       start:0x80BB2ED0 end:0x80BB2F18
 
-system/os/FileCache.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/FileCache.o:
 	.text       start:0x80422890 end:0x80424C30
 	.ctors      start:0x80B349D0 end:0x80B349D4
 	.rodata     start:0x80B35588 end:0x80B35590
 	.data       start:0x80BB2F18 end:0x80BB3078
 	.bss        start:0x80C980D0 end:0x80C980E8
 
-system/os/HDCache.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/HDCache.o:
 	.text       start:0x80424C30 end:0x80426810
 	.ctors      start:0x80B349D4 end:0x80B349D8
 	.data       start:0x80BB3078 end:0x80BB32D8
 	.bss        start:0x80C980E8 end:0x80C98160
 
-system/os/HolmesClient.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/HolmesClient.o:
 	.text       start:0x80426810 end:0x8042A7E0
 	.ctors      start:0x80B349D8 end:0x80B349DC
 	.rodata     start:0x80B35590 end:0x80B355A8
@@ -3827,25 +3827,25 @@ system/os/HolmesClient.cpp:
 	.sbss       start:0x80C7A1B0 end:0x80C7A1B8
 	.bss        start:0x80C98160 end:0x80C98AE8
 
-system/os/HolmesKeyboard.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/HolmesKeyboard.o:
 	.text       start:0x8042A7E0 end:0x8042AFE0
 	.data       start:0x80BB38E8 end:0x80BB39B8
 	.sbss       start:0x80C7A1B8 end:0x80C7A1C0
 	.bss        start:0x80C98AE8 end:0x80C98AF0
 
-system/os/HomeMenu_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/HomeMenu_Wii.o:
 	.text       start:0x8042AFE0 end:0x8042CB00
 	.rodata     start:0x80B355A8 end:0x80B355D0
 	.data       start:0x80BB39B8 end:0x80BB3D78
 	.sbss       start:0x80C7A1C0 end:0x80C7A1C8
 	.bss        start:0x80C98AF0 end:0x80C9C7B0
 
-system/os/DiscErrorMgr_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/DiscErrorMgr_Wii.o:
 	.text       start:0x8042CB00 end:0x8042D2C0
 	.data       start:0x80BB3D78 end:0x80BB3E10
 	.sbss       start:0x80C7A1C8 end:0x80C7A1D0
 
-system/os/Joypad.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Joypad.o:
 	.text       start:0x8042D2C0 end:0x804309F0
 	.ctors      start:0x80B349DC end:0x80B349E0
 	.rodata     start:0x80B355D0 end:0x80B355F0
@@ -3854,7 +3854,7 @@ system/os/Joypad.cpp:
 	.sbss       start:0x80C7A1D0 end:0x80C7A1E8
 	.bss        start:0x80C9C7B0 end:0x80C9CA90
 
-system/os/Joypad_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Joypad_Wii.o:
 	.text       start:0x804309F0 end:0x80432D10
 	.ctors      start:0x80B349E0 end:0x80B349E4
 	.rodata     start:0x80B355F0 end:0x80B35930
@@ -3863,65 +3863,65 @@ system/os/Joypad_Wii.cpp:
 	.sbss       start:0x80C7A1E8 end:0x80C7A1F0
 	.bss        start:0x80C9CA90 end:0x80C9CB10
 
-system/os/JoypadClient.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/JoypadClient.o:
 	.text       start:0x80432D10 end:0x80434420
 	.ctors      start:0x80B349E4 end:0x80B349E8
 	.data       start:0x80BB42D0 end:0x80BB4510
 	.sbss       start:0x80C7A1F0 end:0x80C7A1F8
 	.bss        start:0x80C9CB10 end:0x80C9CB28
 
-system/os/JoypadMsgs.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/JoypadMsgs.o:
 	.text       start:0x80434420 end:0x80434B60
 
-system/os/Keyboard.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Keyboard.o:
 	.text       start:0x80434B60 end:0x804352E0
 	.ctors      start:0x80B349E8 end:0x80B349EC
 	.data       start:0x80BB4510 end:0x80BB45B0
 	.sbss       start:0x80C7A1F8 end:0x80C7A200
 	.bss        start:0x80C9CB28 end:0x80C9CB48
 
-system/os/Keyboard_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Keyboard_Wii.o:
 	.text       start:0x804352E0 end:0x804355C0
 	.data       start:0x80BB45B0 end:0x80BB4660
 	.bss        start:0x80C9CB48 end:0x80C9D808
 
-system/os/MapFile_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/MapFile_Wii.o:
 	.text       start:0x804355C0 end:0x804380B0
 	.data       start:0x80BB4660 end:0x80BB47F8
 	.bss        start:0x80C9D808 end:0x80C9DC08
 
-system/os/Memcard.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Memcard.o:
 	.text       start:0x804380B0 end:0x804384B0
 	.data       start:0x80BB47F8 end:0x80BB48B8
 	.sdata      start:0x80C78DD0 end:0x80C78DD8
 
-system/os/Memcard_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Memcard_Wii.o:
 	.text       start:0x804384B0 end:0x80439540
 	.ctors      start:0x80B349EC end:0x80B349F0
 	.data       start:0x80BB48B8 end:0x80BB5048
 	.bss        start:0x80C9DC08 end:0x80C9DC40
 
-system/os/NetStream.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/NetStream.o:
 	.text       start:0x80439540 end:0x80439D00
 	.data       start:0x80BB5048 end:0x80BB50D8
 
-system/os/NetworkSocket_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/NetworkSocket_Wii.o:
 	.text       start:0x80439D00 end:0x8043A710
 	.data       start:0x80BB50D8 end:0x80BB5300
 	.sbss       start:0x80C7A200 end:0x80C7A208
 
-system/os/OnlineID.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/OnlineID.o:
 	.text       start:0x8043A710 end:0x8043A900
 	.data       start:0x80BB5300 end:0x80BB5328
 
-system/os/PlatformMgr.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/PlatformMgr.o:
 	.text       start:0x8043A900 end:0x8043C2D0
 	.ctors      start:0x80B349F0 end:0x80B349F4
 	.data       start:0x80BB5328 end:0x80BB54E0
 	.sbss       start:0x80C7A208 end:0x80C7A210
 	.bss        start:0x80C9DC40 end:0x80CAAB18
 
-system/os/PlatformMgr_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/PlatformMgr_Wii.o:
 	.text       start:0x8043C2D0 end:0x80441480
 	.ctors      start:0x80B349F4 end:0x80B349F8
 	.rodata     start:0x80B35930 end:0x80B35948
@@ -3929,17 +3929,17 @@ system/os/PlatformMgr_Wii.cpp:
 	.sbss       start:0x80C7A210 end:0x80C7A220
 	.bss        start:0x80CAAB18 end:0x80CAAD20
 
-system/os/ProfilePicture.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/ProfilePicture.o:
 	.text       start:0x80441480 end:0x80441810
 	.data       start:0x80BB5C50 end:0x80BB5CD8
 	.sbss       start:0x80C7A220 end:0x80C7A228
 	.bss        start:0x80CAAD20 end:0x80CAAD28
 
-system/os/ProfilePicture_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/ProfilePicture_Wii.o:
 	.text       start:0x80441810 end:0x80441A00
 	.data       start:0x80BB5CD8 end:0x80BB5D30
 
-system/os/System.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/System.o:
 	.text       start:0x80441A00 end:0x80443B30
 	.ctors      start:0x80B349F8 end:0x80B349FC
 	.data       start:0x80BB5D30 end:0x80BB6158
@@ -3947,17 +3947,17 @@ system/os/System.cpp:
 	.sbss       start:0x80C7A228 end:0x80C7A238
 	.bss        start:0x80CAAD28 end:0x80CAAFD0
 
-system/os/System_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/System_Wii.o:
 	.text       start:0x80443B30 end:0x80443DF0
 	.data       start:0x80BB6158 end:0x80BB6180
 
-system/os/ThreadCall_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/ThreadCall_Wii.o:
 	.text       start:0x80443DF0 end:0x804442E0
 	.data       start:0x80BB6180 end:0x80BB61E0
 	.sbss       start:0x80C7A238 end:0x80C7A240
 	.bss        start:0x80CAAFD0 end:0x80CAB3E8
 
-system/os/Timer.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/Timer.o:
 	.text       start:0x804442E0 end:0x80446050
 	.ctors      start:0x80B349FC end:0x80B34A00
 	.rodata     start:0x80B35948 end:0x80B35960
@@ -3965,59 +3965,59 @@ system/os/Timer.cpp:
 	.sbss       start:0x80C7A240 end:0x80C7A248
 	.bss        start:0x80CAB3E8 end:0x80CAB478
 
-system/os/User.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/User.o:
 	.text       start:0x80446050 end:0x80447470
 	.data       start:0x80BB63E0 end:0x80BB6618
 	.sbss       start:0x80C7A248 end:0x80C7A250
 	.bss        start:0x80CAB478 end:0x80CAB480
 
-system/os/UserMgr.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/UserMgr.o:
 	.text       start:0x80447470 end:0x80447B40
 	.data       start:0x80BB6618 end:0x80BB66D0
 	.bss        start:0x80CAB480 end:0x80CAB488
 
-system/os/SynchronizationEvent.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/SynchronizationEvent.o:
 	.text       start:0x80447B40 end:0x80447D00
 	.data       start:0x80BB66D0 end:0x80BB6730
 
-system/os/VirtualKeyboard.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/VirtualKeyboard.o:
 	.text       start:0x80447D00 end:0x80448730
 	.ctors      start:0x80B34A00 end:0x80B34A04
 	.data       start:0x80BB6730 end:0x80BB6808
 	.bss        start:0x80CAB488 end:0x80CAB4E0
 
-system/os/VirtualKeyboard_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/VirtualKeyboard_Wii.o:
 	.text       start:0x80448730 end:0x80449100
 	.data       start:0x80BB6808 end:0x80BB68D8
 	.sbss       start:0x80C7A250 end:0x80C7A258
 	.bss        start:0x80CAB4E0 end:0x80CAB500
 
-system/os/UsbMidiGuitar.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/UsbMidiGuitar.o:
 	.text       start:0x80449100 end:0x8044A430
 	.ctors      start:0x80B34A04 end:0x80B34A08
 	.data       start:0x80BB68D8 end:0x80BB6930
 	.sbss       start:0x80C7A258 end:0x80C7A260
 	.bss        start:0x80CAB500 end:0x80CAB5B0
 
-system/os/UsbMidiGuitarMsgs.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/UsbMidiGuitarMsgs.o:
 	.text       start:0x8044A430 end:0x8044B580
 	.data       start:0x80BB6930 end:0x80BB6C48
 	.sbss       start:0x80C7A260 end:0x80C7A270
 	.bss        start:0x80CAB5B0 end:0x80CAB5E0
 
-system/os/UsbMidiKeyboard.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/UsbMidiKeyboard.o:
 	.text       start:0x8044B580 end:0x8044C670
 	.data       start:0x80BB6C48 end:0x80BB6D08
 	.sbss       start:0x80C7A270 end:0x80C7A278
 	.bss        start:0x80CAB5E0 end:0x80CAB610
 
-system/os/UsbMidiKeyboardMsgs.cpp:
+lib.a/hproj/band3_wii/system/src/os/wii_release/UsbMidiKeyboardMsgs.o:
 	.text       start:0x8044C670 end:0x8044D650
 	.data       start:0x80BB6D08 end:0x80BB7000
 	.sbss       start:0x80C7A278 end:0x80C7A288
 	.bss        start:0x80CAB610 end:0x80CAB638
 
-system/obj/DataArray.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/DataArray.o:
 	.text       start:0x8044D650 end:0x80451160
 	.ctors      start:0x80B34A08 end:0x80B34A0C
 	.rodata     start:0x80B35960 end:0x80B35970
@@ -4025,7 +4025,7 @@ system/obj/DataArray.cpp:
 	.sbss       start:0x80C7A288 end:0x80C7A290
 	.bss        start:0x80CAB638 end:0x80CAB808
 
-system/obj/DataFile.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/DataFile.o:
 	.text       start:0x80451160 end:0x804544B0
 	.ctors      start:0x80B34A0C end:0x80B34A10
 	.rodata     start:0x80B35970 end:0x80B35978
@@ -4033,7 +4033,7 @@ system/obj/DataFile.cpp:
 	.sbss       start:0x80C7A290 end:0x80C7A298
 	.bss        start:0x80CAB808 end:0x80CAB880
 
-system/obj/DataFunc.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/DataFunc.o:
 	.text       start:0x804544B0 end:0x8045DCF0
 	.ctors      start:0x80B34A10 end:0x80B34A14
 	.data       start:0x80BB7A30 end:0x80BB8208
@@ -4042,13 +4042,13 @@ system/obj/DataFunc.cpp:
 	.sdata2     start:0x80C7B920 end:0x80C7B928
 	.bss        start:0x80CAB880 end:0x80CAB900
 
-system/obj/DataNode.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/DataNode.o:
 	.text       start:0x8045DCF0 end:0x80460190
 	.ctors      start:0x80B34A14 end:0x80B34A18
 	.data       start:0x80BB8208 end:0x80BB8780
 	.bss        start:0x80CAB900 end:0x80CABA00
 
-system/obj/DataUtl.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/DataUtl.o:
 	.text       start:0x80460190 end:0x80460E30
 	.ctors      start:0x80B34A18 end:0x80B34A1C
 	.data       start:0x80BB8780 end:0x80BB8828
@@ -4056,14 +4056,14 @@ system/obj/DataUtl.cpp:
 	.sbss       start:0x80C7A2A0 end:0x80C7A2A8
 	.bss        start:0x80CABA00 end:0x80CABEF8
 
-system/obj/DataFlex.c:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/DataFlex.o:
 	.text       start:0x80460E30 end:0x80461BA0
 	.rodata     start:0x80B35978 end:0x80B369A8
 	.data       start:0x80BB8828 end:0x80BB8A10
 	.sbss       start:0x80C7A2A8 end:0x80C7A2B0
 	.bss        start:0x80CABEF8 end:0x80CABF28
 
-system/obj/Dir.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/Dir.o:
 	.text       start:0x80461BA0 end:0x8046E980
 	.ctors      start:0x80B34A1C end:0x80B34A20
 	.data       start:0x80BB8A10 end:0x80BB9208
@@ -4071,7 +4071,7 @@ system/obj/Dir.cpp:
 	.sbss       start:0x80C7A2B0 end:0x80C7A2C0
 	.bss        start:0x80CABF28 end:0x80CAC598
 
-system/obj/DirLoader.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/DirLoader.o:
 	.text       start:0x8046E980 end:0x804723C0
 	.ctors      start:0x80B34A20 end:0x80B34A24
 	.data       start:0x80BB9208 end:0x80BB97F0
@@ -4079,22 +4079,22 @@ system/obj/DirLoader.cpp:
 	.sbss       start:0x80C7A2C0 end:0x80C7A2C8
 	.bss        start:0x80CAC598 end:0x80CACA20
 
-system/obj/DirUnloader.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/DirUnloader.o:
 	.text       start:0x804723C0 end:0x80473050
 	.data       start:0x80BB97F0 end:0x80BB9940
 
-system/obj/MessageTimer.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/MessageTimer.o:
 	.text       start:0x80473050 end:0x80474E80
 	.ctors      start:0x80B34A24 end:0x80B34A28
 	.data       start:0x80BB9940 end:0x80BB9A28
 	.sbss       start:0x80C7A2C8 end:0x80C7A2D0
 	.bss        start:0x80CACA20 end:0x80CACA38
 
-system/obj/Msg.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/Msg.o:
 	.text       start:0x80474E80 end:0x80477710
 	.data       start:0x80BB9A28 end:0x80BB9B88
 
-system/obj/Object.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/Object.o:
 	.text       start:0x80477710 end:0x8047B7A0
 	.ctors      start:0x80B34A28 end:0x80B34A2C
 	.data       start:0x80BB9B88 end:0x80BB9E98
@@ -4102,87 +4102,87 @@ system/obj/Object.cpp:
 	.sbss       start:0x80C7A2D0 end:0x80C7A2F8
 	.bss        start:0x80CACA38 end:0x80CACB70
 
-system/obj/PropSync.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/PropSync.o:
 	.text       start:0x8047B7A0 end:0x8047D950
 	.data       start:0x80BB9E98 end:0x80BB9F50
 	.sbss       start:0x80C7A2F8 end:0x80C7A300
 	.bss        start:0x80CACB70 end:0x80CACB88
 
-system/obj/Task.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/Task.o:
 	.text       start:0x8047D950 end:0x80481990
 	.ctors      start:0x80B34A2C end:0x80B34A30
 	.data       start:0x80BB9F50 end:0x80BBA308
 	.sbss       start:0x80C7A300 end:0x80C7A308
 	.bss        start:0x80CACB88 end:0x80CACC28
 
-system/obj/TextFile.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/TextFile.o:
 	.text       start:0x80481990 end:0x80482700
 	.data       start:0x80BBA308 end:0x80BBA418
 	.sbss       start:0x80C7A308 end:0x80C7A310
 	.sdata2     start:0x80C7B928 end:0x80C7B930
 	.bss        start:0x80CACC28 end:0x80CACC30
 
-system/obj/TypeProps.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/TypeProps.o:
 	.text       start:0x80482700 end:0x80483A90
 	.data       start:0x80BBA418 end:0x80BBA4F0
 
-system/obj/Utl.cpp:
+lib.a/hproj/band3_wii/system/src/obj/wii_release/Utl.o:
 	.text       start:0x80483A90 end:0x80487140
 	.ctors      start:0x80B34A30 end:0x80B34A34
 	.data       start:0x80BBA4F0 end:0x80BBA638
 	.sbss       start:0x80C7A310 end:0x80C7A318
 	.bss        start:0x80CACC30 end:0x80D0CC88
 
-system/utl/BeatMap.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/BeatMap.o:
 	.text       start:0x80487140 end:0x804879C0
 	.ctors      start:0x80B34A34 end:0x80B34A38
 	.data       start:0x80BBA638 end:0x80BBA678
 	.bss        start:0x80D0CC88 end:0x80D0CCA0
 
-system/utl/BinkIntegration.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/BinkIntegration.o:
 	.text       start:0x804879C0 end:0x80488A60
 	.rodata     start:0x80B369A8 end:0x80B369B0
 	.data       start:0x80BBA678 end:0x80BBA6C8
 	.sbss       start:0x80C7A318 end:0x80C7A320
 	.bss        start:0x80D0CCA0 end:0x80D0CCA8
 
-system/utl/BinStream.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/BinStream.o:
 	.text       start:0x80488A60 end:0x804897A0
 	.data       start:0x80BBA6C8 end:0x80BBA7E8
 	.sdata      start:0x80C78E08 end:0x80C78E10
 	.sbss       start:0x80C7A320 end:0x80C7A328
 	.bss        start:0x80D0CCA8 end:0x80D0CDC0
 
-system/utl/BufStream.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/BufStream.o:
 	.text       start:0x804897A0 end:0x80489CA0
 	.data       start:0x80BBA7E8 end:0x80BBA870
 
-system/utl/BufStreamNAND.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/BufStreamNAND.o:
 	.text       start:0x80489CA0 end:0x8048AAB0
 	.data       start:0x80BBA870 end:0x80BBAA70
 
-system/utl/Cache.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Cache.o:
 	.text       start:0x8048AAB0 end:0x8048ABD0
 	.data       start:0x80BBAA70 end:0x80BBAB00
 
-system/utl/Cache_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Cache_Wii.o:
 	.text       start:0x8048ABD0 end:0x8048CA20
 	.data       start:0x80BBAB00 end:0x80BBAE60
 	.sbss       start:0x80C7A328 end:0x80C7A330
 	.bss        start:0x80D0CDC0 end:0x80D0CE00
 
-system/utl/CacheMgr.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/CacheMgr.o:
 	.text       start:0x8048CA20 end:0x8048D320
 	.data       start:0x80BBAE60 end:0x80BBB020
 	.bss        start:0x80D0CE00 end:0x80D0CE08
 
-system/utl/CacheMgr_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/CacheMgr_Wii.o:
 	.text       start:0x8048D320 end:0x8048E380
 	.data       start:0x80BBB020 end:0x80BBB218
 	.sbss       start:0x80C7A330 end:0x80C7A338
 	.bss        start:0x80D0CE08 end:0x80D0CE30
 
-system/utl/Cheats.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Cheats.o:
 	.text       start:0x8048E380 end:0x80491A20
 	.rodata     start:0x80B369B0 end:0x80B369C0
 	.data       start:0x80BBB218 end:0x80BBB808
@@ -4190,58 +4190,58 @@ system/utl/Cheats.cpp:
 	.sbss       start:0x80C7A338 end:0x80C7A340
 	.bss        start:0x80D0CE30 end:0x80D0CE48
 
-system/utl/Chunks.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Chunks.o:
 	.text       start:0x80491A20 end:0x804926D0
 	.data       start:0x80BBB808 end:0x80BBB948
 
-system/utl/ChunkIDs.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/ChunkIDs.o:
 	.text       start:0x804926D0 end:0x80492800
 	.ctors      start:0x80B34A38 end:0x80B34A3C
 	.data       start:0x80BBB948 end:0x80BBB998
 	.bss        start:0x80D0CE48 end:0x80D0CE88
 
-system/utl/ChunkStream.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/ChunkStream.o:
 	.text       start:0x80492800 end:0x80494110
 	.ctors      start:0x80B34A3C end:0x80B34A40
 	.data       start:0x80BBB998 end:0x80BBBD20
 	.bss        start:0x80D0CE88 end:0x80D0CEA0
 
-system/utl/Compress.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Compress.o:
 	.text       start:0x80494110 end:0x80494400
 	.data       start:0x80BBBD20 end:0x80BBBE60
 
-system/utl/DataPointMgr.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/DataPointMgr.o:
 	.text       start:0x80494400 end:0x804947C0
 	.ctors      start:0x80B34A40 end:0x80B34A44
 	.bss        start:0x80D0CEA0 end:0x80D0CEA8
 
-system/utl/DeJitter.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/DeJitter.o:
 	.text       start:0x804947C0 end:0x80494B20
 	.rodata     start:0x80B369C0 end:0x80B369C8
 	.data       start:0x80BBBE60 end:0x80BBBE90
 	.sbss       start:0x80C7A340 end:0x80C7A348
 	.bss        start:0x80D0CEA8 end:0x80D0CEB0
 
-system/utl/EncryptXTEA.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/EncryptXTEA.o:
 	.text       start:0x80494B20 end:0x80494D50
 
-system/utl/FakeSongMgr.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/FakeSongMgr.o:
 	.text       start:0x80494D50 end:0x80494EB0
 	.data       start:0x80BBBE90 end:0x80BBBF48
 	.bss        start:0x80D0CEB0 end:0x80D0CEB8
 
-system/utl/FilePath.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/FilePath.o:
 	.text       start:0x80494EB0 end:0x80494FD0
 	.ctors      start:0x80B34A44 end:0x80B34A48
 	.data       start:0x80BBBF48 end:0x80BBBF50
 	.bss        start:0x80D0CEB8 end:0x80D0CEE8
 
-system/utl/FileStream.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/FileStream.o:
 	.text       start:0x80494FD0 end:0x80495720
 	.rodata     start:0x80B369C8 end:0x80B369D8
 	.data       start:0x80BBBF50 end:0x80BBBFE0
 
-system/utl/GlitchFinder.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/GlitchFinder.o:
 	.text       start:0x80495720 end:0x80497060
 	.ctors      start:0x80B34A48 end:0x80B34A4C
 	.rodata     start:0x80B369D8 end:0x80B369E0
@@ -4249,12 +4249,12 @@ system/utl/GlitchFinder.cpp:
 	.sbss       start:0x80C7A348 end:0x80C7A350
 	.bss        start:0x80D0CEE8 end:0x80D0D260
 
-system/utl/HangBlock_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/HangBlock_Wii.o:
 	.text       start:0x80497060 end:0x804970C0
 	.ctors      start:0x80B34A4C end:0x80B34A50
 	.bss        start:0x80D0D260 end:0x80D0D2D0
 
-system/utl/HttpWii.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/HttpWii.o:
 	.text       start:0x804970C0 end:0x80497D00
 	.ctors      start:0x80B34A50 end:0x80B34A54
 	.rodata     start:0x80B369E0 end:0x80B36A28
@@ -4262,22 +4262,22 @@ system/utl/HttpWii.cpp:
 	.sbss       start:0x80C7A350 end:0x80C7A358
 	.bss        start:0x80D0D2D0 end:0x80D0D530
 
-system/utl/HxGuid.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/HxGuid.o:
 	.text       start:0x80497D00 end:0x80498210
 	.ctors      start:0x80B34A54 end:0x80B34A58
 	.data       start:0x80BBC410 end:0x80BBC4A0
 	.bss        start:0x80D0D530 end:0x80D0D558
 
-system/utl/IntPacker.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/IntPacker.o:
 	.text       start:0x80498210 end:0x80498920
 	.data       start:0x80BBC4A0 end:0x80BBC500
 
-system/utl/JobMgr.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/JobMgr.o:
 	.text       start:0x80498920 end:0x80498E30
 	.data       start:0x80BBC500 end:0x80BBC540
 	.bss        start:0x80D0D558 end:0x80D0D560
 
-system/utl/Loader.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Loader.o:
 	.text       start:0x80498E30 end:0x8049AC30
 	.ctors      start:0x80B34A58 end:0x80B34A5C
 	.data       start:0x80BBC540 end:0x80BBC828
@@ -4285,7 +4285,7 @@ system/utl/Loader.cpp:
 	.sbss       start:0x80C7A358 end:0x80C7A360
 	.bss        start:0x80D0D560 end:0x80D0D610
 
-system/utl/Locale.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Locale.o:
 	.text       start:0x8049AC30 end:0x8049C1E0
 	.ctors      start:0x80B34A5C end:0x80B34A60
 	.rodata     start:0x80B36A28 end:0x80B36A30
@@ -4293,37 +4293,37 @@ system/utl/Locale.cpp:
 	.sbss       start:0x80C7A360 end:0x80C7A368
 	.bss        start:0x80D0D610 end:0x80D0D7E8
 
-system/utl/LocaleOrdinal.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/LocaleOrdinal.o:
 	.text       start:0x8049C1E0 end:0x8049C530
 	.data       start:0x80BBCA80 end:0x80BBCAD8
 
-system/utl/LogFile.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/LogFile.o:
 	.text       start:0x8049C530 end:0x8049C7A0
 	.data       start:0x80BBCAD8 end:0x80BBCB08
 
-system/utl/MakeString.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MakeString.o:
 	.text       start:0x8049C7A0 end:0x8049DC20
 	.data       start:0x80BBCB08 end:0x80BBCD18
 	.bss        start:0x80D0D7E8 end:0x80D0D828
 
-system/utl/Magnu.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Magnu.o:
 	.text       start:0x8049DC20 end:0x8049DEA0
 	.data       start:0x80BBCD18 end:0x80BBCE00
 
-system/utl/MBT.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MBT.o:
 	.text       start:0x8049DEA0 end:0x8049E0C0
 	.rodata     start:0x80B36A30 end:0x80B36A48
 	.data       start:0x80BBCE00 end:0x80BBCE28
 
-system/utl/MeasureMap.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MeasureMap.o:
 	.text       start:0x8049E0C0 end:0x8049E8B0
 	.rodata     start:0x80B36A48 end:0x80B36A58
 	.data       start:0x80BBCE28 end:0x80BBCEF0
 
-system/utl/MemcardBufStream.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MemcardBufStream.o:
 	.text       start:0x8049E8B0 end:0x8049E8D0
 
-system/utl/MemMgr.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MemMgr.o:
 	.text       start:0x8049E8D0 end:0x804A21D0
 	.ctors      start:0x80B34A60 end:0x80B34A64
 	.data       start:0x80BBCEF0 end:0x80BBD630
@@ -4331,361 +4331,361 @@ system/utl/MemMgr.cpp:
 	.sbss       start:0x80C7A368 end:0x80C7A370
 	.bss        start:0x80D0D828 end:0x80D0E0E8
 
-system/utl/Mem_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Mem_Wii.o:
 	.text       start:0x804A21D0 end:0x804A25A0
 	.data       start:0x80BBD630 end:0x80BBD6E8
 	.sbss       start:0x80C7A370 end:0x80C7A378
 	.bss        start:0x80D0E0E8 end:0x80D0E0F0
 
-system/utl/MemPoint.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MemPoint.o:
 	.text       start:0x804A25A0 end:0x804A2790
 
-system/utl/MemTracker.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MemTracker.o:
 	.text       start:0x804A2790 end:0x804A2810
 
-system/utl/MemStream.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MemStream.o:
 	.text       start:0x804A2810 end:0x804A2C60
 	.data       start:0x80BBD6E8 end:0x80BBD750
 	.sdata      start:0x80C78E28 end:0x80C78E30
 
-system/utl/Messages.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Messages.o:
 	.text       start:0x804A2C60 end:0x804A5FD0
 	.ctors      start:0x80B34A64 end:0x80B34A68
 	.data       start:0x80BBD750 end:0x80BBDC50
 	.sbss       start:0x80C7A378 end:0x80C7A380
 	.bss        start:0x80D0E0F0 end:0x80D0E840
 
-system/utl/Messages2.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Messages2.o:
 	.text       start:0x804A5FD0 end:0x804A8960
 	.ctors      start:0x80B34A68 end:0x80B34A6C
 	.data       start:0x80BBDC50 end:0x80BBE0F0
 	.sbss       start:0x80C7A380 end:0x80C7A388
 	.bss        start:0x80D0E840 end:0x80D0EE28
 
-system/utl/Messages3.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Messages3.o:
 	.text       start:0x804A8960 end:0x804AB4F0
 	.ctors      start:0x80B34A6C end:0x80B34A70
 	.data       start:0x80BBE0F0 end:0x80BBE508
 	.sbss       start:0x80C7A388 end:0x80C7A390
 	.bss        start:0x80D0EE28 end:0x80D0F458
 
-system/utl/Messages4.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Messages4.o:
 	.text       start:0x804AB4F0 end:0x804AE270
 	.ctors      start:0x80B34A70 end:0x80B34A74
 	.data       start:0x80BBE508 end:0x80BBE8F8
 	.sbss       start:0x80C7A390 end:0x80C7A398
 	.bss        start:0x80D0F458 end:0x80D0FAD0
 
-system/utl/MultiTempoTempoMap.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/MultiTempoTempoMap.o:
 	.text       start:0x804AE270 end:0x804AF270
 	.rodata     start:0x80B36A58 end:0x80B36A60
 	.data       start:0x80BBE8F8 end:0x80BBEA58
 
-system/utl/NetLoader.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/NetLoader.o:
 	.text       start:0x804AF270 end:0x804AFB70
 	.rodata     start:0x80B36A60 end:0x80B36A68
 	.data       start:0x80BBEA58 end:0x80BBEB48
 
-system/utl/NetLoader_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/NetLoader_Wii.o:
 	.text       start:0x804AFB70 end:0x804B01A0
 	.data       start:0x80BBEB48 end:0x80BBEC08
 
-system/utl/NetCacheLoader.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/NetCacheLoader.o:
 	.text       start:0x804B01A0 end:0x804B0A60
 	.data       start:0x80BBEC08 end:0x80BBED18
 
-system/utl/NetCacheMgr.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/NetCacheMgr.o:
 	.text       start:0x804B0A60 end:0x804B2CD0
 	.data       start:0x80BBED18 end:0x80BBF120
 	.bss        start:0x80D0FAD0 end:0x80D0FAD8
 
-system/utl/Option.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Option.o:
 	.text       start:0x804B2CD0 end:0x804B3210
 	.data       start:0x80BBF120 end:0x80BBF198
 
-system/utl/PoolAlloc.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/PoolAlloc.o:
 	.text       start:0x804B3210 end:0x804B3E40
 	.data       start:0x80BBF198 end:0x80BBF480
 	.sbss       start:0x80C7A398 end:0x80C7A3A0
 	.bss        start:0x80D0FAD8 end:0x80D0FAE8
 
-system/utl/Profiler.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Profiler.o:
 	.text       start:0x804B3E40 end:0x804B4140
 	.data       start:0x80BBF480 end:0x80BBF4A8
 
-system/utl/Rso_Utl.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Rso_Utl.o:
 	.text       start:0x804B4140 end:0x804B4E90
 	.data       start:0x80BBF4A8 end:0x80BBF6F0
 	.sdata      start:0x80C78E30 end:0x80C78E38
 	.sbss       start:0x80C7A3A0 end:0x80C7A3A8
 	.bss        start:0x80D0FAE8 end:0x80D0FB48
 
-system/utl/Song.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Song.o:
 	.text       start:0x804B4E90 end:0x804B9320
 	.data       start:0x80BBF6F0 end:0x80BBF980
 	.sbss       start:0x80C7A3A8 end:0x80C7A3B0
 	.bss        start:0x80D0FB48 end:0x80D0FB60
 
-system/utl/SongInfoAudioType.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/SongInfoAudioType.o:
 	.text       start:0x804B9320 end:0x804B9400
 	.data       start:0x80BBF980 end:0x80BBF9C0
 
-system/utl/SongInfoCopy.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/SongInfoCopy.o:
 	.text       start:0x804B9400 end:0x804BA6E0
 	.data       start:0x80BBF9C0 end:0x80BBFB40
 
-system/utl/Spew.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Spew.o:
 	.text       start:0x804BA6E0 end:0x804BA700
 
-system/utl/Str.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Str.o:
 	.text       start:0x804BA700 end:0x804BBFB0
 	.rodata     start:0x80B36A68 end:0x80B36A70
 	.data       start:0x80BBFB40 end:0x80BBFC00
 	.sbss       start:0x80C7A3B0 end:0x80C7A3B8
 
-system/utl/StringTable.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/StringTable.o:
 	.text       start:0x804BBFB0 end:0x804BC940
 	.data       start:0x80BBFC00 end:0x80BBFCA0
 
-system/utl/SuperFormatString.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/SuperFormatString.o:
 	.text       start:0x804BC940 end:0x804BD160
 	.data       start:0x80BBFCA0 end:0x80BBFE10
 
-system/utl/Symbol.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Symbol.o:
 	.text       start:0x804BD160 end:0x804BE990
 	.rodata     start:0x80B36A70 end:0x80B36A78
 	.data       start:0x80BBFE10 end:0x80BBFFD0
 	.sdata      start:0x80C78E38 end:0x80C78E40
 	.bss        start:0x80D0FB60 end:0x80D0FB78
 
-system/utl/Symbols.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Symbols.o:
 	.text       start:0x804BE990 end:0x804C4D80
 	.ctors      start:0x80B34A74 end:0x80B34A78
 	.data       start:0x80BBFFD0 end:0x80BC8510
 	.sbss       start:0x80C7A3B8 end:0x80C7A3C0
 	.bss        start:0x80D0FB78 end:0x80D11C28
 
-system/utl/Symbols2.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Symbols2.o:
 	.text       start:0x804C4D80 end:0x804C9CC0
 	.ctors      start:0x80B34A78 end:0x80B34A7C
 	.data       start:0x80BC8510 end:0x80BCE818
 	.sbss       start:0x80C7A3C0 end:0x80C7A3C8
 	.bss        start:0x80D11C28 end:0x80D13678
 
-system/utl/Symbols3.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Symbols3.o:
 	.text       start:0x804C9CC0 end:0x804CEC50
 	.ctors      start:0x80B34A7C end:0x80B34A80
 	.data       start:0x80BCE818 end:0x80BD50D8
 	.sbss       start:0x80C7A3C8 end:0x80C7A3D0
 	.bss        start:0x80D13678 end:0x80D150E0
 
-system/utl/Symbols4.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Symbols4.o:
 	.text       start:0x804CEC50 end:0x804D3BB0
 	.ctors      start:0x80B34A80 end:0x80B34A84
 	.data       start:0x80BD50D8 end:0x80BDB6D8
 	.sbss       start:0x80C7A3D0 end:0x80C7A3D8
 	.bss        start:0x80D150E0 end:0x80D16B40
 
-system/utl/SysTest.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/SysTest.o:
 	.text       start:0x804D3BB0 end:0x804D3E00
 	.data       start:0x80BDB6D8 end:0x80BDB758
 
-system/utl/TempoMap.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/TempoMap.o:
 	.text       start:0x804D3E00 end:0x804D3FC0
 	.ctors      start:0x80B34A84 end:0x80B34A88
 	.rodata     start:0x80B36A78 end:0x80B36A80
 	.data       start:0x80BDB758 end:0x80BDB7C8
 	.bss        start:0x80D16B40 end:0x80D16B48
 
-system/utl/TextFileStream.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/TextFileStream.o:
 	.text       start:0x804D3FC0 end:0x804D40D0
 	.data       start:0x80BDB7C8 end:0x80BDB800
 	.sdata2     start:0x80C7B930 end:0x80C7B938
 
-system/utl/TextStream.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/TextStream.o:
 	.text       start:0x804D40D0 end:0x804D4780
 	.data       start:0x80BDB800 end:0x80BDB9D0
 
-system/utl/TimeConversion.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/TimeConversion.o:
 	.text       start:0x804D4780 end:0x804D4BE0
 	.data       start:0x80BDB9D0 end:0x80BDBA08
 
-system/utl/UserGuid.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/UserGuid.o:
 	.text       start:0x804D4BE0 end:0x804D4BF0
 	.ctors      start:0x80B34A88 end:0x80B34A8C
 	.bss        start:0x80D16B48 end:0x80D16B58
 
-system/utl/UTF8.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/UTF8.o:
 	.text       start:0x804D4BF0 end:0x804D6220
 	.data       start:0x80BDBA08 end:0x80BDBB80
 	.sdata      start:0x80C78E40 end:0x80C78E48
 	.sbss       start:0x80C7A3D8 end:0x80C7A3E0
 	.bss        start:0x80D16B58 end:0x80D16B70
 
-system/utl/VarTimer.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/VarTimer.o:
 	.text       start:0x804D6220 end:0x804D6520
 
-system/utl/Wav.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/Wav.o:
 	.text       start:0x804D6520 end:0x804D6740
 	.data       start:0x80BDBB80 end:0x80BDBBC0
 
-system/utl/WaveFile.cpp:
+lib.a/hproj/band3_wii/system/src/utl/wii_release/WaveFile.o:
 	.text       start:0x804D6740 end:0x804D82F0
 	.data       start:0x80BDBBC0 end:0x80BDBD68
 
-system/zlib/adler32.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/adler32.o:
 	.text       start:0x804D82F0 end:0x804D8490
 
-system/zlib/compress.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/compress.o:
 	.text       start:0x804D8490 end:0x804D8490
 
-system/zlib/crc32.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/crc32.o:
 	.text       start:0x804D8490 end:0x804D85E0
 	.rodata     start:0x80B36A80 end:0x80B36E80
 
-system/zlib/deflate.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/deflate.o:
 	.text       start:0x804D85E0 end:0x804DA890
 	.rodata     start:0x80B36E80 end:0x80B36EF8
 
-system/zlib/trees.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/trees.o:
 	.text       start:0x804DA890 end:0x804DCD80
 	.rodata     start:0x80B36EF8 end:0x80B37930
 	.data       start:0x80BDBD68 end:0x80BDBDA8
 
-system/zlib/zutil.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/zutil.o:
 	.text       start:0x804DCD80 end:0x804DCDC0
 	.rodata     start:0x80B37930 end:0x80B37958
 	.data       start:0x80BDBDA8 end:0x80BDBE28
 	.sdata      start:0x80C78E48 end:0x80C78E50
 
-system/zlib/inflate.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/inflate.o:
 	.text       start:0x804DCDC0 end:0x804DE810
 	.rodata     start:0x80B37958 end:0x80B38200
 	.data       start:0x80BDBE28 end:0x80BDC050
 
-system/zlib/inftrees.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/inftrees.o:
 	.text       start:0x804DE810 end:0x804DEF70
 	.rodata     start:0x80B38200 end:0x80B38300
 
-system/zlib/inffast.cpp:
+lib.a/hproj/band3_wii/system/src/zlib/wii_release/inffast.o:
 	.text       start:0x804DEF70 end:0x804DF4C0
 	.data       start:0x80BDC050 end:0x80BDC0A0
 
-system/bandobj/ArpeggioShape.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/ArpeggioShape.o:
 	.text       start:0x804DF4C0 end:0x804E0CF0
 	.data       start:0x80BDC0A0 end:0x80BDC290
 	.sbss       start:0x80C7A3E0 end:0x80C7A3E8
 	.bss        start:0x80D16B70 end:0x80D16B78
 
-system/bandobj/Band.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/Band.o:
 	.text       start:0x804E0CF0 end:0x804E1E10
 	.data       start:0x80BDC290 end:0x80BDC538
 	.sbss       start:0x80C7A3E8 end:0x80C7A408
 	.bss        start:0x80D16B78 end:0x80D16BE0
 
-system/bandobj/BandButton.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandButton.o:
 	.text       start:0x804E1E10 end:0x804E3E30
 	.data       start:0x80BDC538 end:0x80BDC828
 	.sbss       start:0x80C7A408 end:0x80C7A410
 	.bss        start:0x80D16BE0 end:0x80D16BF0
 
-system/bandobj/BandCamShot.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandCamShot.o:
 	.text       start:0x804E3E30 end:0x804EEDE0
 	.ctors      start:0x80B34A8C end:0x80B34A90
 	.data       start:0x80BDC828 end:0x80BDCF80
 	.sbss       start:0x80C7A410 end:0x80C7A428
 	.bss        start:0x80D16BF0 end:0x80D16C88
 
-system/bandobj/BandConfiguration.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandConfiguration.o:
 	.text       start:0x804EEDE0 end:0x804F0220
 	.data       start:0x80BDCF80 end:0x80BDD168
 	.sbss       start:0x80C7A428 end:0x80C7A430
 	.bss        start:0x80D16C88 end:0x80D16C98
 
-system/bandobj/BandDirector.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandDirector.o:
 	.text       start:0x804F0220 end:0x80503630
 	.rodata     start:0x80B38300 end:0x80B38360
 	.data       start:0x80BDD168 end:0x80BDEAF8
 	.sbss       start:0x80C7A430 end:0x80C7A448
 	.bss        start:0x80D16C98 end:0x80D16D48
 
-system/bandobj/BandCrowdMeter.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandCrowdMeter.o:
 	.text       start:0x80503630 end:0x8050BEA0
 	.data       start:0x80BDEAF8 end:0x80BDF348
 	.sbss       start:0x80C7A448 end:0x80C7A450
 	.bss        start:0x80D16D48 end:0x80D16D60
 
-system/bandobj/BandHighlight.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandHighlight.o:
 	.text       start:0x8050BEA0 end:0x8050DC90
 	.data       start:0x80BDF348 end:0x80BDF638
 	.sbss       start:0x80C7A450 end:0x80C7A458
 	.bss        start:0x80D16D60 end:0x80D16D68
 
-system/bandobj/BandFaceDeform.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandFaceDeform.o:
 	.text       start:0x8050DC90 end:0x8050FF40
 	.rodata     start:0x80B38360 end:0x80B38368
 	.data       start:0x80BDF638 end:0x80BDF8A8
 	.sbss       start:0x80C7A458 end:0x80C7A460
 	.bss        start:0x80D16D68 end:0x80D16D80
 
-system/bandobj/BandIKEffector.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandIKEffector.o:
 	.text       start:0x8050FF40 end:0x80516700
 	.rodata     start:0x80B38368 end:0x80B38370
 	.data       start:0x80BDF8A8 end:0x80BE03F8
 	.sbss       start:0x80C7A460 end:0x80C7A470
 	.bss        start:0x80D16D80 end:0x80D16DB0
 
-system/bandobj/BandLabel.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandLabel.o:
 	.text       start:0x80516700 end:0x80518D80
 	.data       start:0x80BE03F8 end:0x80BE0708
 	.sbss       start:0x80C7A470 end:0x80C7A478
 	.bss        start:0x80D16DB0 end:0x80D16DC0
 
-system/bandobj/BandLeadMeter.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandLeadMeter.o:
 	.text       start:0x80518D80 end:0x8051B680
 	.data       start:0x80BE0708 end:0x80BE0B38
 	.sbss       start:0x80C7A478 end:0x80C7A480
 	.bss        start:0x80D16DC0 end:0x80D16DC8
 
-system/bandobj/BandList.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandList.o:
 	.text       start:0x8051B680 end:0x80524CA0
 	.data       start:0x80BE0B38 end:0x80BE10E0
 	.sdata      start:0x80C78E50 end:0x80C78E60
 	.sbss       start:0x80C7A480 end:0x80C7A488
 	.bss        start:0x80D16DC8 end:0x80D16DD8
 
-system/bandobj/BandPatchMesh.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandPatchMesh.o:
 	.text       start:0x80524CA0 end:0x80533670
 	.rodata     start:0x80B38370 end:0x80B38388
 	.data       start:0x80BE10E0 end:0x80BE1B20
 	.sbss       start:0x80C7A488 end:0x80C7A490
 	.bss        start:0x80D16DD8 end:0x80D16DE0
 
-system/bandobj/BandScoreboard.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandScoreboard.o:
 	.text       start:0x80533670 end:0x805365F0
 	.data       start:0x80BE1B20 end:0x80BE2028
 	.sbss       start:0x80C7A490 end:0x80C7A498
 	.bss        start:0x80D16DE0 end:0x80D16DE8
 
-system/bandobj/BandSong.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandSong.o:
 	.text       start:0x805365F0 end:0x80536C50
 	.data       start:0x80BE2028 end:0x80BE21C0
 	.sbss       start:0x80C7A498 end:0x80C7A4A0
 	.bss        start:0x80D16DE8 end:0x80D16DF0
 
-system/bandobj/BandStarDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandStarDisplay.o:
 	.text       start:0x80536C50 end:0x8053B0B0
 	.data       start:0x80BE21C0 end:0x80BE2678
 	.sbss       start:0x80C7A4A0 end:0x80C7A4A8
 	.bss        start:0x80D16DF0 end:0x80D16DF8
 
-system/bandobj/BandSwatch.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandSwatch.o:
 	.text       start:0x8053B0B0 end:0x8053CE10
 	.data       start:0x80BE2678 end:0x80BE2AD8
 	.sbss       start:0x80C7A4A8 end:0x80C7A4B0
 	.bss        start:0x80D16DF8 end:0x80D16E10
 
-system/bandobj/BandCharacter.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandCharacter.o:
 	.text       start:0x8053CE10 end:0x8054FBE0
 	.rodata     start:0x80B38388 end:0x80B38400
 	.data       start:0x80BE2AD8 end:0x80BE5050
@@ -4693,7 +4693,7 @@ system/bandobj/BandCharacter.cpp:
 	.sbss       start:0x80C7A4B0 end:0x80C7A4D8
 	.bss        start:0x80D16E10 end:0x80D16F48
 
-system/bandobj/BandCharDesc.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandCharDesc.o:
 	.text       start:0x8054FBE0 end:0x80558710
 	.ctors      start:0x80B34A90 end:0x80B34A94
 	.rodata     start:0x80B38400 end:0x80B38558
@@ -4702,7 +4702,7 @@ system/bandobj/BandCharDesc.cpp:
 	.sbss       start:0x80C7A4D8 end:0x80C7A4E0
 	.bss        start:0x80D16F48 end:0x80D16F78
 
-system/bandobj/BandHeadShaper.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandHeadShaper.o:
 	.text       start:0x80558710 end:0x8055B2A0
 	.ctors      start:0x80B34A94 end:0x80B34A98
 	.rodata     start:0x80B38558 end:0x80B38560
@@ -4710,37 +4710,37 @@ system/bandobj/BandHeadShaper.cpp:
 	.sbss       start:0x80C7A4E0 end:0x80C7A4E8
 	.bss        start:0x80D16F78 end:0x80D17028
 
-system/bandobj/BandRetargetVignette.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandRetargetVignette.o:
 	.text       start:0x8055B2A0 end:0x8055D570
 	.data       start:0x80BE5CC0 end:0x80BE6058
 	.sbss       start:0x80C7A4E8 end:0x80C7A4F0
 	.bss        start:0x80D17028 end:0x80D17040
 
-system/bandobj/BandSongPref.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandSongPref.o:
 	.text       start:0x8055D570 end:0x8055E130
 	.data       start:0x80BE6058 end:0x80BE6178
 	.sbss       start:0x80C7A4F0 end:0x80C7A4F8
 	.bss        start:0x80D17040 end:0x80D17048
 
-system/bandobj/BandWardrobe.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandWardrobe.o:
 	.text       start:0x8055E130 end:0x805729B0
 	.rodata     start:0x80B38560 end:0x80B38608
 	.data       start:0x80BE6178 end:0x80BE6E40
 	.sbss       start:0x80C7A4F8 end:0x80C7A510
 	.bss        start:0x80D17048 end:0x80D170D0
 
-system/bandobj/CharDeform.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/CharDeform.o:
 	.text       start:0x805729B0 end:0x80572AB0
 	.data       start:0x80BE6E40 end:0x80BE6E58
 
-system/bandobj/CharKeyHandMidi.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/CharKeyHandMidi.o:
 	.text       start:0x80572AB0 end:0x80577B10
 	.rodata     start:0x80B38608 end:0x80B38610
 	.data       start:0x80BE6E58 end:0x80BE7348
 	.sbss       start:0x80C7A510 end:0x80C7A518
 	.bss        start:0x80D170D0 end:0x80D170D8
 
-system/bandobj/ChordShapeGenerator.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/ChordShapeGenerator.o:
 	.text       start:0x80577B10 end:0x80580BB0
 	.ctors      start:0x80B34A98 end:0x80B34A9C
 	.rodata     start:0x80B38610 end:0x80B38618
@@ -4749,43 +4749,43 @@ system/bandobj/ChordShapeGenerator.cpp:
 	.sbss       start:0x80C7A518 end:0x80C7A520
 	.bss        start:0x80D170D8 end:0x80D17120
 
-system/bandobj/DialogDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/DialogDisplay.o:
 	.text       start:0x80580BB0 end:0x80582120
 	.data       start:0x80BE7E50 end:0x80BE8068
 	.sbss       start:0x80C7A520 end:0x80C7A528
 	.bss        start:0x80D17120 end:0x80D17128
 
-system/bandobj/EndingBonus.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/EndingBonus.o:
 	.text       start:0x80582120 end:0x80585280
 	.data       start:0x80BE8068 end:0x80BE85F0
 	.sbss       start:0x80C7A528 end:0x80C7A530
 	.bss        start:0x80D17128 end:0x80D17130
 
-system/bandobj/FingerShape.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/FingerShape.o:
 	.text       start:0x80585280 end:0x80587350
 	.data       start:0x80BE85F0 end:0x80BE87F8
 
-system/bandobj/LayerDir.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/LayerDir.o:
 	.text       start:0x80587350 end:0x8058BC70
 	.data       start:0x80BE87F8 end:0x80BE8CF8
 	.sdata      start:0x80C78E80 end:0x80C78E90
 	.sbss       start:0x80C7A530 end:0x80C7A538
 	.bss        start:0x80D17130 end:0x80D17148
 
-system/bandobj/NoteTube.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/NoteTube.o:
 	.text       start:0x8058BC70 end:0x8058E2C0
 	.rodata     start:0x80B38618 end:0x80B38620
 	.data       start:0x80BE8CF8 end:0x80BE8FC0
 	.sbss       start:0x80C7A538 end:0x80C7A540
 
-system/bandobj/OutfitConfig.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/OutfitConfig.o:
 	.text       start:0x8058E2C0 end:0x805A9360
 	.data       start:0x80BE8FC0 end:0x80BEA388
 	.sdata      start:0x80C78E90 end:0x80C78E98
 	.sbss       start:0x80C7A540 end:0x80C7A550
 	.bss        start:0x80D17148 end:0x80D171A0
 
-system/bandobj/PatchDir.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/PatchDir.o:
 	.text       start:0x805A9360 end:0x805B1D00
 	.ctors      start:0x80B34A9C end:0x80B34AA0
 	.rodata     start:0x80B38620 end:0x80B38650
@@ -4794,67 +4794,67 @@ system/bandobj/PatchDir.cpp:
 	.sbss       start:0x80C7A550 end:0x80C7A558
 	.bss        start:0x80D171A0 end:0x80D171E8
 
-system/bandobj/PatchRenderer.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/PatchRenderer.o:
 	.text       start:0x805B1D00 end:0x805B3420
 	.data       start:0x80BEB298 end:0x80BEB598
 	.sbss       start:0x80C7A558 end:0x80C7A560
 	.bss        start:0x80D171E8 end:0x80D171F8
 
-system/bandobj/PitchArrow.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/PitchArrow.o:
 	.text       start:0x805B3420 end:0x805B8160
 	.data       start:0x80BEB598 end:0x80BEBB20
 	.sbss       start:0x80C7A560 end:0x80C7A568
 	.bss        start:0x80D171F8 end:0x80D17210
 
-system/bandobj/PlayerDiffIcon.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/PlayerDiffIcon.o:
 	.text       start:0x805B8160 end:0x805BA330
 	.data       start:0x80BEBB20 end:0x80BEBE18
 	.sbss       start:0x80C7A568 end:0x80C7A570
 	.bss        start:0x80D17210 end:0x80D17218
 
-system/bandobj/InstrumentDifficultyDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/InstrumentDifficultyDisplay.o:
 	.text       start:0x805BA330 end:0x805BC840
 	.data       start:0x80BEBE18 end:0x80BEC200
 	.sbss       start:0x80C7A570 end:0x80C7A578
 	.bss        start:0x80D17218 end:0x80D17220
 
-system/bandobj/ScrollbarDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/ScrollbarDisplay.o:
 	.text       start:0x805BC840 end:0x805BEEA0
 	.data       start:0x80BEC200 end:0x80BEC5F8
 	.sbss       start:0x80C7A578 end:0x80C7A580
 	.bss        start:0x80D17220 end:0x80D17228
 
-system/bandobj/CheckboxDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/CheckboxDisplay.o:
 	.text       start:0x805BEEA0 end:0x805BFF40
 	.data       start:0x80BEC5F8 end:0x80BEC848
 	.sbss       start:0x80C7A580 end:0x80C7A588
 	.bss        start:0x80D17228 end:0x80D17230
 
-system/bandobj/ScoreDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/ScoreDisplay.o:
 	.text       start:0x805BFF40 end:0x805C17C0
 	.data       start:0x80BEC848 end:0x80BECB10
 	.sbss       start:0x80C7A588 end:0x80C7A590
 	.bss        start:0x80D17230 end:0x80D17238
 
-system/bandobj/ReviewDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/ReviewDisplay.o:
 	.text       start:0x805C17C0 end:0x805C2DA0
 	.data       start:0x80BECB10 end:0x80BECDA8
 	.sbss       start:0x80C7A590 end:0x80C7A598
 	.bss        start:0x80D17238 end:0x80D17240
 
-system/bandobj/StarDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/StarDisplay.o:
 	.text       start:0x805C2DA0 end:0x805C5620
 	.data       start:0x80BECDA8 end:0x80BED040
 	.sbss       start:0x80C7A598 end:0x80C7A5A0
 	.bss        start:0x80D17240 end:0x80D17248
 
-system/bandobj/MeterDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/MeterDisplay.o:
 	.text       start:0x805C5620 end:0x805C7720
 	.data       start:0x80BED040 end:0x80BED2D0
 	.sbss       start:0x80C7A5A0 end:0x80C7A5A8
 	.bss        start:0x80D17248 end:0x80D17250
 
-system/bandobj/MicInputArrow.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/MicInputArrow.o:
 	.text       start:0x805C7720 end:0x805C9DE0
 	.ctors      start:0x80B34AA0 end:0x80B34AA4
 	.data       start:0x80BED2D0 end:0x80BED650
@@ -4862,26 +4862,26 @@ system/bandobj/MicInputArrow.cpp:
 	.sbss       start:0x80C7A5A8 end:0x80C7A5B0
 	.bss        start:0x80D17250 end:0x80D17260
 
-system/bandobj/MiniLeaderboardDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/MiniLeaderboardDisplay.o:
 	.text       start:0x805C9DE0 end:0x805CACD0
 	.data       start:0x80BED650 end:0x80BED8A8
 	.sbss       start:0x80C7A5B0 end:0x80C7A5B8
 	.bss        start:0x80D17260 end:0x80D17268
 
-system/bandobj/StreakMeter.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/StreakMeter.o:
 	.text       start:0x805CACD0 end:0x805D06A0
 	.rodata     start:0x80B38650 end:0x80B38658
 	.data       start:0x80BED8A8 end:0x80BEDFF8
 	.sbss       start:0x80C7A5B8 end:0x80C7A5C0
 	.bss        start:0x80D17268 end:0x80D17270
 
-system/bandobj/OverdriveMeter.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/OverdriveMeter.o:
 	.text       start:0x805D06A0 end:0x805D24B0
 	.data       start:0x80BEDFF8 end:0x80BEE428
 	.sbss       start:0x80C7A5C0 end:0x80C7A5C8
 	.bss        start:0x80D17270 end:0x80D17278
 
-system/bandobj/GemTrackDir.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/GemTrackDir.o:
 	.text       start:0x805D24B0 end:0x805E1060
 	.rodata     start:0x80B38658 end:0x80B38668
 	.data       start:0x80BEE428 end:0x80BF0828
@@ -4889,13 +4889,13 @@ system/bandobj/GemTrackDir.cpp:
 	.sbss       start:0x80C7A5C8 end:0x80C7A5D0
 	.bss        start:0x80D17278 end:0x80D172B0
 
-system/bandobj/GemTrackResourceManager.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/GemTrackResourceManager.o:
 	.text       start:0x805E1060 end:0x805E2690
 	.data       start:0x80BF0828 end:0x80BF0A30
 	.sbss       start:0x80C7A5D0 end:0x80C7A5D8
 	.bss        start:0x80D172B0 end:0x80D172C8
 
-system/bandobj/VocalTrackDir.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/VocalTrackDir.o:
 	.text       start:0x805E2690 end:0x805F0650
 	.rodata     start:0x80B38668 end:0x80B38678
 	.data       start:0x80BF0A30 end:0x80BF2B88
@@ -4903,7 +4903,7 @@ system/bandobj/VocalTrackDir.cpp:
 	.sbss       start:0x80C7A5D8 end:0x80C7A5E0
 	.bss        start:0x80D172C8 end:0x80D172F8
 
-system/bandobj/BandTrack.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/BandTrack.o:
 	.text       start:0x805F0650 end:0x805F7840
 	.rodata     start:0x80B38678 end:0x80B38680
 	.data       start:0x80BF2B88 end:0x80BF3120
@@ -4911,7 +4911,7 @@ system/bandobj/BandTrack.cpp:
 	.sbss       start:0x80C7A5E0 end:0x80C7A5F0
 	.bss        start:0x80D172F8 end:0x80D173A0
 
-system/bandobj/TrackPanelDirBase.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/TrackPanelDirBase.o:
 	.text       start:0x805F7840 end:0x805FB920
 	.rodata     start:0x80B38680 end:0x80B38688
 	.data       start:0x80BF3120 end:0x80BF36E8
@@ -4919,269 +4919,269 @@ system/bandobj/TrackPanelDirBase.cpp:
 	.sbss       start:0x80C7A5F0 end:0x80C7A600
 	.bss        start:0x80D173A0 end:0x80D173F8
 
-system/bandobj/TrackPanelDir.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/TrackPanelDir.o:
 	.text       start:0x805FB920 end:0x806050F0
 	.data       start:0x80BF36E8 end:0x80BF4F90
 	.sbss       start:0x80C7A600 end:0x80C7A610
 	.bss        start:0x80D173F8 end:0x80D17458
 
-system/bandobj/CrowdMeterIcon.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/CrowdMeterIcon.o:
 	.text       start:0x806050F0 end:0x80607BE0
 	.data       start:0x80BF4F90 end:0x80BF5380
 	.sbss       start:0x80C7A610 end:0x80C7A618
 	.bss        start:0x80D17458 end:0x80D17460
 
-system/bandobj/CrowdAudio.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/CrowdAudio.o:
 	.text       start:0x80607BE0 end:0x8060B730
 	.data       start:0x80BF5380 end:0x80BF5790
 	.sbss       start:0x80C7A618 end:0x80C7A628
 	.bss        start:0x80D17460 end:0x80D17480
 
-system/bandobj/InlineHelp.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/InlineHelp.o:
 	.text       start:0x8060B730 end:0x8060FAE0
 	.rodata     start:0x80B38688 end:0x80B38690
 	.data       start:0x80BF5790 end:0x80BF5AA0
 	.sbss       start:0x80C7A628 end:0x80C7A638
 	.bss        start:0x80D17480 end:0x80D17498
 
-system/bandobj/UnisonIcon.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/UnisonIcon.o:
 	.text       start:0x8060FAE0 end:0x80611270
 	.data       start:0x80BF5AA0 end:0x80BF5E20
 	.sbss       start:0x80C7A638 end:0x80C7A640
 	.bss        start:0x80D17498 end:0x80D174A0
 
-system/bandobj/SongSectionController.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/SongSectionController.o:
 	.text       start:0x80611270 end:0x80618B70
 	.data       start:0x80BF5E20 end:0x80BF6328
 	.sbss       start:0x80C7A640 end:0x80C7A650
 	.bss        start:0x80D174A0 end:0x80D174D8
 
-system/bandobj/OvershellDir.cpp:
+lib.a/hproj/band3_wii/system/src/bandobj/wii_release/OvershellDir.o:
 	.text       start:0x80618B70 end:0x8061AF90
 	.data       start:0x80BF6328 end:0x80BF66A0
 	.sbss       start:0x80C7A650 end:0x80C7A658
 	.bss        start:0x80D174D8 end:0x80D174F0
 
-system/beatmatch/BaseGuitarTrackWatcherImpl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/BaseGuitarTrackWatcherImpl.o:
 	.text       start:0x8061AF90 end:0x8061C600
 	.data       start:0x80BF66A0 end:0x80BF6840
 
-system/beatmatch/BeatMaster.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/BeatMaster.o:
 	.text       start:0x8061C600 end:0x8061E080
 	.data       start:0x80BF6840 end:0x80BF6A00
 	.sdata      start:0x80C78EC8 end:0x80C78ED0
 	.sbss       start:0x80C7A658 end:0x80C7A660
 	.bss        start:0x80D174F0 end:0x80D174F8
 
-system/beatmatch/BeatMatch.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/BeatMatch.o:
 	.text       start:0x8061E080 end:0x8061E090
 
-system/beatmatch/BeatMatchController.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/BeatMatchController.o:
 	.text       start:0x8061E090 end:0x8061E880
 	.data       start:0x80BF6A00 end:0x80BF6B98
 
-system/beatmatch/BeatMatchUtl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/BeatMatchUtl.o:
 	.text       start:0x8061E880 end:0x8061ED00
 	.data       start:0x80BF6B98 end:0x80BF6D08
 
-system/beatmatch/BeatMatcher.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/BeatMatcher.o:
 	.text       start:0x8061ED00 end:0x80621410
 	.rodata     start:0x80B38690 end:0x80B386A0
 	.data       start:0x80BF6D08 end:0x80BF6FD0
 
-system/beatmatch/ButtonGuitarController.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/ButtonGuitarController.o:
 	.text       start:0x80621410 end:0x80622D30
 	.data       start:0x80BF6FD0 end:0x80BF70F8
 
-system/beatmatch/DrumFillTrackWatcherImpl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/DrumFillTrackWatcherImpl.o:
 	.text       start:0x80622D30 end:0x80623150
 	.data       start:0x80BF70F8 end:0x80BF7218
 
-system/beatmatch/DrumMap.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/DrumMap.o:
 	.text       start:0x80623150 end:0x80623820
 	.data       start:0x80BF7218 end:0x80BF72D0
 
-system/beatmatch/DrumMixDB.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/DrumMixDB.o:
 	.text       start:0x80623820 end:0x806246D0
 	.data       start:0x80BF72D0 end:0x80BF7360
 
-system/beatmatch/DrumPlayer.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/DrumPlayer.o:
 	.text       start:0x806246D0 end:0x80624F90
 	.data       start:0x80BF7360 end:0x80BF7450
 
-system/beatmatch/DrumTrackWatcherImpl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/DrumTrackWatcherImpl.o:
 	.text       start:0x80624F90 end:0x80626160
 	.data       start:0x80BF7450 end:0x80BF7558
 	.sbss       start:0x80C7A660 end:0x80C7A668
 
-system/beatmatch/FillInfo.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/FillInfo.o:
 	.text       start:0x80626160 end:0x80626D50
 	.data       start:0x80BF7558 end:0x80BF75C0
 
-system/beatmatch/GameGem.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/GameGem.o:
 	.text       start:0x80626D50 end:0x80628230
 	.data       start:0x80BF75C0 end:0x80BF7660
 	.sdata      start:0x80C78ED0 end:0x80C78ED8
 
-system/beatmatch/GameGemDB.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/GameGemDB.o:
 	.text       start:0x80628230 end:0x80628940
 	.data       start:0x80BF7660 end:0x80BF76D0
 
-system/beatmatch/GameGemList.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/GameGemList.o:
 	.text       start:0x80628940 end:0x8062C070
 	.rodata     start:0x80B386A0 end:0x80B386A8
 	.data       start:0x80BF76D0 end:0x80BF7760
 
-system/beatmatch/GuitarController.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/GuitarController.o:
 	.text       start:0x8062C070 end:0x8062DB20
 	.rodata     start:0x80B386A8 end:0x80B386B0
 	.data       start:0x80BF7760 end:0x80BF7AF0
 
-system/beatmatch/GuitarTrackWatcherImpl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/GuitarTrackWatcherImpl.o:
 	.text       start:0x8062DB20 end:0x8062E440
 	.data       start:0x80BF7AF0 end:0x80BF7C40
 
-system/beatmatch/JoypadController.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/JoypadController.o:
 	.text       start:0x8062E440 end:0x8062FCC0
 	.data       start:0x80BF7C40 end:0x80BF7DB8
 
-system/beatmatch/JoypadGuitarController.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/JoypadGuitarController.o:
 	.text       start:0x8062FCC0 end:0x80630810
 	.data       start:0x80BF7DB8 end:0x80BF7F00
 
-system/beatmatch/JoypadMidiController.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/JoypadMidiController.o:
 	.text       start:0x80630810 end:0x806319B0
 	.data       start:0x80BF7F00 end:0x80BF8040
 	.sbss       start:0x80C7A668 end:0x80C7A670
 	.bss        start:0x80D174F8 end:0x80D17500
 
-system/beatmatch/JoypadTrackWatcherImpl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/JoypadTrackWatcherImpl.o:
 	.text       start:0x806319B0 end:0x806323B0
 	.data       start:0x80BF8040 end:0x80BF8160
 
-system/beatmatch/KeyboardController.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/KeyboardController.o:
 	.text       start:0x806323B0 end:0x806334F0
 	.data       start:0x80BF8160 end:0x80BF8280
 
-system/beatmatch/KeyboardTrackWatcherImpl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/KeyboardTrackWatcherImpl.o:
 	.text       start:0x806334F0 end:0x806352B0
 	.data       start:0x80BF8280 end:0x80BF8498
 
-system/beatmatch/MasterAudio.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/MasterAudio.o:
 	.text       start:0x806352B0 end:0x8063B990
 	.rodata     start:0x80B386B0 end:0x80B386D8
 	.data       start:0x80BF8498 end:0x80BF8DD0
 	.sdata      start:0x80C78ED8 end:0x80C78EE0
 
-system/beatmatch/MercurySwitchFilter.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/MercurySwitchFilter.o:
 	.text       start:0x8063B990 end:0x8063C040
 	.data       start:0x80BF8DD0 end:0x80BF8F78
 	.bss        start:0x80D17500 end:0x80D17508
 
-system/beatmatch/Output.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/Output.o:
 	.text       start:0x8063C040 end:0x8063C090
 	.ctors      start:0x80B34AA4 end:0x80B34AA8
 	.data       start:0x80BF8F78 end:0x80BF8F90
 	.bss        start:0x80D17508 end:0x80D17538
 
-system/beatmatch/PhraseAnalyzer.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/PhraseAnalyzer.o:
 	.text       start:0x8063C090 end:0x8063E050
 	.data       start:0x80BF8F90 end:0x80BF90D8
 
-system/beatmatch/PhraseDB.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/PhraseDB.o:
 	.text       start:0x8063E050 end:0x8063E400
 	.data       start:0x80BF90D8 end:0x80BF9138
 
-system/beatmatch/PhraseList.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/PhraseList.o:
 	.text       start:0x8063E400 end:0x8063EDC0
 	.data       start:0x80BF9138 end:0x80BF91C8
 
-system/beatmatch/Playback.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/Playback.o:
 	.text       start:0x8063EDC0 end:0x8063F640
 	.ctors      start:0x80B34AA8 end:0x80B34AAC
 	.data       start:0x80BF91C8 end:0x80BF9238
 	.bss        start:0x80D17538 end:0x80D17578
 
-system/beatmatch/PlayerTrackConfigList.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/PlayerTrackConfigList.o:
 	.text       start:0x8063F640 end:0x80641850
 	.data       start:0x80BF9238 end:0x80BF9528
 
-system/beatmatch/RealGuitarController.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/RealGuitarController.o:
 	.text       start:0x80641850 end:0x80642C50
 	.data       start:0x80BF9528 end:0x80BF9690
 
-system/beatmatch/RealGuitarTrackWatcherImpl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/RealGuitarTrackWatcherImpl.o:
 	.text       start:0x80642C50 end:0x80643E70
 	.data       start:0x80BF9690 end:0x80BF97E0
 
-system/beatmatch/RGGemMatcher.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/RGGemMatcher.o:
 	.text       start:0x80643E70 end:0x80644880
 	.rodata     start:0x80B386D8 end:0x80B386E0
 	.data       start:0x80BF97E0 end:0x80BF9818
 
-system/beatmatch/RGState.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/RGState.o:
 	.text       start:0x80644880 end:0x80644B40
 	.data       start:0x80BF9818 end:0x80BF9850
 
-system/beatmatch/RGUtl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/RGUtl.o:
 	.text       start:0x80644B40 end:0x80647430
 	.data       start:0x80BF9850 end:0x80BF9B48
 	.sdata      start:0x80C78EE0 end:0x80C78F00
 	.sbss       start:0x80C7A670 end:0x80C7A678
 	.bss        start:0x80D17578 end:0x80D17580
 
-system/beatmatch/SlotChannelMapping.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/SlotChannelMapping.o:
 	.text       start:0x80647430 end:0x806483D0
 	.data       start:0x80BF9B48 end:0x80BF9D90
 
-system/beatmatch/SongData.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/SongData.o:
 	.text       start:0x806483D0 end:0x80655FB0
 	.rodata     start:0x80B386E0 end:0x80B386E8
 	.data       start:0x80BF9D90 end:0x80BFB228
 	.sdata      start:0x80C78F00 end:0x80C78F08
 	.sbss       start:0x80C7A678 end:0x80C7A680
 
-system/beatmatch/SongParser.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/SongParser.o:
 	.text       start:0x80655FB0 end:0x806634A0
 	.ctors      start:0x80B34AAC end:0x80B34AB0
 	.rodata     start:0x80B386E8 end:0x80B38708
 	.data       start:0x80BFB228 end:0x80BFC810
 	.bss        start:0x80D17580 end:0x80D175B0
 
-system/beatmatch/Submix.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/Submix.o:
 	.text       start:0x806634A0 end:0x80663D50
 	.data       start:0x80BFC810 end:0x80BFC878
 
-system/beatmatch/TimeSpanVector.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/TimeSpanVector.o:
 	.text       start:0x80663D50 end:0x80663F00
 	.data       start:0x80BFC878 end:0x80BFC8B8
 
-system/beatmatch/TrackType.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/TrackType.o:
 	.text       start:0x80663F00 end:0x80664020
 	.data       start:0x80BFC8B8 end:0x80BFC8E0
 
-system/beatmatch/TrackWatcher.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/TrackWatcher.o:
 	.text       start:0x80664020 end:0x80664960
 	.data       start:0x80BFC8E0 end:0x80BFC948
 
-system/beatmatch/TrackWatcherImpl.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/TrackWatcherImpl.o:
 	.text       start:0x80664960 end:0x80669B80
 	.rodata     start:0x80B38708 end:0x80B38710
 	.data       start:0x80BFC948 end:0x80BFCC18
 
-system/beatmatch/VocalNoteList.cpp:
+lib.a/hproj/band3_wii/system/src/beatmatch/wii_release/VocalNoteList.o:
 	.text       start:0x80669B80 end:0x8066E4D0
 	.data       start:0x80BFCC18 end:0x80BFD0B0
 	.sbss       start:0x80C7A680 end:0x80C7A688
 
-system/char/Char.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/Char.o:
 	.text       start:0x8066E4D0 end:0x80671D90
 	.ctors      start:0x80B34AB0 end:0x80B34AB4
 	.data       start:0x80BFD0B0 end:0x80BFD3B8
 	.sbss       start:0x80C7A688 end:0x80C7A6B8
 	.bss        start:0x80D175B0 end:0x80D176A0
 
-system/char/Character.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/Character.o:
 	.text       start:0x80671D90 end:0x8067E8B0
 	.rodata     start:0x80B38710 end:0x80B38718
 	.data       start:0x80BFD3B8 end:0x80BFE778
@@ -5189,210 +5189,210 @@ system/char/Character.cpp:
 	.sbss       start:0x80C7A6B8 end:0x80C7A6C8
 	.bss        start:0x80D176A0 end:0x80D176C0
 
-system/char/CharBlendBone.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBlendBone.o:
 	.text       start:0x8067E8B0 end:0x806805E0
 	.data       start:0x80BFE778 end:0x80BFE960
 	.sbss       start:0x80C7A6C8 end:0x80C7A6D0
 	.bss        start:0x80D176C0 end:0x80D176C8
 
-system/char/CharBone.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBone.o:
 	.text       start:0x806805E0 end:0x80683440
 	.data       start:0x80BFE960 end:0x80BFECD8
 	.sdata      start:0x80C78F10 end:0x80C78F18
 	.sbss       start:0x80C7A6D0 end:0x80C7A6D8
 	.bss        start:0x80D176C8 end:0x80D176D0
 
-system/char/CharBoneDir.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBoneDir.o:
 	.text       start:0x80683440 end:0x806886D0
 	.data       start:0x80BFECD8 end:0x80BFF170
 	.sbss       start:0x80C7A6D8 end:0x80C7A6E0
 	.bss        start:0x80D176D0 end:0x80D176E0
 
-system/char/CharBones.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBones.o:
 	.text       start:0x806886D0 end:0x8068CD30
 	.rodata     start:0x80B38718 end:0x80B38730
 	.data       start:0x80BFF170 end:0x80BFF4B8
 	.sbss       start:0x80C7A6E0 end:0x80C7A6E8
 	.bss        start:0x80D176E0 end:0x80D17700
 
-system/char/CharBoneOffset.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBoneOffset.o:
 	.text       start:0x8068CD30 end:0x8068DAE0
 	.data       start:0x80BFF4B8 end:0x80BFF648
 	.sbss       start:0x80C7A6E8 end:0x80C7A6F0
 	.bss        start:0x80D17700 end:0x80D17708
 
-system/char/CharBonesMeshes.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBonesMeshes.o:
 	.text       start:0x8068DAE0 end:0x8068FA30
 	.data       start:0x80BFF648 end:0x80BFF748
 
-system/char/CharBonesSamples.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBonesSamples.o:
 	.text       start:0x8068FA30 end:0x80692ED0
 	.rodata     start:0x80B38730 end:0x80B38738
 	.data       start:0x80BFF748 end:0x80BFFA88
 	.sbss       start:0x80C7A6F0 end:0x80C7A6F8
 	.bss        start:0x80D17708 end:0x80D17738
 
-system/char/CharBonesBlender.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBonesBlender.o:
 	.text       start:0x80692ED0 end:0x80694220
 	.data       start:0x80BFFA88 end:0x80BFFCD8
 	.sbss       start:0x80C7A6F8 end:0x80C7A700
 	.bss        start:0x80D17738 end:0x80D17740
 
-system/char/CharBoneTwist.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharBoneTwist.o:
 	.text       start:0x80694220 end:0x80695A20
 	.data       start:0x80BFFCD8 end:0x80BFFEF0
 	.sbss       start:0x80C7A700 end:0x80C7A708
 	.bss        start:0x80D17740 end:0x80D17748
 
-system/char/CharClip.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharClip.o:
 	.text       start:0x80695A20 end:0x8069E0A0
 	.ctors      start:0x80B34AB4 end:0x80B34AB8
 	.data       start:0x80BFFEF0 end:0x80C005E0
 	.sbss       start:0x80C7A708 end:0x80C7A718
 	.bss        start:0x80D17748 end:0x80D17868
 
-system/char/CharClipDisplay.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharClipDisplay.o:
 	.text       start:0x8069E0A0 end:0x8069F600
 	.rodata     start:0x80B38738 end:0x80B38740
 	.data       start:0x80C005E0 end:0x80C006C0
 	.bss        start:0x80D17868 end:0x80D17870
 
-system/char/CharClipDriver.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharClipDriver.o:
 	.text       start:0x8069F600 end:0x806A14C0
 	.data       start:0x80C006C0 end:0x80C007E8
 	.sbss       start:0x80C7A718 end:0x80C7A720
 	.bss        start:0x80D17870 end:0x80D17890
 
-system/char/CharClipGroup.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharClipGroup.o:
 	.text       start:0x806A14C0 end:0x806A5930
 	.data       start:0x80C007E8 end:0x80C009E0
 	.sbss       start:0x80C7A720 end:0x80C7A728
 	.bss        start:0x80D17890 end:0x80D17898
 
-system/char/CharClipSet.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharClipSet.o:
 	.text       start:0x806A5930 end:0x806AAED0
 	.data       start:0x80C009E0 end:0x80C00FA8
 	.sbss       start:0x80C7A728 end:0x80C7A730
 	.bss        start:0x80D17898 end:0x80D178A0
 
-system/char/CharCollide.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharCollide.o:
 	.text       start:0x806AAED0 end:0x806AD2F0
 	.data       start:0x80C00FA8 end:0x80C011C8
 	.sbss       start:0x80C7A730 end:0x80C7A738
 	.bss        start:0x80D178A0 end:0x80D178B8
 
-system/char/CharCuff.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharCuff.o:
 	.text       start:0x806AD2F0 end:0x806B1480
 	.rodata     start:0x80B38740 end:0x80B38750
 	.data       start:0x80C011C8 end:0x80C01450
 	.sbss       start:0x80C7A738 end:0x80C7A740
 	.bss        start:0x80D178B8 end:0x80D178C0
 
-system/char/CharDriver.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharDriver.o:
 	.text       start:0x806B1480 end:0x806B7B80
 	.data       start:0x80C01450 end:0x80C01838
 	.sbss       start:0x80C7A740 end:0x80C7A750
 	.bss        start:0x80D178C0 end:0x80D17918
 
-system/char/CharDriverMidi.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharDriverMidi.o:
 	.text       start:0x806B7B80 end:0x806B9430
 	.data       start:0x80C01838 end:0x80C01A38
 	.sbss       start:0x80C7A750 end:0x80C7A758
 	.bss        start:0x80D17918 end:0x80D17920
 
-system/char/CharEyes.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharEyes.o:
 	.text       start:0x806B9430 end:0x806C62D0
 	.rodata     start:0x80B38750 end:0x80B38790
 	.data       start:0x80C01A38 end:0x80C021D0
 	.sbss       start:0x80C7A758 end:0x80C7A768
 	.bss        start:0x80D17920 end:0x80D17940
 
-system/char/CharInterest.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharInterest.o:
 	.text       start:0x806C62D0 end:0x806C8610
 	.rodata     start:0x80B38790 end:0x80B387A0
 	.data       start:0x80C021D0 end:0x80C024E0
 	.sbss       start:0x80C7A768 end:0x80C7A770
 	.bss        start:0x80D17940 end:0x80D17948
 
-system/char/CharEyeDartRuleset.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharEyeDartRuleset.o:
 	.text       start:0x806C8610 end:0x806C9850
 	.rodata     start:0x80B387A0 end:0x80B387A8
 	.data       start:0x80C024E0 end:0x80C026C0
 	.sbss       start:0x80C7A770 end:0x80C7A778
 	.bss        start:0x80D17948 end:0x80D17950
 
-system/char/CharFaceServo.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharFaceServo.o:
 	.text       start:0x806C9850 end:0x806CB640
 	.data       start:0x80C026C0 end:0x80C02880
 	.sbss       start:0x80C7A778 end:0x80C7A780
 	.bss        start:0x80D17950 end:0x80D17970
 
-system/char/CharForeTwist.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharForeTwist.o:
 	.text       start:0x806CB640 end:0x806CCBC0
 	.rodata     start:0x80B387A8 end:0x80B387B0
 	.data       start:0x80C02880 end:0x80C02A10
 	.sbss       start:0x80C7A780 end:0x80C7A788
 	.bss        start:0x80D17970 end:0x80D17978
 
-system/char/CharHair.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharHair.o:
 	.text       start:0x806CCBC0 end:0x806E3660
 	.rodata     start:0x80B387B0 end:0x80B387B8
 	.data       start:0x80C02A10 end:0x80C02D40
 	.sbss       start:0x80C7A788 end:0x80C7A790
 	.bss        start:0x80D17978 end:0x80D17988
 
-system/char/CharIKFingers.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharIKFingers.o:
 	.text       start:0x806E3660 end:0x806EA810
 	.rodata     start:0x80B387B8 end:0x80B38808
 	.data       start:0x80C02D40 end:0x80C033B0
 	.sbss       start:0x80C7A790 end:0x80C7A798
 	.bss        start:0x80D17988 end:0x80D17990
 
-system/char/CharIKFoot.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharIKFoot.o:
 	.text       start:0x806EA810 end:0x806EC9F0
 	.data       start:0x80C033B0 end:0x80C035C0
 	.sbss       start:0x80C7A798 end:0x80C7A7A0
 	.bss        start:0x80D17990 end:0x80D17998
 
-system/char/CharIKHand.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharIKHand.o:
 	.text       start:0x806EC9F0 end:0x806F23A0
 	.rodata     start:0x80B38808 end:0x80B38810
 	.data       start:0x80C035C0 end:0x80C038D0
 	.sbss       start:0x80C7A7A0 end:0x80C7A7A8
 	.bss        start:0x80D17998 end:0x80D179A0
 
-system/char/CharIKHead.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharIKHead.o:
 	.text       start:0x806F23A0 end:0x806F5760
 	.data       start:0x80C038D0 end:0x80C03B30
 	.sbss       start:0x80C7A7A8 end:0x80C7A7B0
 	.bss        start:0x80D179A0 end:0x80D179A8
 
-system/char/CharIKMidi.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharIKMidi.o:
 	.text       start:0x806F5760 end:0x806F83F0
 	.rodata     start:0x80B38810 end:0x80B38820
 	.data       start:0x80C03B30 end:0x80C04240
 	.sbss       start:0x80C7A7B0 end:0x80C7A7B8
 	.bss        start:0x80D179A8 end:0x80D179C8
 
-system/char/CharIKRod.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharIKRod.o:
 	.text       start:0x806F83F0 end:0x806F9BB0
 	.data       start:0x80C04240 end:0x80C043F0
 	.sbss       start:0x80C7A7B8 end:0x80C7A7C0
 	.bss        start:0x80D179C8 end:0x80D179D0
 
-system/char/CharIKScale.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharIKScale.o:
 	.text       start:0x806F9BB0 end:0x806FB820
 	.data       start:0x80C043F0 end:0x80C045B8
 	.sbss       start:0x80C7A7C0 end:0x80C7A7C8
 	.bss        start:0x80D179D0 end:0x80D179D8
 
-system/char/CharIKSliderMidi.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharIKSliderMidi.o:
 	.text       start:0x806FB820 end:0x806FD600
 	.data       start:0x80C045B8 end:0x80C047F0
 	.sbss       start:0x80C7A7C8 end:0x80C7A7D0
 	.bss        start:0x80D179D8 end:0x80D179E0
 
-system/char/CharLipSync.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharLipSync.o:
 	.text       start:0x806FD600 end:0x80701530
 	.rodata     start:0x80B38820 end:0x80B38828
 	.data       start:0x80C047F0 end:0x80C04B60
@@ -5400,139 +5400,139 @@ system/char/CharLipSync.cpp:
 	.sbss       start:0x80C7A7D0 end:0x80C7A7D8
 	.bss        start:0x80D179E0 end:0x80D179F0
 
-system/char/CharLipSyncDriver.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharLipSyncDriver.o:
 	.text       start:0x80701530 end:0x80704A50
 	.data       start:0x80C04B60 end:0x80C04E88
 	.sbss       start:0x80C7A7D8 end:0x80C7A7E0
 	.bss        start:0x80D179F0 end:0x80D179F8
 
-system/char/CharLookAt.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharLookAt.o:
 	.text       start:0x80704A50 end:0x80707B50
 	.rodata     start:0x80B38828 end:0x80B38830
 	.data       start:0x80C04E88 end:0x80C050C8
 	.sbss       start:0x80C7A7E0 end:0x80C7A7F0
 	.bss        start:0x80D179F8 end:0x80D17A28
 
-system/char/CharMeshHide.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharMeshHide.o:
 	.text       start:0x80707B50 end:0x80709C00
 	.data       start:0x80C050C8 end:0x80C052A8
 	.sbss       start:0x80C7A7F0 end:0x80C7A7F8
 	.bss        start:0x80D17A28 end:0x80D17A30
 
-system/char/CharMeshCacheMgr.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharMeshCacheMgr.o:
 	.text       start:0x80709C00 end:0x8070BA10
 	.data       start:0x80C052A8 end:0x80C053D8
 
-system/char/CharMirror.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharMirror.o:
 	.text       start:0x8070BA10 end:0x8070D960
 	.data       start:0x80C053D8 end:0x80C05668
 	.sbss       start:0x80C7A7F8 end:0x80C7A800
 	.bss        start:0x80D17A30 end:0x80D17A38
 
-system/char/CharNeckTwist.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharNeckTwist.o:
 	.text       start:0x8070D960 end:0x8070E760
 	.data       start:0x80C05668 end:0x80C057E8
 	.sbss       start:0x80C7A800 end:0x80C7A808
 	.bss        start:0x80D17A38 end:0x80D17A40
 
-system/char/CharPosConstraint.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharPosConstraint.o:
 	.text       start:0x8070E760 end:0x8070FB30
 	.data       start:0x80C057E8 end:0x80C059D0
 	.sbss       start:0x80C7A808 end:0x80C7A810
 	.bss        start:0x80D17A40 end:0x80D17A48
 
-system/char/CharPollGroup.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharPollGroup.o:
 	.text       start:0x8070FB30 end:0x80712AB0
 	.data       start:0x80C059D0 end:0x80C05D60
 	.sbss       start:0x80C7A810 end:0x80C7A818
 	.bss        start:0x80D17A48 end:0x80D17A50
 
-system/char/CharServoBone.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharServoBone.o:
 	.text       start:0x80712AB0 end:0x80714C70
 	.data       start:0x80C05D60 end:0x80C05FA8
 	.sbss       start:0x80C7A818 end:0x80C7A820
 	.bss        start:0x80D17A50 end:0x80D17A58
 
-system/char/CharSleeve.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharSleeve.o:
 	.text       start:0x80714C70 end:0x80716EC0
 	.rodata     start:0x80B38830 end:0x80B38838
 	.data       start:0x80C05FA8 end:0x80C06188
 	.sbss       start:0x80C7A820 end:0x80C7A828
 	.bss        start:0x80D17A58 end:0x80D17A60
 
-system/char/CharTaskMgr.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharTaskMgr.o:
 	.text       start:0x80716EC0 end:0x80716F20
 	.data       start:0x80C06188 end:0x80C061E0
 	.sbss       start:0x80C7A828 end:0x80C7A830
 
-system/char/CharTransCopy.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharTransCopy.o:
 	.text       start:0x80716F20 end:0x80717CE0
 	.data       start:0x80C061E0 end:0x80C063A0
 	.sbss       start:0x80C7A830 end:0x80C7A838
 	.bss        start:0x80D17A60 end:0x80D17A68
 
-system/char/CharTransDraw.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharTransDraw.o:
 	.text       start:0x80717CE0 end:0x80719DF0
 	.data       start:0x80C063A0 end:0x80C066B0
 	.sbss       start:0x80C7A838 end:0x80C7A840
 	.bss        start:0x80D17A68 end:0x80D17A70
 
-system/char/CharacterTest.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharacterTest.o:
 	.text       start:0x80719DF0 end:0x8071F400
 	.data       start:0x80C066B0 end:0x80C06B28
 	.sbss       start:0x80C7A840 end:0x80C7A848
 	.bss        start:0x80D17A70 end:0x80D17A78
 
-system/char/CharUpperTwist.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharUpperTwist.o:
 	.text       start:0x8071F400 end:0x80720510
 	.rodata     start:0x80B38838 end:0x80B38840
 	.data       start:0x80C06B28 end:0x80C06CA8
 	.sbss       start:0x80C7A848 end:0x80C7A850
 	.bss        start:0x80D17A78 end:0x80D17A80
 
-system/char/CharUtl.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharUtl.o:
 	.text       start:0x80720510 end:0x80722680
 	.data       start:0x80C06CA8 end:0x80C06E20
 
-system/char/CharWeightable.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharWeightable.o:
 	.text       start:0x80722680 end:0x80723500
 	.data       start:0x80C06E20 end:0x80C06F88
 	.sbss       start:0x80C7A850 end:0x80C7A858
 	.bss        start:0x80D17A80 end:0x80D17A88
 
-system/char/CharWeightSetter.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharWeightSetter.o:
 	.text       start:0x80723500 end:0x80727280
 	.data       start:0x80C06F88 end:0x80C07358
 	.sbss       start:0x80C7A858 end:0x80C7A860
 	.bss        start:0x80D17A88 end:0x80D17A90
 
-system/char/ClipCollide.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/ClipCollide.o:
 	.text       start:0x80727280 end:0x8072D450
 	.rodata     start:0x80B38840 end:0x80B38860
 	.data       start:0x80C07358 end:0x80C075D8
 	.sbss       start:0x80C7A860 end:0x80C7A868
 	.bss        start:0x80D17A90 end:0x80D17AC0
 
-system/char/ClipCompressor.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/ClipCompressor.o:
 	.text       start:0x8072D450 end:0x8072D4C0
 
-system/char/ClipDistMap.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/ClipDistMap.o:
 	.text       start:0x8072D4C0 end:0x80732950
 	.data       start:0x80C075D8 end:0x80C078C0
 
-system/char/ClipGraphGen.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/ClipGraphGen.o:
 	.text       start:0x80732950 end:0x80733240
 	.data       start:0x80C078C0 end:0x80C07AC8
 	.sbss       start:0x80C7A868 end:0x80C7A870
 	.bss        start:0x80D17AC0 end:0x80D17AC8
 
-system/char/FileMerger.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/FileMerger.o:
 	.text       start:0x80733240 end:0x8073F460
 	.data       start:0x80C07AC8 end:0x80C07F18
 	.sbss       start:0x80C7A870 end:0x80C7A880
 	.bss        start:0x80D17AC8 end:0x80D17B50
 
-system/char/FileMergerOrganizer.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/FileMergerOrganizer.o:
 	.text       start:0x8073F460 end:0x80741650
 	.ctors      start:0x80B34AB8 end:0x80B34ABC
 	.data       start:0x80C07F18 end:0x80C08368
@@ -5540,164 +5540,164 @@ system/char/FileMergerOrganizer.cpp:
 	.sbss       start:0x80C7A880 end:0x80C7A888
 	.bss        start:0x80D17B50 end:0x80D17B80
 
-system/char/Waypoint.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/Waypoint.o:
 	.text       start:0x80741650 end:0x80744AE0
 	.data       start:0x80C08368 end:0x80C085E8
 	.sbss       start:0x80C7A888 end:0x80C7A890
 	.bss        start:0x80D17B80 end:0x80D17B88
 
-system/char/CharGuitarString.cpp:
+lib.a/hproj/band3_wii/system/src/char/wii_release/CharGuitarString.o:
 	.text       start:0x80744AE0 end:0x80745C50
 	.data       start:0x80C085E8 end:0x80C087A8
 	.sbss       start:0x80C7A890 end:0x80C7A898
 	.bss        start:0x80D17B88 end:0x80D17B90
 
-system/dsp/IIRFilter.cpp:
+lib.a/hproj/band3_wii/system/src/dsp/wii_release/IIRFilter.o:
 	.text       start:0x80745C50 end:0x80745DE0
 
-system/dsp/SndAnalysis.cpp:
+lib.a/hproj/band3_wii/system/src/dsp/wii_release/SndAnalysis.o:
 	.text       start:0x80745DE0 end:0x80746810
 	.data       start:0x80C087A8 end:0x80C08818
 	.sbss       start:0x80C7A898 end:0x80C7A8A0
 	.bss        start:0x80D17B90 end:0x80D17BA8
 
-system/dsp/PitchDetector.cpp:
+lib.a/hproj/band3_wii/system/src/dsp/wii_release/PitchDetector.o:
 	.text       start:0x80746810 end:0x80747580
 	.rodata     start:0x80B38860 end:0x80B38898
 	.data       start:0x80C08818 end:0x80C088D0
 	.sbss       start:0x80C7A8A0 end:0x80C7A8A8
 	.bss        start:0x80D17BA8 end:0x80D17BC8
 
-system/dsp/VibratoDetector.cpp:
+lib.a/hproj/band3_wii/system/src/dsp/wii_release/VibratoDetector.o:
 	.text       start:0x80747580 end:0x807479E0
 
-system/meta/Achievements.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/Achievements.o:
 	.text       start:0x807479E0 end:0x80747EF0
 	.data       start:0x80C088D0 end:0x80C08998
 	.bss        start:0x80D17BC8 end:0x80D17BD0
 
-system/meta/ButtonHolder.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/ButtonHolder.o:
 	.text       start:0x80747EF0 end:0x8074B040
 	.data       start:0x80C08998 end:0x80C08C90
 	.sbss       start:0x80C7A8A8 end:0x80C7A8B0
 	.bss        start:0x80D17BD0 end:0x80D17BE8
 
-system/meta/CreditsPanel.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/CreditsPanel.o:
 	.text       start:0x8074B040 end:0x8074C680
 	.rodata     start:0x80B38898 end:0x80B388A0
 	.data       start:0x80C08C90 end:0x80C08ED8
 	.sbss       start:0x80C7A8B0 end:0x80C7A8B8
 	.bss        start:0x80D17BE8 end:0x80D17BF0
 
-system/meta/ConnectionStatusPanel.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/ConnectionStatusPanel.o:
 	.text       start:0x8074C680 end:0x8074D010
 	.data       start:0x80C08ED8 end:0x80C09050
 	.sbss       start:0x80C7A8B8 end:0x80C7A8C0
 	.bss        start:0x80D17BF0 end:0x80D17BF8
 
-system/meta/DataArraySongInfo.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/DataArraySongInfo.o:
 	.text       start:0x8074D010 end:0x8074F4E0
 	.data       start:0x80C09050 end:0x80C09310
 
-system/meta/DeJitterPanel.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/DeJitterPanel.o:
 	.text       start:0x8074F4E0 end:0x8074FB10
 	.data       start:0x80C09310 end:0x80C09408
 	.sbss       start:0x80C7A8C0 end:0x80C7A8C8
 	.bss        start:0x80D17BF8 end:0x80D17C00
 
-system/meta/FixedSizeSaveable.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/FixedSizeSaveable.o:
 	.text       start:0x8074FB10 end:0x80750B70
 	.data       start:0x80C09408 end:0x80C09758
 	.sbss       start:0x80C7A8C8 end:0x80C7A8D0
 
-system/meta/FixedSizeSaveableStream.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/FixedSizeSaveableStream.o:
 	.text       start:0x80750B70 end:0x807515D0
 	.data       start:0x80C09758 end:0x80C09810
 
-system/meta/HAQManager.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/HAQManager.o:
 	.text       start:0x807515D0 end:0x80752D80
 	.data       start:0x80C09810 end:0x80C09980
 	.bss        start:0x80D17C00 end:0x80D17C08
 
-system/meta/HeldButtonPanel.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/HeldButtonPanel.o:
 	.text       start:0x80752D80 end:0x80754320
 	.data       start:0x80C09980 end:0x80C09AE0
 	.sbss       start:0x80C7A8D0 end:0x80C7A8D8
 	.bss        start:0x80D17C08 end:0x80D17C38
 
-system/meta/MemcardAction.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/MemcardAction.o:
 	.text       start:0x80754320 end:0x80754370
 	.data       start:0x80C09AE0 end:0x80C09AF8
 
-system/meta/Meta.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/Meta.o:
 	.text       start:0x80754370 end:0x807545C0
 	.data       start:0x80C09AF8 end:0x80C09B08
 	.sbss       start:0x80C7A8D8 end:0x80C7A8E0
 	.bss        start:0x80D17C38 end:0x80D17C40
 
-system/meta/MetaMusicScene.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/MetaMusicScene.o:
 	.text       start:0x807545C0 end:0x80754820
 	.data       start:0x80C09B08 end:0x80C09B50
 
-system/meta/MetaMusicManager.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/MetaMusicManager.o:
 	.text       start:0x80754820 end:0x80755870
 	.data       start:0x80C09B50 end:0x80C09CB8
 	.sdata      start:0x80C78F28 end:0x80C78F30
 	.bss        start:0x80D17C40 end:0x80D17C48
 
-system/meta/MoviePanel.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/MoviePanel.o:
 	.text       start:0x80755870 end:0x80757490
 	.data       start:0x80C09CB8 end:0x80C09F58
 	.sbss       start:0x80C7A8E0 end:0x80C7A8E8
 	.bss        start:0x80D17C48 end:0x80D17C50
 
-system/meta/PreloadPanel.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/PreloadPanel.o:
 	.text       start:0x80757490 end:0x80759830
 	.data       start:0x80C09F58 end:0x80C0A248
 	.sbss       start:0x80C7A8E8 end:0x80C7A8F0
 	.bss        start:0x80D17C50 end:0x80D17C70
 
-system/meta/Profile.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/Profile.o:
 	.text       start:0x80759830 end:0x8075A0C0
 	.data       start:0x80C0A248 end:0x80C0A328
 
-system/meta/SongMetadata.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/SongMetadata.o:
 	.text       start:0x8075A0C0 end:0x8075AF40
 	.data       start:0x80C0A328 end:0x80C0A428
 
-system/meta/SongMgr.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/SongMgr.o:
 	.text       start:0x8075AF40 end:0x8075E980
 	.data       start:0x80C0A428 end:0x80C0A998
 	.bss        start:0x80D17C70 end:0x80D17C78
 
-system/meta/SongPreview.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/SongPreview.o:
 	.text       start:0x8075E980 end:0x807605E0
 	.data       start:0x80C0A998 end:0x80C0AB60
 
-system/meta/Sorting.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/Sorting.o:
 	.text       start:0x807605E0 end:0x80760920
 	.data       start:0x80C0AB60 end:0x80C0AB68
 	.sbss       start:0x80C7A8F0 end:0x80C7A8F8
 	.bss        start:0x80D17C78 end:0x80D17C80
 
-system/meta/StoreEnumeration.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/StoreEnumeration.o:
 	.text       start:0x80760920 end:0x80760AF0
 	.data       start:0x80C0AB68 end:0x80C0ABC8
 
-system/meta/StoreArtLoaderPanel.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/StoreArtLoaderPanel.o:
 	.text       start:0x80760AF0 end:0x807619A0
 	.data       start:0x80C0ABC8 end:0x80C0AD80
 	.sbss       start:0x80C7A8F8 end:0x80C7A900
 	.bss        start:0x80D17C80 end:0x80D17C88
 
-system/meta/StoreOffer.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/StoreOffer.o:
 	.text       start:0x807619A0 end:0x80764980
 	.data       start:0x80C0AD80 end:0x80C0BF08
 	.sdata      start:0x80C78F30 end:0x80C78F38
 	.sbss       start:0x80C7A900 end:0x80C7A908
 	.bss        start:0x80D17C88 end:0x80D17C90
 
-system/meta/StorePackedMetadata.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/StorePackedMetadata.o:
 	.text       start:0x80764980 end:0x8076D7B0
 	.ctors      start:0x80B34ABC end:0x80B34AC0
 	.data       start:0x80C0BF08 end:0x80C0CCC0
@@ -5705,59 +5705,59 @@ system/meta/StorePackedMetadata.cpp:
 	.sbss       start:0x80C7A908 end:0x80C7A910
 	.bss        start:0x80D17C90 end:0x80D17DA0
 
-system/meta/StorePreviewMgr.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/StorePreviewMgr.o:
 	.text       start:0x8076D7B0 end:0x8076EAA0
 	.rodata     start:0x80B388A0 end:0x80B388A8
 	.data       start:0x80C0CCC0 end:0x80C0CE68
 	.sbss       start:0x80C7A910 end:0x80C7A918
 	.bss        start:0x80D17DA0 end:0x80D17DB8
 
-system/meta/StreamPlayer.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/StreamPlayer.o:
 	.text       start:0x8076EAA0 end:0x8076F130
 	.data       start:0x80C0CE68 end:0x80C0CF28
 
-system/meta/MemcardMgr_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/MemcardMgr_Wii.o:
 	.text       start:0x8076F130 end:0x80771E50
 	.ctors      start:0x80B34AC0 end:0x80B34AC4
 	.data       start:0x80C0CF28 end:0x80C0D8F8
 	.sbss       start:0x80C7A918 end:0x80C7A920
 	.bss        start:0x80D17DB8 end:0x80D17EE0
 
-system/meta/StorePanel.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/StorePanel.o:
 	.text       start:0x80771E50 end:0x80776A10
 	.data       start:0x80C0D8F8 end:0x80C0DC58
 	.sdata      start:0x80C78F48 end:0x80C78F50
 	.sbss       start:0x80C7A920 end:0x80C7A928
 	.bss        start:0x80D17EE0 end:0x80D17F08
 
-system/meta/WiiProfileMgr.cpp:
+lib.a/hproj/band3_wii/system/src/meta/wii_release/WiiProfileMgr.o:
 	.text       start:0x80776A10 end:0x80778660
 	.ctors      start:0x80B34AC4 end:0x80B34AC8
 	.data       start:0x80C0DC58 end:0x80C0DEA8
 	.bss        start:0x80D17F08 end:0x80D18108
 
-system/midi/DataEventList.cpp:
+lib.a/hproj/band3_wii/system/src/midi/wii_release/DataEventList.o:
 	.text       start:0x80778660 end:0x8077A930
 	.data       start:0x80C0DEA8 end:0x80C0DFE8
 
-system/midi/DisplayEvents.cpp:
+lib.a/hproj/band3_wii/system/src/midi/wii_release/DisplayEvents.o:
 	.text       start:0x8077A930 end:0x8077ADF0
 	.data       start:0x80C0DFE8 end:0x80C0DFF8
 
-system/midi/MidiParser.cpp:
+lib.a/hproj/band3_wii/system/src/midi/wii_release/MidiParser.o:
 	.text       start:0x8077ADF0 end:0x807803C0
 	.ctors      start:0x80B34AC8 end:0x80B34ACC
 	.data       start:0x80C0DFF8 end:0x80C0E430
 	.sbss       start:0x80C7A928 end:0x80C7A930
 	.bss        start:0x80D18108 end:0x80D18168
 
-system/midi/MidiParserMgr.cpp:
+lib.a/hproj/band3_wii/system/src/midi/wii_release/MidiParserMgr.o:
 	.text       start:0x807803C0 end:0x80782390
 	.rodata     start:0x80B388A8 end:0x80B388B0
 	.data       start:0x80C0E430 end:0x80C0E830
 	.bss        start:0x80D18168 end:0x80D18170
 
-system/midi/MidiReader.cpp:
+lib.a/hproj/band3_wii/system/src/midi/wii_release/MidiReader.o:
 	.text       start:0x80782390 end:0x80785080
 	.ctors      start:0x80B34ACC end:0x80B34AD0
 	.rodata     start:0x80B388B0 end:0x80B388B8
@@ -5765,15 +5765,15 @@ system/midi/MidiReader.cpp:
 	.sbss       start:0x80C7A930 end:0x80C7A938
 	.bss        start:0x80D18170 end:0x80D18178
 
-system/midi/MidiReceiver.cpp:
+lib.a/hproj/band3_wii/system/src/midi/wii_release/MidiReceiver.o:
 	.text       start:0x80785080 end:0x80785230
 	.data       start:0x80C0ED30 end:0x80C0ED98
 
-system/midi/MidiVarLen.cpp:
+lib.a/hproj/band3_wii/system/src/midi/wii_release/MidiVarLen.o:
 	.text       start:0x80785230 end:0x80785320
 	.data       start:0x80C0ED98 end:0x80C0EDD8
 
-system/movie/Movie.cpp:
+lib.a/hproj/band3_wii/system/src/movie/wii_release/Movie.o:
 	.text       start:0x80785320 end:0x80789B20
 	.ctors      start:0x80B34AD0 end:0x80B34AD4
 	.rodata     start:0x80B388B8 end:0x80B388C0
@@ -5782,151 +5782,151 @@ system/movie/Movie.cpp:
 	.sbss       start:0x80C7A938 end:0x80C7A940
 	.bss        start:0x80D18178 end:0x80D18220
 
-system/movie/Splash.cpp:
+lib.a/hproj/band3_wii/system/src/movie/wii_release/Splash.o:
 	.text       start:0x80789B20 end:0x8078BD40
 	.data       start:0x80C0F190 end:0x80C0F3D8
 	.sbss       start:0x80C7A940 end:0x80C7A948
 	.bss        start:0x80D18220 end:0x80D18228
 
-system/movie/TexMovie.cpp:
+lib.a/hproj/band3_wii/system/src/movie/wii_release/TexMovie.o:
 	.text       start:0x8078BD40 end:0x8078DE80
 	.data       start:0x80C0F3D8 end:0x80C0F670
 	.sbss       start:0x80C7A948 end:0x80C7A950
 	.bss        start:0x80D18228 end:0x80D18240
 
-system/movie/Movie_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/movie/wii_release/Movie_Wii.o:
 	.text       start:0x8078DE80 end:0x8078F660
 	.rodata     start:0x80B388C0 end:0x80B38900
 	.data       start:0x80C0F670 end:0x80C0F818
 	.sbss       start:0x80C7A950 end:0x80C7A958
 	.bss        start:0x80D18240 end:0x80D18288
 
-system/movie/CustomSplash_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/movie/wii_release/CustomSplash_Wii.o:
 	.text       start:0x8078F660 end:0x807904A0
 	.rodata     start:0x80B38900 end:0x80B38908
 	.data       start:0x80C0F818 end:0x80C0F970
 	.sbss       start:0x80C7A958 end:0x80C7A960
 
-system/track/Track.cpp:
+lib.a/hproj/band3_wii/system/src/track/wii_release/Track.o:
 	.text       start:0x807904A0 end:0x807905F0
 	.data       start:0x80C0F970 end:0x80C0F988
 	.sbss       start:0x80C7A960 end:0x80C7A968
 	.bss        start:0x80D18288 end:0x80D18290
 
-system/track/TrackDir.cpp:
+lib.a/hproj/band3_wii/system/src/track/wii_release/TrackDir.o:
 	.text       start:0x807905F0 end:0x80796EB0
 	.data       start:0x80C0F988 end:0x80C100A8
 	.sbss       start:0x80C7A968 end:0x80C7A970
 	.bss        start:0x80D18290 end:0x80D18298
 
-system/track/TrackTest.cpp:
+lib.a/hproj/band3_wii/system/src/track/wii_release/TrackTest.o:
 	.text       start:0x80796EB0 end:0x80797200
 	.data       start:0x80C100A8 end:0x80C100E0
 
-system/track/TrackWidget.cpp:
+lib.a/hproj/band3_wii/system/src/track/wii_release/TrackWidget.o:
 	.text       start:0x80797200 end:0x8079DFE0
 	.data       start:0x80C100E0 end:0x80C105F8
 	.sdata      start:0x80C78F58 end:0x80C78F68
 	.sbss       start:0x80C7A970 end:0x80C7A980
 	.bss        start:0x80D18298 end:0x80D182C0
 
-system/track/TrackWidgetImp.cpp:
+lib.a/hproj/band3_wii/system/src/track/wii_release/TrackWidgetImp.o:
 	.text       start:0x8079DFE0 end:0x807A0970
 	.data       start:0x80C105F8 end:0x80C10B20
 	.sbss       start:0x80C7A980 end:0x80C7A988
 	.bss        start:0x80D182C0 end:0x80D182C8
 
-system/ui/CheatProvider.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/CheatProvider.o:
 	.text       start:0x807A0970 end:0x807A2480
 	.data       start:0x80C10B20 end:0x80C10D50
 	.bss        start:0x80D182C8 end:0x80D182D0
 
-system/ui/LabelNumberTicker.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/LabelNumberTicker.o:
 	.text       start:0x807A2480 end:0x807A4130
 	.data       start:0x80C10D50 end:0x80C11020
 	.sbss       start:0x80C7A988 end:0x80C7A990
 	.bss        start:0x80D182D0 end:0x80D182D8
 
-system/ui/LabelShrinkWrapper.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/LabelShrinkWrapper.o:
 	.text       start:0x807A4130 end:0x807A58A0
 	.data       start:0x80C11020 end:0x80C11318
 	.sbss       start:0x80C7A990 end:0x80C7A998
 	.bss        start:0x80D182D8 end:0x80D182E0
 
-system/ui/LocalePanel.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/LocalePanel.o:
 	.text       start:0x807A58A0 end:0x807A8280
 	.data       start:0x80C11318 end:0x80C11628
 	.sbss       start:0x80C7A998 end:0x80C7A9A0
 	.bss        start:0x80D182E0 end:0x80D182F0
 
-system/ui/PanelDir.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/PanelDir.o:
 	.text       start:0x807A8280 end:0x807AD140
 	.data       start:0x80C11628 end:0x80C11B18
 	.sdata      start:0x80C78F68 end:0x80C78F70
 	.sbss       start:0x80C7A9A0 end:0x80C7A9A8
 	.bss        start:0x80D182F0 end:0x80D18310
 
-system/ui/Screenshot.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/Screenshot.o:
 	.text       start:0x807AD140 end:0x807AE180
 	.data       start:0x80C11B18 end:0x80C11CD8
 	.sbss       start:0x80C7A9A8 end:0x80C7A9B0
 	.bss        start:0x80D18310 end:0x80D18318
 
-system/ui/ScrollSelect.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/ScrollSelect.o:
 	.text       start:0x807AE180 end:0x807AF1A0
 	.data       start:0x80C11CD8 end:0x80C11D80
 	.sbss       start:0x80C7A9B0 end:0x80C7A9B8
 	.bss        start:0x80D18318 end:0x80D18330
 
-system/ui/UI.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UI.o:
 	.text       start:0x807AF1A0 end:0x807B81B0
 	.rodata     start:0x80B38908 end:0x80B38910
 	.data       start:0x80C11D80 end:0x80C122D0
 	.sbss       start:0x80C7A9B8 end:0x80C7A9C8
 	.bss        start:0x80D18330 end:0x80D18370
 
-system/ui/UIButton.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIButton.o:
 	.text       start:0x807B81B0 end:0x807B9030
 	.data       start:0x80C122D0 end:0x80C12500
 	.sbss       start:0x80C7A9C8 end:0x80C7A9D0
 	.bss        start:0x80D18370 end:0x80D18378
 
-system/ui/UIColor.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIColor.o:
 	.text       start:0x807B9030 end:0x807B9850
 	.data       start:0x80C12500 end:0x80C12608
 	.sbss       start:0x80C7A9D0 end:0x80C7A9D8
 	.bss        start:0x80D18378 end:0x80D18380
 
-system/ui/UIComponent.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIComponent.o:
 	.text       start:0x807B9850 end:0x807BE960
 	.data       start:0x80C12608 end:0x80C12CC8
 	.sbss       start:0x80C7A9D8 end:0x80C7A9E8
 	.bss        start:0x80D18380 end:0x80D183C8
 
-system/ui/UILabel.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UILabel.o:
 	.text       start:0x807BE960 end:0x807C5C40
 	.data       start:0x80C12CC8 end:0x80C13410
 	.sbss       start:0x80C7A9E8 end:0x80C7A9F8
 	.bss        start:0x80D183C8 end:0x80D183D8
 
-system/ui/UIFontImporter.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIFontImporter.o:
 	.text       start:0x807C5C40 end:0x807CF040
 	.rodata     start:0x80B38910 end:0x80B38920
 	.data       start:0x80C13410 end:0x80C13A10
 	.sbss       start:0x80C7A9F8 end:0x80C7AA00
 	.bss        start:0x80D183D8 end:0x80D183E0
 
-system/ui/UIGridProvider.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIGridProvider.o:
 	.text       start:0x807CF040 end:0x807CF9B0
 	.data       start:0x80C13A10 end:0x80C13B88
 
-system/ui/UILabelDir.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UILabelDir.o:
 	.text       start:0x807CF9B0 end:0x807D21E0
 	.data       start:0x80C13B88 end:0x80C13F60
 	.sbss       start:0x80C7AA00 end:0x80C7AA08
 	.bss        start:0x80D183E0 end:0x80D183E8
 
-system/ui/UIList.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIList.o:
 	.text       start:0x807D21E0 end:0x807DB590
 	.ctors      start:0x80B34AD4 end:0x80B34AD8
 	.data       start:0x80C13F60 end:0x80C15038
@@ -5934,139 +5934,139 @@ system/ui/UIList.cpp:
 	.sbss       start:0x80C7AA08 end:0x80C7AA20
 	.bss        start:0x80D183E8 end:0x80D18430
 
-system/ui/UIListArrow.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListArrow.o:
 	.text       start:0x807DB590 end:0x807DC540
 	.data       start:0x80C15038 end:0x80C151D0
 	.sbss       start:0x80C7AA20 end:0x80C7AA28
 	.bss        start:0x80D18430 end:0x80D18438
 
-system/ui/UIListCustom.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListCustom.o:
 	.text       start:0x807DC540 end:0x807DD2D0
 	.data       start:0x80C151D0 end:0x80C15440
 	.sdata      start:0x80C78F78 end:0x80C78F80
 	.sbss       start:0x80C7AA28 end:0x80C7AA30
 	.bss        start:0x80D18438 end:0x80D18440
 
-system/ui/UIListDir.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListDir.o:
 	.text       start:0x807DD2D0 end:0x807E1F30
 	.data       start:0x80C15440 end:0x80C15878
 	.sbss       start:0x80C7AA30 end:0x80C7AA38
 	.bss        start:0x80D18440 end:0x80D18448
 
-system/ui/UIListHighlight.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListHighlight.o:
 	.text       start:0x807E1F30 end:0x807E29F0
 	.data       start:0x80C15878 end:0x80C15A18
 	.sbss       start:0x80C7AA38 end:0x80C7AA40
 	.bss        start:0x80D18448 end:0x80D18450
 
-system/ui/UIListLabel.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListLabel.o:
 	.text       start:0x807E29F0 end:0x807E3900
 	.data       start:0x80C15A18 end:0x80C15C00
 	.sbss       start:0x80C7AA40 end:0x80C7AA48
 	.bss        start:0x80D18450 end:0x80D18458
 
-system/ui/UIListMesh.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListMesh.o:
 	.text       start:0x807E3900 end:0x807E46D0
 	.data       start:0x80C15C00 end:0x80C15E00
 	.sbss       start:0x80C7AA48 end:0x80C7AA50
 	.bss        start:0x80D18458 end:0x80D18460
 
-system/ui/UIListProvider.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListProvider.o:
 	.text       start:0x807E46D0 end:0x807E5250
 	.data       start:0x80C15E00 end:0x80C15FF8
 	.sbss       start:0x80C7AA50 end:0x80C7AA58
 	.bss        start:0x80D18460 end:0x80D18478
 
-system/ui/UIListSlot.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListSlot.o:
 	.text       start:0x807E5250 end:0x807E6620
 	.data       start:0x80C15FF8 end:0x80C16190
 	.sbss       start:0x80C7AA58 end:0x80C7AA60
 	.bss        start:0x80D18478 end:0x80D18480
 
-system/ui/UIListState.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListState.o:
 	.text       start:0x807E6620 end:0x807E81C0
 	.data       start:0x80C16190 end:0x80C162C8
 
-system/ui/UIListSubList.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListSubList.o:
 	.text       start:0x807E81C0 end:0x807E9500
 	.data       start:0x80C162C8 end:0x80C16550
 	.sbss       start:0x80C7AA60 end:0x80C7AA68
 	.bss        start:0x80D18480 end:0x80D18488
 
-system/ui/UIListWidget.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIListWidget.o:
 	.text       start:0x807E9500 end:0x807EBC40
 	.data       start:0x80C16550 end:0x80C167C8
 	.sbss       start:0x80C7AA68 end:0x80C7AA70
 	.bss        start:0x80D18488 end:0x80D18490
 
-system/ui/UIPanel.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIPanel.o:
 	.text       start:0x807EBC40 end:0x807EE340
 	.data       start:0x80C167C8 end:0x80C16980
 	.sbss       start:0x80C7AA70 end:0x80C7AA78
 	.bss        start:0x80D18490 end:0x80D184A0
 
-system/ui/UIPicture.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIPicture.o:
 	.text       start:0x807EE340 end:0x807EFF00
 	.data       start:0x80C16980 end:0x80C16C58
 	.sbss       start:0x80C7AA78 end:0x80C7AA80
 	.bss        start:0x80D184A0 end:0x80D184A8
 
-system/ui/UIProxy.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIProxy.o:
 	.text       start:0x807EFF00 end:0x807F30F0
 	.data       start:0x80C16C58 end:0x80C16F60
 	.sbss       start:0x80C7AA80 end:0x80C7AA88
 	.bss        start:0x80D184A8 end:0x80D184B0
 
-system/ui/UIResource.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIResource.o:
 	.text       start:0x807F30F0 end:0x807F3A80
 	.data       start:0x80C16F60 end:0x80C16F80
 
-system/ui/UIScreen.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIScreen.o:
 	.text       start:0x807F3A80 end:0x807F6A40
 	.data       start:0x80C16F80 end:0x80C17160
 	.sbss       start:0x80C7AA88 end:0x80C7AA90
 	.bss        start:0x80D184B0 end:0x80D184E8
 
-system/ui/UISlider.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UISlider.o:
 	.text       start:0x807F6A40 end:0x807F8C50
 	.data       start:0x80C17160 end:0x80C17420
 	.sbss       start:0x80C7AA90 end:0x80C7AA98
 	.bss        start:0x80D184E8 end:0x80D184F0
 
-system/ui/UITransitionHandler.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UITransitionHandler.o:
 	.text       start:0x807F8C50 end:0x807F9430
 	.data       start:0x80C17420 end:0x80C17470
 
-system/ui/UITrigger.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UITrigger.o:
 	.text       start:0x807F9430 end:0x807FCF80
 	.data       start:0x80C17470 end:0x80C17A48
 	.sbss       start:0x80C7AA98 end:0x80C7AAA0
 	.bss        start:0x80D184F0 end:0x80D18500
 
-system/ui/UIGuide.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/UIGuide.o:
 	.text       start:0x807FCF80 end:0x807FD8D0
 	.data       start:0x80C17A48 end:0x80C17B80
 	.sbss       start:0x80C7AAA0 end:0x80C7AAA8
 	.bss        start:0x80D18500 end:0x80D18508
 
-system/ui/Utl.cpp:
+lib.a/hproj/band3_wii/system/src/ui/wii_release/Utl.o:
 	.text       start:0x807FD8D0 end:0x807FDA80
 
-system/world/CameraManager.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/CameraManager.o:
 	.text       start:0x807FDA80 end:0x80803550
 	.ctors      start:0x80B34AD8 end:0x80B34ADC
 	.data       start:0x80C17B80 end:0x80C17DC0
 	.sbss       start:0x80C7AAA8 end:0x80C7AAB0
 	.bss        start:0x80D18508 end:0x80D18940
 
-system/world/CameraShot.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/CameraShot.o:
 	.text       start:0x80803550 end:0x808192E0
 	.rodata     start:0x80B38920 end:0x80B38938
 	.data       start:0x80C17DC0 end:0x80C19058
 	.sbss       start:0x80C7AAB0 end:0x80C7AAC8
 	.bss        start:0x80D18940 end:0x80D18A48
 
-system/world/Crowd.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/Crowd.o:
 	.text       start:0x808192E0 end:0x80827050
 	.rodata     start:0x80B38938 end:0x80B38948
 	.data       start:0x80C19058 end:0x80C1A290
@@ -6074,13 +6074,13 @@ system/world/Crowd.cpp:
 	.sbss       start:0x80C7AAC8 end:0x80C7AAD8
 	.bss        start:0x80D18A48 end:0x80D18AA8
 
-system/world/ColorPalette.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/ColorPalette.o:
 	.text       start:0x80827050 end:0x80828830
 	.data       start:0x80C1A290 end:0x80C1A420
 	.sbss       start:0x80C7AAD8 end:0x80C7AAE0
 	.bss        start:0x80D18AA8 end:0x80D18AB0
 
-system/world/Dir.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/Dir.o:
 	.text       start:0x80828830 end:0x80831DF0
 	.ctors      start:0x80B34ADC end:0x80B34AE0
 	.rodata     start:0x80B38948 end:0x80B38950
@@ -6088,11 +6088,11 @@ system/world/Dir.cpp:
 	.sbss       start:0x80C7AAE0 end:0x80C7AAF8
 	.bss        start:0x80D18AB0 end:0x80D18B18
 
-system/world/FreeCamera.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/FreeCamera.o:
 	.text       start:0x80831DF0 end:0x80832E70
 	.data       start:0x80C1AB00 end:0x80C1ABB8
 
-system/world/LightPreset.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/LightPreset.o:
 	.text       start:0x80832E70 end:0x80851F80
 	.ctors      start:0x80B34AE0 end:0x80B34AE4
 	.data       start:0x80C1ABB8 end:0x80C1BB08
@@ -6100,39 +6100,39 @@ system/world/LightPreset.cpp:
 	.sbss       start:0x80C7AAF8 end:0x80C7AB00
 	.bss        start:0x80D18B18 end:0x80D18B60
 
-system/world/LightHue.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/LightHue.o:
 	.text       start:0x80851F80 end:0x80854630
 	.data       start:0x80C1BB08 end:0x80C1BC58
 	.sbss       start:0x80C7AB00 end:0x80C7AB08
 	.bss        start:0x80D18B60 end:0x80D18B68
 
-system/world/LightPresetManager.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/LightPresetManager.o:
 	.text       start:0x80854630 end:0x80857370
 	.data       start:0x80C1BC58 end:0x80C1BE70
 	.sdata      start:0x80C78F90 end:0x80C78F98
 	.sbss       start:0x80C7AB08 end:0x80C7AB10
 	.bss        start:0x80D18B68 end:0x80D18BB8
 
-system/world/Reflection.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/Reflection.o:
 	.text       start:0x80857370 end:0x8085A900
 	.data       start:0x80C1BE70 end:0x80C1C0C0
 	.sbss       start:0x80C7AB10 end:0x80C7AB18
 	.bss        start:0x80D18BB8 end:0x80D18BC8
 
-system/world/World.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/World.o:
 	.text       start:0x8085A900 end:0x8085ADC0
 	.data       start:0x80C1C0C0 end:0x80C1C0E8
 	.sbss       start:0x80C7AB18 end:0x80C7AB20
 	.bss        start:0x80D18BC8 end:0x80D18BD0
 
-system/world/Spotlight.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/Spotlight.o:
 	.text       start:0x8085ADC0 end:0x80869E60
 	.rodata     start:0x80B38950 end:0x80B38960
 	.data       start:0x80C1C0E8 end:0x80C1C6B0
 	.sbss       start:0x80C7AB20 end:0x80C7AB30
 	.bss        start:0x80D18BD0 end:0x80D18C38
 
-system/world/SpotlightDrawer.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/SpotlightDrawer.o:
 	.text       start:0x80869E60 end:0x808712D0
 	.ctors      start:0x80B34AE4 end:0x80B34AE8
 	.rodata     start:0x80B38960 end:0x80B38968
@@ -6140,46 +6140,46 @@ system/world/SpotlightDrawer.cpp:
 	.sbss       start:0x80C7AB30 end:0x80C7AB40
 	.bss        start:0x80D18C38 end:0x80D18CD0
 
-system/world/SpotlightEnder.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/SpotlightEnder.o:
 	.text       start:0x808712D0 end:0x80871E30
 	.rodata     start:0x80B38968 end:0x80B38970
 	.data       start:0x80C1D1B8 end:0x80C1D378
 	.sbss       start:0x80C7AB40 end:0x80C7AB48
 	.bss        start:0x80D18CD0 end:0x80D18CD8
 
-system/world/Instance.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/Instance.o:
 	.text       start:0x80871E30 end:0x808777D0
 	.data       start:0x80C1D378 end:0x80C1D978
 	.sbss       start:0x80C7AB48 end:0x80C7AB50
 	.bss        start:0x80D18CD8 end:0x80D18CE0
 
-system/world/EventAnim.cpp:
+lib.a/hproj/band3_wii/system/src/world/wii_release/EventAnim.o:
 	.text       start:0x808777D0 end:0x8087A100
 	.data       start:0x80C1D978 end:0x80C1DB28
 	.sbss       start:0x80C7AB50 end:0x80C7AB58
 	.bss        start:0x80D18CE0 end:0x80D18CE8
 
-system/rndobj/Anim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Anim.o:
 	.text       start:0x8087A100 end:0x8087D070
 	.rodata     start:0x80B38970 end:0x80B38980
 	.data       start:0x80C1DB28 end:0x80C1DE50
 	.sbss       start:0x80C7AB58 end:0x80C7AB68
 	.bss        start:0x80D18CE8 end:0x80D18CF8
 
-system/rndobj/AnimFilter.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/AnimFilter.o:
 	.text       start:0x8087D070 end:0x8087F3D0
 	.data       start:0x80C1DE50 end:0x80C1DFA8
 	.sbss       start:0x80C7AB68 end:0x80C7AB70
 	.bss        start:0x80D18CF8 end:0x80D18D00
 
-system/rndobj/Bitmap.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Bitmap.o:
 	.text       start:0x8087F3D0 end:0x80883430
 	.rodata     start:0x80B38980 end:0x80B389A0
 	.data       start:0x80C1DFA8 end:0x80C1E4A8
 	.sdata      start:0x80C78F98 end:0x80C78FA0
 	.bss        start:0x80D18D00 end:0x80D18D18
 
-system/rndobj/BoxMap.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/BoxMap.o:
 	.text       start:0x80883430 end:0x808846A0
 	.ctors      start:0x80B34AE8 end:0x80B34AEC
 	.rodata     start:0x80B389A0 end:0x80B389A8
@@ -6187,7 +6187,7 @@ system/rndobj/BoxMap.cpp:
 	.sbss       start:0x80C7AB70 end:0x80C7AB78
 	.bss        start:0x80D18D18 end:0x80D18D70
 
-system/rndobj/Cam.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Cam.o:
 	.text       start:0x808846A0 end:0x80886940
 	.ctors      start:0x80B34AEC end:0x80B34AF0
 	.rodata     start:0x80B389A8 end:0x80B389B0
@@ -6195,65 +6195,65 @@ system/rndobj/Cam.cpp:
 	.sbss       start:0x80C7AB78 end:0x80C7AB80
 	.bss        start:0x80D18D70 end:0x80D18DC0
 
-system/rndobj/CamAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/CamAnim.o:
 	.text       start:0x80886940 end:0x808882E0
 	.data       start:0x80C1E640 end:0x80C1E8C8
 	.sbss       start:0x80C7AB80 end:0x80C7AB88
 	.bss        start:0x80D18DC0 end:0x80D18DC8
 
-system/rndobj/ColorXfm.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/ColorXfm.o:
 	.text       start:0x808882E0 end:0x80888E80
 	.rodata     start:0x80B389B0 end:0x80B389C0
 
-system/rndobj/Console.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Console.o:
 	.text       start:0x80888E80 end:0x8088BB50
 	.data       start:0x80C1E8C8 end:0x80C1EF90
 	.bss        start:0x80D18DC8 end:0x80D18DD0
 
-system/rndobj/Dir.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Dir.o:
 	.text       start:0x8088BB50 end:0x808917C0
 	.data       start:0x80C1EF90 end:0x80C1F350
 	.sbss       start:0x80C7AB88 end:0x80C7AB90
 	.bss        start:0x80D18DD0 end:0x80D18DD8
 
-system/rndobj/DOFProc.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/DOFProc.o:
 	.text       start:0x808917C0 end:0x80891C20
 	.data       start:0x80C1F350 end:0x80C1F470
 	.sbss       start:0x80C7AB90 end:0x80C7AB98
 	.bss        start:0x80D18DD8 end:0x80D18DE8
 
-system/rndobj/Draw.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Draw.o:
 	.text       start:0x80891C20 end:0x80893AA0
 	.data       start:0x80C1F470 end:0x80C1F608
 	.sbss       start:0x80C7AB98 end:0x80C7ABA0
 	.bss        start:0x80D18DE8 end:0x80D18E00
 
-system/rndobj/Env.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Env.o:
 	.text       start:0x80893AA0 end:0x80899AF0
 	.ctors      start:0x80B34AF0 end:0x80B34AF4
 	.data       start:0x80C1F608 end:0x80C1F818
 	.sbss       start:0x80C7ABA0 end:0x80C7ABB0
 	.bss        start:0x80D18E00 end:0x80D1C730
 
-system/rndobj/EnvAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/EnvAnim.o:
 	.text       start:0x80899AF0 end:0x8089E510
 	.data       start:0x80C1F818 end:0x80C1FB50
 	.sbss       start:0x80C7ABB0 end:0x80C7ABB8
 	.bss        start:0x80D1C730 end:0x80D1C738
 
-system/rndobj/EventTrigger.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/EventTrigger.o:
 	.text       start:0x8089E510 end:0x808AE350
 	.data       start:0x80C1FB50 end:0x80C20E00
 	.sbss       start:0x80C7ABB8 end:0x80C7ABC8
 	.bss        start:0x80D1C738 end:0x80D1C778
 
-system/rndobj/Flare.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Flare.o:
 	.text       start:0x808AE350 end:0x808B0950
 	.data       start:0x80C20E00 end:0x80C21070
 	.sbss       start:0x80C7ABC8 end:0x80C7ABD0
 	.bss        start:0x80D1C778 end:0x80D1C780
 
-system/rndobj/Font.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Font.o:
 	.text       start:0x808B0950 end:0x808B6DB0
 	.rodata     start:0x80B389C0 end:0x80B38A20
 	.data       start:0x80C21070 end:0x80C21548
@@ -6261,64 +6261,64 @@ system/rndobj/Font.cpp:
 	.sbss       start:0x80C7ABD0 end:0x80C7ABD8
 	.bss        start:0x80D1C780 end:0x80D1C790
 
-system/rndobj/Gen.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Gen.o:
 	.text       start:0x808B6DB0 end:0x808BA520
 	.rodata     start:0x80B38A20 end:0x80B38A28
 	.data       start:0x80C21548 end:0x80C21F30
 	.sbss       start:0x80C7ABD8 end:0x80C7ABE0
 	.bss        start:0x80D1C790 end:0x80D1C798
 
-system/rndobj/Graph.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Graph.o:
 	.text       start:0x808BA520 end:0x808BB5C0
 	.ctors      start:0x80B34AF4 end:0x80B34AF8
 	.data       start:0x80C21F30 end:0x80C22080
 	.bss        start:0x80D1C798 end:0x80D1C7D0
 
-system/rndobj/Group.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Group.o:
 	.text       start:0x808BB5C0 end:0x808BF9F0
 	.data       start:0x80C22080 end:0x80C22330
 	.sbss       start:0x80C7ABE0 end:0x80C7ABE8
 	.bss        start:0x80D1C7D0 end:0x80D1C7E0
 
-system/rndobj/HiResScreen.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/HiResScreen.o:
 	.text       start:0x808BF9F0 end:0x808C13C0
 	.ctors      start:0x80B34AF8 end:0x80B34AFC
 	.data       start:0x80C22330 end:0x80C22490
 	.bss        start:0x80D1C7E0 end:0x80D1C820
 
-system/rndobj/Line.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Line.o:
 	.text       start:0x808C13C0 end:0x808C7C70
 	.rodata     start:0x80B38A28 end:0x80B38A30
 	.data       start:0x80C22490 end:0x80C22790
 	.sbss       start:0x80C7ABE8 end:0x80C7ABF0
 	.bss        start:0x80D1C820 end:0x80D1C838
 
-system/rndobj/Lit.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Lit.o:
 	.text       start:0x808C7C70 end:0x808CA960
 	.rodata     start:0x80B38A30 end:0x80B38A40
 	.data       start:0x80C22790 end:0x80C22A30
 	.sbss       start:0x80C7ABF0 end:0x80C7ABF8
 	.bss        start:0x80D1C838 end:0x80D1C840
 
-system/rndobj/LitAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/LitAnim.o:
 	.text       start:0x808CA960 end:0x808CC950
 	.data       start:0x80C22A30 end:0x80C22D20
 	.sbss       start:0x80C7ABF8 end:0x80C7AC00
 	.bss        start:0x80D1C840 end:0x80D1C848
 
-system/rndobj/Mat.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Mat.o:
 	.text       start:0x808CC950 end:0x808D1050
 	.data       start:0x80C22D20 end:0x80C22F88
 	.sbss       start:0x80C7AC00 end:0x80C7AC20
 	.bss        start:0x80D1C848 end:0x80D1C898
 
-system/rndobj/MatAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/MatAnim.o:
 	.text       start:0x808D1050 end:0x808D59F0
 	.data       start:0x80C22F88 end:0x80C23298
 	.sbss       start:0x80C7AC20 end:0x80C7AC28
 	.bss        start:0x80D1C898 end:0x80D1C8A0
 
-system/rndobj/Mesh.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Mesh.o:
 	.text       start:0x808D59F0 end:0x808E5A30
 	.ctors      start:0x80B34AFC end:0x80B34B00
 	.rodata     start:0x80B38A40 end:0x80B38A58
@@ -6327,50 +6327,50 @@ system/rndobj/Mesh.cpp:
 	.sbss       start:0x80C7AC28 end:0x80C7AC38
 	.bss        start:0x80D1C8A0 end:0x80D1C8D0
 
-system/rndobj/MeshAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/MeshAnim.o:
 	.text       start:0x808E5A30 end:0x808EFB80
 	.data       start:0x80C24488 end:0x80C24D10
 	.sbss       start:0x80C7AC38 end:0x80C7AC40
 	.bss        start:0x80D1C8D0 end:0x80D1C8F0
 
-system/rndobj/MeshDeform.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/MeshDeform.o:
 	.text       start:0x808EFB80 end:0x808F3CC0
 	.data       start:0x80C24D10 end:0x80C25058
 	.sbss       start:0x80C7AC40 end:0x80C7AC48
 	.bss        start:0x80D1C8F0 end:0x80D1C8F8
 
-system/rndobj/Morph.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Morph.o:
 	.text       start:0x808F3CC0 end:0x808F8E20
 	.data       start:0x80C25058 end:0x80C255F0
 	.sbss       start:0x80C7AC48 end:0x80C7AC50
 	.bss        start:0x80D1C8F8 end:0x80D1C900
 
-system/rndobj/MotionBlur.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/MotionBlur.o:
 	.text       start:0x808F8E20 end:0x808FA7D0
 	.data       start:0x80C255F0 end:0x80C257E8
 	.sbss       start:0x80C7AC50 end:0x80C7AC58
 	.bss        start:0x80D1C900 end:0x80D1C908
 
-system/rndobj/Movie.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Movie.o:
 	.text       start:0x808FA7D0 end:0x808FBA20
 	.data       start:0x80C257E8 end:0x80C25990
 	.sbss       start:0x80C7AC58 end:0x80C7AC60
 	.bss        start:0x80D1C908 end:0x80D1C910
 
-system/rndobj/MultiMesh.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/MultiMesh.o:
 	.text       start:0x808FBA20 end:0x808FF010
 	.ctors      start:0x80B34B00 end:0x80B34B04
 	.data       start:0x80C25990 end:0x80C25BC8
 	.sbss       start:0x80C7AC60 end:0x80C7AC68
 	.bss        start:0x80D1C910 end:0x80D1C938
 
-system/rndobj/MultiMeshProxy.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/MultiMeshProxy.o:
 	.text       start:0x808FF010 end:0x808FFA50
 	.data       start:0x80C25BC8 end:0x80C25DA0
 	.sbss       start:0x80C7AC68 end:0x80C7AC70
 	.bss        start:0x80D1C938 end:0x80D1C940
 
-system/rndobj/Overlay.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Overlay.o:
 	.text       start:0x808FFA50 end:0x80900800
 	.ctors      start:0x80B34B04 end:0x80B34B08
 	.rodata     start:0x80B38A58 end:0x80B38A70
@@ -6378,7 +6378,7 @@ system/rndobj/Overlay.cpp:
 	.sdata      start:0x80C78FC0 end:0x80C78FC8
 	.bss        start:0x80D1C940 end:0x80D1C958
 
-system/rndobj/Part.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Part.o:
 	.text       start:0x80900800 end:0x8090B340
 	.ctors      start:0x80B34B08 end:0x80B34B0C
 	.rodata     start:0x80B38A70 end:0x80B38A88
@@ -6386,31 +6386,31 @@ system/rndobj/Part.cpp:
 	.sbss       start:0x80C7AC70 end:0x80C7AC88
 	.bss        start:0x80D1C958 end:0x80D1CA20
 
-system/rndobj/PartAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/PartAnim.o:
 	.text       start:0x8090B340 end:0x8090E960
 	.data       start:0x80C26378 end:0x80C26698
 	.sbss       start:0x80C7AC88 end:0x80C7AC90
 	.bss        start:0x80D1CA20 end:0x80D1CA28
 
-system/rndobj/PartLauncher.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/PartLauncher.o:
 	.text       start:0x8090E960 end:0x80911600
 	.data       start:0x80C26698 end:0x80C26820
 	.sbss       start:0x80C7AC90 end:0x80C7AC98
 	.bss        start:0x80D1CA28 end:0x80D1CA30
 
-system/rndobj/Poll.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Poll.o:
 	.text       start:0x80911600 end:0x80911B00
 	.data       start:0x80C26820 end:0x80C268D0
 	.sbss       start:0x80C7AC98 end:0x80C7ACA0
 	.bss        start:0x80D1CA30 end:0x80D1CA38
 
-system/rndobj/PollAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/PollAnim.o:
 	.text       start:0x80911B00 end:0x809132B0
 	.data       start:0x80C268D0 end:0x80C26B08
 	.sbss       start:0x80C7ACA0 end:0x80C7ACA8
 	.bss        start:0x80D1CA38 end:0x80D1CA40
 
-system/rndobj/PostProc.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/PostProc.o:
 	.text       start:0x809132B0 end:0x80917370
 	.ctors      start:0x80B34B0C end:0x80B34B10
 	.rodata     start:0x80B38A88 end:0x80B38A90
@@ -6418,7 +6418,7 @@ system/rndobj/PostProc.cpp:
 	.sbss       start:0x80C7ACA8 end:0x80C7ACB0
 	.bss        start:0x80D1CA40 end:0x80D1CA68
 
-system/rndobj/PropKeys.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/PropKeys.o:
 	.text       start:0x80917370 end:0x80926F60
 	.ctors      start:0x80B34B10 end:0x80B34B14
 	.data       start:0x80C26CD0 end:0x80C27900
@@ -6426,75 +6426,75 @@ system/rndobj/PropKeys.cpp:
 	.sbss       start:0x80C7ACB0 end:0x80C7ACB8
 	.bss        start:0x80D1CA68 end:0x80D1CA80
 
-system/rndobj/PropAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/PropAnim.o:
 	.text       start:0x80926F60 end:0x8092EE20
 	.ctors      start:0x80B34B14 end:0x80B34B18
 	.data       start:0x80C27900 end:0x80C27B80
 	.sbss       start:0x80C7ACB8 end:0x80C7ACC0
 	.bss        start:0x80D1CA80 end:0x80D1CAA0
 
-system/rndobj/Rnd.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Rnd.o:
 	.text       start:0x8092EE20 end:0x809372B0
 	.rodata     start:0x80B38A90 end:0x80B38B20
 	.data       start:0x80C27B80 end:0x80C280F0
 	.sbss       start:0x80C7ACC0 end:0x80C7ACD8
 	.bss        start:0x80D1CAA0 end:0x80D1CB08
 
-system/rndobj/ScreenMask.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/ScreenMask.o:
 	.text       start:0x809372B0 end:0x80938600
 	.data       start:0x80C280F0 end:0x80C28310
 	.sbss       start:0x80C7ACD8 end:0x80C7ACE0
 	.bss        start:0x80D1CB08 end:0x80D1CB28
 
-system/rndobj/Set.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Set.o:
 	.text       start:0x80938600 end:0x8093A0F0
 	.data       start:0x80C28310 end:0x80C284D8
 	.sbss       start:0x80C7ACE0 end:0x80C7ACE8
 	.bss        start:0x80D1CB28 end:0x80D1CB48
 
-system/rndobj/ShaderOptions.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/ShaderOptions.o:
 	.text       start:0x8093A0F0 end:0x8093A340
 	.ctors      start:0x80B34B18 end:0x80B34B1C
 	.data       start:0x80C284D8 end:0x80C28A28
 	.bss        start:0x80D1CB48 end:0x80D1CBB0
 
-system/rndobj/ShadowMap.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/ShadowMap.o:
 	.text       start:0x8093A340 end:0x8093AAF0
 	.data       start:0x80C28A28 end:0x80C28A58
 	.sbss       start:0x80C7ACE8 end:0x80C7ACF0
 	.bss        start:0x80D1CBB0 end:0x80D1CBE8
 
-system/rndobj/SIVideo.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/SIVideo.o:
 	.text       start:0x8093AAF0 end:0x8093ADF0
 	.data       start:0x80C28A58 end:0x80C28A78
 
-system/rndobj/Tex.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Tex.o:
 	.text       start:0x8093ADF0 end:0x8093E030
 	.rodata     start:0x80B38B20 end:0x80B38B40
 	.data       start:0x80C28A78 end:0x80C28E80
 	.sbss       start:0x80C7ACF0 end:0x80C7AD00
 	.bss        start:0x80D1CBE8 end:0x80D1CBF8
 
-system/rndobj/TexBlendController.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/TexBlendController.o:
 	.text       start:0x8093E030 end:0x8093F2E0
 	.data       start:0x80C28E80 end:0x80C28F98
 	.sbss       start:0x80C7AD00 end:0x80C7AD08
 	.bss        start:0x80D1CBF8 end:0x80D1CC00
 
-system/rndobj/TexBlender.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/TexBlender.o:
 	.text       start:0x8093F2E0 end:0x809419D0
 	.rodata     start:0x80B38B40 end:0x80B38B48
 	.data       start:0x80C28F98 end:0x80C292A0
 	.sbss       start:0x80C7AD08 end:0x80C7AD10
 	.bss        start:0x80D1CC00 end:0x80D1CC08
 
-system/rndobj/TexRenderer.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/TexRenderer.o:
 	.text       start:0x809419D0 end:0x80945020
 	.data       start:0x80C292A0 end:0x80C29630
 	.sbss       start:0x80C7AD10 end:0x80C7AD20
 	.bss        start:0x80D1CC08 end:0x80D1CC80
 
-system/rndobj/Text.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Text.o:
 	.text       start:0x80945020 end:0x80950870
 	.ctors      start:0x80B34B1C end:0x80B34B20
 	.rodata     start:0x80B38B48 end:0x80B38B68
@@ -6503,7 +6503,7 @@ system/rndobj/Text.cpp:
 	.sbss       start:0x80C7AD20 end:0x80C7AD28
 	.bss        start:0x80D1CC80 end:0x80D1CCB0
 
-system/rndobj/Trans.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Trans.o:
 	.text       start:0x80950870 end:0x80956F40
 	.ctors      start:0x80B34B20 end:0x80B34B24
 	.rodata     start:0x80B38B68 end:0x80B38B80
@@ -6511,19 +6511,19 @@ system/rndobj/Trans.cpp:
 	.sbss       start:0x80C7AD28 end:0x80C7AD30
 	.bss        start:0x80D1CCB0 end:0x80D1CCC8
 
-system/rndobj/TransProxy.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/TransProxy.o:
 	.text       start:0x80956F40 end:0x80957F20
 	.data       start:0x80C2A390 end:0x80C2A518
 	.sbss       start:0x80C7AD30 end:0x80C7AD38
 	.bss        start:0x80D1CCC8 end:0x80D1CCD0
 
-system/rndobj/TransAnim.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/TransAnim.o:
 	.text       start:0x80957F20 end:0x8095D530
 	.data       start:0x80C2A518 end:0x80C2A7F8
 	.sbss       start:0x80C7AD38 end:0x80C7AD40
 	.bss        start:0x80D1CCD0 end:0x80D1CCD8
 
-system/rndobj/Utl.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Utl.o:
 	.text       start:0x8095D530 end:0x8096A400
 	.ctors      start:0x80B34B24 end:0x80B34B28
 	.rodata     start:0x80B38B80 end:0x80B38B88
@@ -6531,7 +6531,7 @@ system/rndobj/Utl.cpp:
 	.sbss       start:0x80C7AD40 end:0x80C7AD48
 	.bss        start:0x80D1CCD8 end:0x80D1CFB8
 
-system/rndobj/Wind.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Wind.o:
 	.text       start:0x8096A400 end:0x8096BB00
 	.ctors      start:0x80B34B28 end:0x80B34B2C
 	.rodata     start:0x80B38B88 end:0x80B38BA0
@@ -6539,149 +6539,149 @@ system/rndobj/Wind.cpp:
 	.sbss       start:0x80C7AD48 end:0x80C7AD50
 	.bss        start:0x80D1CFB8 end:0x80D1EFD8
 
-system/rndobj/SoftParticles.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/SoftParticles.o:
 	.text       start:0x8096BB00 end:0x8096C7D0
 	.data       start:0x80C2AE68 end:0x80C2B028
 	.sbss       start:0x80C7AD50 end:0x80C7AD58
 	.bss        start:0x80D1EFD8 end:0x80D1EFE0
 
-system/rndobj/CubeTex.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/CubeTex.o:
 	.text       start:0x8096C7D0 end:0x8096E100
 	.data       start:0x80C2B028 end:0x80C2B1C8
 	.sbss       start:0x80C7AD58 end:0x80C7AD60
 	.bss        start:0x80D1EFE0 end:0x80D1EFE8
 
-system/rndobj/Fur.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Fur.o:
 	.text       start:0x8096E100 end:0x8096EA80
 	.data       start:0x80C2B1C8 end:0x80C2B2F0
 	.sbss       start:0x80C7AD60 end:0x80C7AD68
 	.bss        start:0x80D1EFE8 end:0x80D1EFF0
 
-system/rndobj/AmbientOcclusion.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/AmbientOcclusion.o:
 	.text       start:0x8096EA80 end:0x8096F3D0
 	.data       start:0x80C2B2F0 end:0x80C2B438
 	.sbss       start:0x80C7AD68 end:0x80C7AD70
 	.bss        start:0x80D1EFF0 end:0x80D1EFF8
 
-system/rndobj/DOFProc_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/DOFProc_Wii.o:
 	.text       start:0x8096F3D0 end:0x8096F810
 	.data       start:0x80C2B438 end:0x80C2B558
 	.sbss       start:0x80C7AD70 end:0x80C7AD78
 	.bss        start:0x80D1EFF8 end:0x80D1F000
 
-system/rndobj/Dxt1Compress.cpp:
+lib.a/hproj/band3_wii/system/src/rndobj/wii_release/Dxt1Compress.o:
 	.text       start:0x8096F810 end:0x80971A60
 
-system/synthwii/EnvelopeWii.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/EnvelopeWii.o:
 	.text       start:0x80971A60 end:0x80971E40
 	.data       start:0x80C2B558 end:0x80C2B580
 
-system/synthwii/FXWii.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/FXWii.o:
 	.text       start:0x80971E40 end:0x809728A0
 	.ctors      start:0x80B34B2C end:0x80B34B30
 	.data       start:0x80C2B580 end:0x80C2B5F0
 	.bss        start:0x80D1F000 end:0x80D1F3D0
 
-system/synthwii/Mic_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/Mic_Wii.o:
 	.text       start:0x809728A0 end:0x80974080
 	.rodata     start:0x80B38BA0 end:0x80B38BC8
 	.data       start:0x80C2B5F0 end:0x80C2B8A8
 	.sbss       start:0x80C7AD78 end:0x80C7AD80
 	.bss        start:0x80D1F3D0 end:0x80D1F3E0
 
-system/synthwii/PitchShiftEffect.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/PitchShiftEffect.o:
 	.text       start:0x80974080 end:0x809743E0
 	.data       start:0x80C2B8A8 end:0x80C2B900
 
-system/synthwii/Synth_Wii.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/Synth_Wii.o:
 	.text       start:0x809743E0 end:0x80976D20
 	.data       start:0x80C2B900 end:0x80C2BD78
 	.sbss       start:0x80C7AD80 end:0x80C7AD88
 	.bss        start:0x80D1F3E0 end:0x80D1F3F0
 
-system/synthwii/SampleInst.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/SampleInst.o:
 	.text       start:0x80976D20 end:0x809771F0
 	.data       start:0x80C2BD78 end:0x80C2BE98
 
-system/synthwii/SynthSample.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/SynthSample.o:
 	.text       start:0x809771F0 end:0x80977630
 	.data       start:0x80C2BE98 end:0x80C2BF98
 	.sbss       start:0x80C7AD88 end:0x80C7AD90
 	.bss        start:0x80D1F3F0 end:0x80D1F3F8
 
-system/synthwii/VoiceWii.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/VoiceWii.o:
 	.text       start:0x80977630 end:0x80978EB0
 	.rodata     start:0x80B38BC8 end:0x80B38BD8
 	.data       start:0x80C2BF98 end:0x80C2C148
 	.sbss       start:0x80C7AD90 end:0x80C7AD98
 	.bss        start:0x80D1F3F8 end:0x80D1F588
 
-system/synthwii/WahEffect.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/WahEffect.o:
 	.rodata     start:0x80B38BD8 end:0x80B38BE0
 
-system/synthwii/StreamReceiver.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/wii_release/StreamReceiver.o:
 	.text       start:0x80978EB0 end:0x80979FF0
 	.data       start:0x80C2C148 end:0x80C2C230
 	.sbss       start:0x80C7AD98 end:0x80C7ADA0
 	.bss        start:0x80D1F588 end:0x80D1F598
 
-system/synthwii/soundtouch/AAFilter.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/soundtouch/wii_release/AAFilter.o:
 	.text       start:0x80979FF0 end:0x8097A2F0
 	.rodata     start:0x80B38BE0 end:0x80B38C08
 
-system/synthwii/soundtouch/FIFOSampleBuffer.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/soundtouch/wii_release/FIFOSampleBuffer.o:
 	.text       start:0x8097A2F0 end:0x8097A7F0
 	.data       start:0x80C2C230 end:0x80C2C2D8
 	.sbss       start:0x80C7ADA0 end:0x80C7ADA8
 	.bss        start:0x80D1F598 end:0x80D1F5A0
 
-system/synthwii/soundtouch/FIRFilter.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/soundtouch/wii_release/FIRFilter.o:
 	.text       start:0x8097A7F0 end:0x8097ACE0
 	.data       start:0x80C2C2D8 end:0x80C2C338
 
-system/synthwii/soundtouch/RateTransposer.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/soundtouch/wii_release/RateTransposer.o:
 	.text       start:0x8097ACE0 end:0x8097B8F0
 	.data       start:0x80C2C338 end:0x80C2C458
 
-system/synthwii/soundtouch/SoundTouch.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/soundtouch/wii_release/SoundTouch.o:
 	.text       start:0x8097B8F0 end:0x8097C290
 	.data       start:0x80C2C458 end:0x80C2C548
 
-system/synthwii/soundtouch/TDStretch.cpp:
+lib.a/hproj/band3_wii/system/src/synthwii/soundtouch/wii_release/TDStretch.o:
 	.text       start:0x8097C290 end:0x8097D590
 	.data       start:0x80C2C548 end:0x80C2C748
 
-system/synth/ADSR.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/ADSR.o:
 	.text       start:0x8097D590 end:0x8097DDC0
 	.rodata     start:0x80B38C08 end:0x80B395A0
 	.data       start:0x80C2C748 end:0x80C2C8A0
 
-system/synth/BinkClip.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/BinkClip.o:
 	.text       start:0x8097DDC0 end:0x8097FD20
 	.data       start:0x80C2C8A0 end:0x80C2CA40
 	.sdata      start:0x80C78FD8 end:0x80C78FE0
 	.sbss       start:0x80C7ADA8 end:0x80C7ADB0
 	.bss        start:0x80D1F5A0 end:0x80D1F5A8
 
-system/synth/BinkReader.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/BinkReader.o:
 	.text       start:0x8097FD20 end:0x80980FA0
 	.data       start:0x80C2CA40 end:0x80C2CD48
 	.sbss       start:0x80C7ADB0 end:0x80C7ADC0
 	.bss        start:0x80D1F5A8 end:0x80D1F620
 
-system/synth/ByteGrinder.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/ByteGrinder.o:
 	.text       start:0x80980FA0 end:0x80984970
 	.data       start:0x80C2CD48 end:0x80C2CEF8
 	.bss        start:0x80D1F620 end:0x80D1FE60
 
-system/synth/Emitter.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Emitter.o:
 	.text       start:0x80984970 end:0x80986B90
 	.rodata     start:0x80B395A0 end:0x80B395A8
 	.data       start:0x80C2CEF8 end:0x80C2D2A8
 	.sbss       start:0x80C7ADC0 end:0x80C7ADC8
 	.bss        start:0x80D1FE60 end:0x80D1FE70
 
-system/synth/Faders.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Faders.o:
 	.text       start:0x80986B90 end:0x8098A600
 	.ctors      start:0x80B34B30 end:0x80B34B34
 	.data       start:0x80C2D2A8 end:0x80C2D5F8
@@ -6689,198 +6689,198 @@ system/synth/Faders.cpp:
 	.sbss       start:0x80C7ADC8 end:0x80C7ADD0
 	.bss        start:0x80D1FE70 end:0x80D1FEA8
 
-system/synth/FxSend.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSend.o:
 	.text       start:0x8098A600 end:0x8098C290
 	.data       start:0x80C2D5F8 end:0x80C2D898
 	.sbss       start:0x80C7ADD0 end:0x80C7ADD8
 	.bss        start:0x80D1FEA8 end:0x80D1FEB0
 
-system/synth/FxSendChorus.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendChorus.o:
 	.text       start:0x8098C290 end:0x8098D330
 	.data       start:0x80C2D898 end:0x80C2DA08
 	.sbss       start:0x80C7ADD8 end:0x80C7ADE0
 	.bss        start:0x80D1FEB0 end:0x80D1FEB8
 
-system/synth/FxSendFlanger.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendFlanger.o:
 	.text       start:0x8098D330 end:0x8098E400
 	.data       start:0x80C2DA08 end:0x80C2DB78
 	.sbss       start:0x80C7ADE0 end:0x80C7ADE8
 	.bss        start:0x80D1FEB8 end:0x80D1FEC0
 
-system/synth/FxSendReverb.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendReverb.o:
 	.text       start:0x8098E400 end:0x8098F450
 	.data       start:0x80C2DB78 end:0x80C2DCE8
 	.sbss       start:0x80C7ADE8 end:0x80C7ADF0
 	.bss        start:0x80D1FEC0 end:0x80D1FEC8
 
-system/synth/FxSendDelay.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendDelay.o:
 	.text       start:0x8098F450 end:0x809902A0
 	.data       start:0x80C2DCE8 end:0x80C2DE18
 	.sbss       start:0x80C7ADF0 end:0x80C7ADF8
 	.bss        start:0x80D1FEC8 end:0x80D1FED0
 
-system/synth/FxSendDistortion.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendDistortion.o:
 	.text       start:0x809902A0 end:0x80990B40
 	.data       start:0x80C2DE18 end:0x80C2DF90
 	.sbss       start:0x80C7ADF8 end:0x80C7AE00
 	.bss        start:0x80D1FED0 end:0x80D1FED8
 
-system/synth/FxSendCompress.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendCompress.o:
 	.text       start:0x80990B40 end:0x80991CB0
 	.rodata     start:0x80B395A8 end:0x80B395B0
 	.data       start:0x80C2DF90 end:0x80C2E100
 	.sbss       start:0x80C7AE00 end:0x80C7AE08
 	.bss        start:0x80D1FED8 end:0x80D1FEE0
 
-system/synth/FxSendEQ.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendEQ.o:
 	.text       start:0x80991CB0 end:0x80993000
 	.rodata     start:0x80B395B0 end:0x80B395B8
 	.data       start:0x80C2E100 end:0x80C2E260
 	.sbss       start:0x80C7AE08 end:0x80C7AE10
 	.bss        start:0x80D1FEE0 end:0x80D1FEE8
 
-system/synth/FxSendMeterEffect.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendMeterEffect.o:
 	.text       start:0x80993000 end:0x80993AC0
 	.data       start:0x80C2E260 end:0x80C2E3D8
 	.sbss       start:0x80C7AE10 end:0x80C7AE18
 	.bss        start:0x80D1FEE8 end:0x80D1FEF0
 
-system/synth/FxSendPitchShift.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendPitchShift.o:
 	.text       start:0x80993AC0 end:0x80994300
 	.data       start:0x80C2E3D8 end:0x80C2E558
 	.sbss       start:0x80C7AE18 end:0x80C7AE20
 	.bss        start:0x80D1FEF0 end:0x80D1FEF8
 
-system/synth/FxSendSynapse.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendSynapse.o:
 	.text       start:0x80994300 end:0x80995490
 	.data       start:0x80C2E558 end:0x80C2E660
 	.sbss       start:0x80C7AE20 end:0x80C7AE28
 	.bss        start:0x80D1FEF8 end:0x80D1FF00
 
-system/synth/FxSendWah.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/FxSendWah.o:
 	.text       start:0x80995490 end:0x80996A50
 	.data       start:0x80C2E660 end:0x80C2E7C8
 	.sbss       start:0x80C7AE28 end:0x80C7AE30
 	.bss        start:0x80D1FF00 end:0x80D1FF08
 
-system/synth/MetaMusic.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MetaMusic.o:
 	.text       start:0x80996A50 end:0x8099A2B0
 	.data       start:0x80C2E7C8 end:0x80C2EAC0
 	.sdata      start:0x80C78FE8 end:0x80C78FF0
 	.sbss       start:0x80C7AE30 end:0x80C7AE38
 	.bss        start:0x80D1FF08 end:0x80D1FF10
 
-system/synth/Mic.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Mic.o:
 	.text       start:0x8099A2B0 end:0x8099A470
 	.data       start:0x80C2EAC0 end:0x80C2EAF8
 
-system/synth/MicClientMapper.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MicClientMapper.o:
 	.text       start:0x8099A470 end:0x8099B630
 	.ctors      start:0x80B34B34 end:0x80B34B38
 	.data       start:0x80C2EAF8 end:0x80C2ECC8
 	.bss        start:0x80D1FF10 end:0x80D1FF18
 
-system/synth/MidiInstrumentMgr.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MidiInstrumentMgr.o:
 	.text       start:0x8099B630 end:0x8099BB10
 	.data       start:0x80C2ECC8 end:0x80C2ED18
 
-system/synth/MidiInstrument.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MidiInstrument.o:
 	.text       start:0x8099BB10 end:0x809A06C0
 	.data       start:0x80C2ED18 end:0x80C2F108
 	.sbss       start:0x80C7AE38 end:0x80C7AE40
 	.bss        start:0x80D1FF18 end:0x80D1FF20
 
-system/synth/MicNull.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MicNull.o:
 	.text       start:0x809A06C0 end:0x809A0A80
 	.ctors      start:0x80B34B38 end:0x80B34B3C
 	.data       start:0x80C2F108 end:0x80C2F1D0
 	.bss        start:0x80D1FF20 end:0x80D20330
 
-system/synth/MidiChannel.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MidiChannel.o:
 	.text       start:0x809A0A80 end:0x809A0BB0
 
-system/synth/MidiSynth.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MidiSynth.o:
 	.text       start:0x809A0BB0 end:0x809A2510
 	.data       start:0x80C2F1D0 end:0x80C2F3B0
 
-system/synth/MoggClip.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MoggClip.o:
 	.text       start:0x809A2510 end:0x809A42A0
 	.data       start:0x80C2F3B0 end:0x80C2F5D0
 	.sbss       start:0x80C7AE40 end:0x80C7AE48
 	.bss        start:0x80D20330 end:0x80D20338
 
-system/synth/MoggClipMap.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/MoggClipMap.o:
 	.text       start:0x809A42A0 end:0x809A4770
 	.data       start:0x80C2F5D0 end:0x80C2F6D0
 	.bss        start:0x80D20338 end:0x80D20340
 
-system/synth/OggMap.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/OggMap.o:
 	.text       start:0x809A4770 end:0x809A4C00
 	.data       start:0x80C2F6D0 end:0x80C2F758
 
-system/synth/Pollable.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Pollable.o:
 	.text       start:0x809A4C00 end:0x809A4EC0
 	.ctors      start:0x80B34B3C end:0x80B34B40
 	.data       start:0x80C2F758 end:0x80C2F770
 	.bss        start:0x80D20340 end:0x80D20358
 
-system/synth/SampleData.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/SampleData.o:
 	.text       start:0x809A4EC0 end:0x809A5F40
 	.rodata     start:0x80B395B8 end:0x80B395C0
 	.data       start:0x80C2F770 end:0x80C2F890
 	.sdata      start:0x80C78FF0 end:0x80C78FF8
 	.bss        start:0x80D20358 end:0x80D20360
 
-system/synth/SampleInst.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/SampleInst.o:
 	.text       start:0x809A5F40 end:0x809A62E0
 	.data       start:0x80C2F890 end:0x80C2F928
 
-system/synth/SampleZone.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/SampleZone.o:
 	.text       start:0x809A62E0 end:0x809A6680
 	.data       start:0x80C2F928 end:0x80C2F958
 	.bss        start:0x80D20360 end:0x80D20368
 
-system/synth/Sequence.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Sequence.o:
 	.text       start:0x809A6680 end:0x809AF1A0
 	.data       start:0x80C2F958 end:0x80C30878
 	.sbss       start:0x80C7AE48 end:0x80C7AE58
 	.bss        start:0x80D20368 end:0x80D20398
 
-system/synth/Sfx.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Sfx.o:
 	.text       start:0x809AF1A0 end:0x809B5F40
 	.data       start:0x80C30878 end:0x80C310B0
 	.sbss       start:0x80C7AE58 end:0x80C7AE60
 	.bss        start:0x80D20398 end:0x80D203A0
 
-system/synth/SfxMap.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/SfxMap.o:
 	.text       start:0x809B5F40 end:0x809B60B0
 	.bss        start:0x80D203A0 end:0x80D203A8
 
-system/synth/SlipTrack.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/SlipTrack.o:
 	.text       start:0x809B60B0 end:0x809B6550
 	.data       start:0x80C310B0 end:0x80C310D8
 
-system/synth/StandardStream.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/StandardStream.o:
 	.text       start:0x809B6550 end:0x809BA980
 	.rodata     start:0x80B395C0 end:0x80B395C8
 	.data       start:0x80C310D8 end:0x80C31760
 	.sdata      start:0x80C78FF8 end:0x80C79000
 
-system/synth/Stream.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Stream.o:
 	.text       start:0x809BA980 end:0x809BAB50
 	.rodata     start:0x80B395C8 end:0x80B395D0
 	.data       start:0x80C31760 end:0x80C31838
 
-system/synth/StreamNull.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/StreamNull.o:
 	.text       start:0x809BAB50 end:0x809BB0C0
 	.data       start:0x80C31838 end:0x80C31948
 
-system/synth/StreamReceiver.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/StreamReceiver.o:
 	.text       start:0x809BB0C0 end:0x809BBD00
 	.data       start:0x80C31948 end:0x80C31A68
 	.bss        start:0x80D203A8 end:0x80D203B0
 
-system/synth/Synth.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Synth.o:
 	.text       start:0x809BBD00 end:0x809C0B90
 	.ctors      start:0x80B34B40 end:0x80B34B44
 	.rodata     start:0x80B395D0 end:0x80B39608
@@ -6888,18 +6888,18 @@ system/synth/Synth.cpp:
 	.sbss       start:0x80C7AE60 end:0x80C7AE68
 	.bss        start:0x80D203B0 end:0x80D20448
 
-system/synth/SynthSample.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/SynthSample.o:
 	.text       start:0x809C0B90 end:0x809C2970
 	.data       start:0x80C32910 end:0x80C32AA0
 	.sbss       start:0x80C7AE68 end:0x80C7AE70
 	.bss        start:0x80D20448 end:0x80D20450
 
-system/synth/Utl.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/Utl.o:
 	.text       start:0x809C2970 end:0x809C2B40
 	.data       start:0x80C32AA0 end:0x80C32AF8
 	.bss        start:0x80D20450 end:0x80D20550
 
-system/synth/VoiceBeat.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/VoiceBeat.o:
 	.text       start:0x809C2B40 end:0x809C42A0
 	.rodata     start:0x80B39608 end:0x80B396C8
 	.data       start:0x80C32AF8 end:0x80C32B68
@@ -6907,112 +6907,112 @@ system/synth/VoiceBeat.cpp:
 	.sbss       start:0x80C7AE70 end:0x80C7AE78
 	.bss        start:0x80D20550 end:0x80D20558
 
-system/synth/VorbisReader.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/VorbisReader.o:
 	.text       start:0x809C42A0 end:0x809C6680
 	.data       start:0x80C32B68 end:0x80C32F10
 	.sbss       start:0x80C7AE78 end:0x80C7AE88
 	.bss        start:0x80D20558 end:0x80D20690
 
-system/synth/WavReader.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/WavReader.o:
 	.text       start:0x809C6680 end:0x809C6D00
 	.data       start:0x80C32F10 end:0x80C32FF0
 
-system/synth/aes.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/aes.o:
 	.text       start:0x809C6D00 end:0x809C96F0
 	.rodata     start:0x80B396C8 end:0x80B3D7A8
 	.data       start:0x80C32FF0 end:0x80C33138
 
-system/synth/crypt.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/crypt.o:
 	.text       start:0x809C96F0 end:0x809C9820
 	.data       start:0x80C33138 end:0x80C33298
 	.bss        start:0x80D20690 end:0x80D20C18
 
-system/synth/ctr.cpp:
+lib.a/hproj/band3_wii/system/src/synth/wii_release/ctr.o:
 	.text       start:0x809C9820 end:0x809C9C20
 
-system/speex/bits.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/bits.o:
 	.text       start:0x809C9C20 end:0x809CA2F0
 	.data       start:0x80C33298 end:0x80C333E8
 
-system/speex/cb_search.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/cb_search.o:
 	.text       start:0x809CA2F0 end:0x809CD890
 	.rodata     start:0x80B3D7A8 end:0x80B3D7C8
 
-system/speex/exc_10_16_table.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/exc_10_16_table.o:
 	.rodata     start:0x80B3D7C8 end:0x80B3D868
 
-system/speex/exc_10_32_table.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/exc_10_32_table.o:
 	.rodata     start:0x80B3D868 end:0x80B3D9A8
 
-system/speex/exc_20_32_table.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/exc_20_32_table.o:
 	.rodata     start:0x80B3D9A8 end:0x80B3DC28
 
-system/speex/exc_5_256_table.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/exc_5_256_table.o:
 	.rodata     start:0x80B3DC28 end:0x80B3E128
 
-system/speex/exc_5_64_table.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/exc_5_64_table.o:
 	.rodata     start:0x80B3E128 end:0x80B3E268
 
-system/speex/exc_8_128_table.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/exc_8_128_table.o:
 	.rodata     start:0x80B3E268 end:0x80B3E668
 
-system/speex/filters.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/filters.o:
 	.text       start:0x809CD890 end:0x809D0170
 	.rodata     start:0x80B3E668 end:0x80B3E760
 
-system/speex/gain_table.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/gain_table.o:
 	.rodata     start:0x80B3E760 end:0x80B3E960
 
-system/speex/gain_table_lbr.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/gain_table_lbr.o:
 	.rodata     start:0x80B3E960 end:0x80B3E9E0
 
-system/speex/lpc.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/lpc.o:
 	.text       start:0x809D0170 end:0x809D0870
 	.rodata     start:0x80B3E9E0 end:0x80B3E9E8
 
-system/speex/lsp.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/lsp.o:
 	.text       start:0x809D0870 end:0x809D1A80
 	.rodata     start:0x80B3E9E8 end:0x80B3EA10
 
-system/speex/lsp_tables_nb.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/lsp_tables_nb.o:
 	.rodata     start:0x80B3EA10 end:0x80B3F190
 
-system/speex/ltp.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/ltp.o:
 	.text       start:0x809D1A80 end:0x809D49C0
 	.rodata     start:0x80B3F190 end:0x80B3F1B0
 
-system/speex/modes.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/modes.o:
 	.text       start:0x809D49C0 end:0x809D49C0
 	.rodata     start:0x80B3F1B0 end:0x80B3F4E0
 	.data       start:0x80C333E8 end:0x80C333F8
 
-system/speex/nb_celp.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/nb_celp.o:
 	.text       start:0x809D49C0 end:0x809D8B40
 	.rodata     start:0x80B3F4E0 end:0x80B3F6A8
 	.data       start:0x80C333F8 end:0x80C33910
 
-system/speex/quant_lsp.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/quant_lsp.o:
 	.text       start:0x809D8B40 end:0x809DB1B0
 	.rodata     start:0x80B3F6A8 end:0x80B3F6D0
 
-system/speex/speex.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/speex.o:
 	.text       start:0x809DB1B0 end:0x809DB2E0
 	.data       start:0x80C33910 end:0x80C33968
 
-system/speex/speex_callbacks.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/speex_callbacks.o:
 	.text       start:0x809DB2E0 end:0x809DB410
 
-system/speex/vbr.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/vbr.o:
 	.text       start:0x809DB410 end:0x809DBE50
 	.rodata     start:0x80B3F6D0 end:0x80B3F898
 
-system/speex/window.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/window.o:
 	.rodata     start:0x80B3F898 end:0x80B3FBE8
 
-system/speex/vq.cpp:
+lib.a/hproj/band3_wii/system/src/speex/wii_release/vq.o:
 	.text       start:0x809DBE50 end:0x809DC270
 
-system/rndwii/Cam.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Cam.o:
 	.text       start:0x809DC270 end:0x809DCC00
 	.ctors      start:0x80B34B44 end:0x80B34B48
 	.rodata     start:0x80B3FBE8 end:0x80B3FBF0
@@ -7020,7 +7020,7 @@ system/rndwii/Cam.cpp:
 	.sbss       start:0x80C7AE88 end:0x80C7AE90
 	.bss        start:0x80D20C18 end:0x80D20C80
 
-system/rndwii/Env.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Env.o:
 	.text       start:0x809DCC00 end:0x809DDC40
 	.ctors      start:0x80B34B48 end:0x80B34B4C
 	.rodata     start:0x80B3FBF0 end:0x80B3FBF8
@@ -7028,11 +7028,11 @@ system/rndwii/Env.cpp:
 	.sbss       start:0x80C7AE90 end:0x80C7AE98
 	.bss        start:0x80D20C80 end:0x80D20CB0
 
-system/rndwii/Lit.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Lit.o:
 	.text       start:0x809DDC40 end:0x809DE1F0
 	.rodata     start:0x80B3FBF8 end:0x80B3FC00
 
-system/rndwii/Mat.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Mat.o:
 	.text       start:0x809DE1F0 end:0x809E13F0
 	.rodata     start:0x80B3FC00 end:0x80B3FC38
 	.data       start:0x80C33C28 end:0x80C33E58
@@ -7040,7 +7040,7 @@ system/rndwii/Mat.cpp:
 	.sbss       start:0x80C7AE98 end:0x80C7AEA0
 	.bss        start:0x80D20CB0 end:0x80D20CD0
 
-system/rndwii/Mesh.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Mesh.o:
 	.text       start:0x809E13F0 end:0x809E98C0
 	.rodata     start:0x80B3FC38 end:0x80B3FC50
 	.data       start:0x80C33E58 end:0x80C347D0
@@ -7048,26 +7048,26 @@ system/rndwii/Mesh.cpp:
 	.sbss       start:0x80C7AEA0 end:0x80C7AEB8
 	.bss        start:0x80D20CD0 end:0x80D20D88
 
-system/rndwii/Movie.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Movie.o:
 	.text       start:0x809E98C0 end:0x809EA710
 	.data       start:0x80C347D0 end:0x80C34948
 	.sbss       start:0x80C7AEB8 end:0x80C7AEC0
 	.bss        start:0x80D20D88 end:0x80D20D98
 
-system/rndwii/MultiMesh.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/MultiMesh.o:
 	.text       start:0x809EA710 end:0x809EBF90
 	.data       start:0x80C34948 end:0x80C34A98
 	.sbss       start:0x80C7AEC0 end:0x80C7AEE0
 	.bss        start:0x80D20D98 end:0x80D20E00
 
-system/rndwii/Part.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Part.o:
 	.text       start:0x809EBF90 end:0x809ED5D0
 	.data       start:0x80C34A98 end:0x80C34CF0
 	.sdata      start:0x80C79018 end:0x80C79020
 	.sbss       start:0x80C7AEE0 end:0x80C7AEF0
 	.bss        start:0x80D20E00 end:0x80D20ED8
 
-system/rndwii/PostProc.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/PostProc.o:
 	.text       start:0x809ED5D0 end:0x809F1CE0
 	.rodata     start:0x80B3FC50 end:0x80B3FC78
 	.data       start:0x80C34CF0 end:0x80C35340
@@ -7075,7 +7075,7 @@ system/rndwii/PostProc.cpp:
 	.sbss       start:0x80C7AEF0 end:0x80C7AF00
 	.bss        start:0x80D20ED8 end:0x80D20F30
 
-system/rndwii/Rnd.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Rnd.o:
 	.text       start:0x809F1CE0 end:0x809F93E0
 	.ctors      start:0x80B34B4C end:0x80B34B50
 	.rodata     start:0x80B3FC78 end:0x80B3FDB0
@@ -7084,13 +7084,13 @@ system/rndwii/Rnd.cpp:
 	.sbss       start:0x80C7AF00 end:0x80C7AF28
 	.bss        start:0x80D20F30 end:0x80D21850
 
-system/rndwii/SplitPostProc.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/SplitPostProc.o:
 	.text       start:0x809F93E0 end:0x809FA270
 	.data       start:0x80C35CB0 end:0x80C35D68
 	.sbss       start:0x80C7AF28 end:0x80C7AF30
 	.bss        start:0x80D21850 end:0x80D21860
 
-system/rndwii/Tex.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/Tex.o:
 	.text       start:0x809FA270 end:0x809FC8C0
 	.ctors      start:0x80B34B50 end:0x80B34B54
 	.data       start:0x80C35D68 end:0x80C360E8
@@ -7098,106 +7098,106 @@ system/rndwii/Tex.cpp:
 	.sbss       start:0x80C7AF30 end:0x80C7AF38
 	.bss        start:0x80D21860 end:0x80D21890
 
-system/rndwii/TexRenderer.cpp:
+lib.a/hproj/band3_wii/system/src/rndwii/wii_release/TexRenderer.o:
 	.text       start:0x809FC8C0 end:0x809FCDE0
 	.data       start:0x80C360E8 end:0x80C362D0
 	.sbss       start:0x80C7AF38 end:0x80C7AF40
 	.bss        start:0x80D21890 end:0x80D218A0
 
-system/usbwii/UsbWii.cpp:
+lib.a/hproj/band3_wii/system/src/usbwii/wii_release/UsbWii.o:
 	.text       start:0x809FCDE0 end:0x809FE640
 	.data       start:0x80C362D0 end:0x80C36330
 	.sbss       start:0x80C7AF40 end:0x80C7AF48
 	.bss        start:0x80D218A0 end:0x80D21CC8
 
-system/oggvorbis/analysis.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/analysis.o:
 	.text       start:0x809FE640 end:0x809FE640
 	.rodata     start:0x80B3FDB0 end:0x80B3FDC8
 
-system/oggvorbis/bitrate.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/bitrate.o:
 	.text       start:0x809FE640 end:0x809FE780
 
-system/oggvorbis/bitwise.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/bitwise.o:
 	.text       start:0x809FE780 end:0x809FEC20
 	.data       start:0x80C36330 end:0x80C363B8
 
-system/oggvorbis/block.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/block.o:
 	.text       start:0x809FEC20 end:0x80A00720
 	.rodata     start:0x80B3FDC8 end:0x80B3FDD0
 
-system/oggvorbis/codebook.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/codebook.o:
 	.text       start:0x80A00720 end:0x80A01300
 	.data       start:0x80C363B8 end:0x80C363E0
 
-system/oggvorbis/envelope.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/envelope.o:
 	.text       start:0x80A01300 end:0x80A01390
 
-system/oggvorbis/floor0.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/floor0.o:
 	.text       start:0x80A01390 end:0x80A01C60
 	.rodata     start:0x80B3FDD0 end:0x80B3FDD8
 	.data       start:0x80C363E0 end:0x80C36400
 
-system/oggvorbis/floor1.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/floor1.o:
 	.text       start:0x80A01C60 end:0x80A047A0
 	.rodata     start:0x80B3FDD8 end:0x80B3FDE0
 	.data       start:0x80C36400 end:0x80C36820
 	.bss        start:0x80D21CC8 end:0x80D21CD0
 
-system/oggvorbis/framing.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/framing.o:
 	.text       start:0x80A047A0 end:0x80A056B0
 	.data       start:0x80C36820 end:0x80C36C28
 
-system/oggvorbis/info.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/info.o:
 	.text       start:0x80A056B0 end:0x80A061A0
 	.data       start:0x80C36C28 end:0x80C36C38
 
-system/oggvorbis/lsp.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/lsp.o:
 	.text       start:0x80A061A0 end:0x80A06890
 	.rodata     start:0x80B3FDE0 end:0x80B3FDF0
 	.data       start:0x80C36C38 end:0x80C370D0
 
-system/oggvorbis/mapping0.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/mapping0.o:
 	.text       start:0x80A06890 end:0x80A083B0
 	.data       start:0x80C370D0 end:0x80C370F8
 
-system/oggvorbis/mdct.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/mdct.o:
 	.text       start:0x80A083B0 end:0x80A0A050
 	.rodata     start:0x80B3FDF0 end:0x80B3FDF8
 
-system/oggvorbis/psy.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/psy.o:
 	.text       start:0x80A0A050 end:0x80A0E1F0
 	.rodata     start:0x80B3FDF8 end:0x80B3FE40
 	.data       start:0x80C370F8 end:0x80C3D060
 
-system/oggvorbis/registry.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/registry.o:
 	.data       start:0x80C3D060 end:0x80C3D080
 
-system/oggvorbis/res0.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/res0.o:
 	.text       start:0x80A0E1F0 end:0x80A102A0
 	.data       start:0x80C3D080 end:0x80C3D0E0
 
-system/oggvorbis/sharedbook.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/sharedbook.o:
 	.text       start:0x80A102A0 end:0x80A116F0
 
-system/oggvorbis/smallft.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/smallft.o:
 	.text       start:0x80A116F0 end:0x80A14640
 	.data       start:0x80C3D0E0 end:0x80C3D100
 
-system/oggvorbis/VorbisMem.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/VorbisMem.o:
 	.text       start:0x80A14640 end:0x80A146C0
 
-system/oggvorbis/window.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/window.o:
 	.text       start:0x80A146C0 end:0x80A14BA0
 	.data       start:0x80C3D100 end:0x80C450A0
 
-system/oggvorbis/synthesis.cpp:
+lib.a/hproj/band3_wii/system/src/oggvorbis/wii_release/synthesis.o:
 	.text       start:0x80A14BA0 end:0x80A14D90
 
-lib/binkwii/binkwii.c:
+binkwii.a/binkwii.obj:
 	.text       start:0x80A14D90 end:0x80A14FE0
 	.sbss       start:0x80C7AF48 end:0x80C7AF50
 
-lib/binkwii/binkread.c:
+binkwii.a/binkread.obj:
 	.text       start:0x80A14FE0 end:0x80A18810
 	.rodata     start:0x80B3FE40 end:0x80B3FF20
 	.sdata      start:0x80C79038 end:0x80C79048
@@ -7205,49 +7205,49 @@ lib/binkwii/binkread.c:
 	.sdata2     start:0x80C7B938 end:0x80C7B940
 	.bss        start:0x80D21CD0 end:0x80D21E50
 
-lib/binkwii/wiiax.c:
+binkwii.a/wiiax.obj:
 	.text       start:0x80A18810 end:0x80A19BD0
 	.sbss       start:0x80C7AF68 end:0x80C7AF78
 	.sdata2     start:0x80C7B940 end:0x80C7B978
 
-lib/binkwii/wiifile.c:
+binkwii.a/wiifile.obj:
 	.text       start:0x80A19BD0 end:0x80A1A9D0
 
-lib/binkwii/binkacd.c:
+binkwii.a/binkacd.obj:
 	.text       start:0x80A1A9D0 end:0x80A1B880
 	.data       start:0x80C450A0 end:0x80C452F8
 	.sdata2     start:0x80C7B978 end:0x80C7B9A8
 
-lib/binkwii/expand.c:
+binkwii.a/expand.obj:
 	.text       start:0x80A1B880 end:0x80A1F960
 	.rodata     start:0x80B3FF20 end:0x80B40400
 	.data       start:0x80C452F8 end:0x80C45340
 	.sdata2     start:0x80C7B9A8 end:0x80C7B9B0
 
-lib/binkwii/radcb.c:
+binkwii.a/radcb.obj:
 	.text       start:0x80A1F960 end:0x80A20280
 	.bss        start:0x80D21E50 end:0x80D220B0
 
-lib/binkwii/popmal.c:
+binkwii.a/popmal.obj:
 	.text       start:0x80A20280 end:0x80A20430
 
-lib/binkwii/radmem.c:
+binkwii.a/radmem.obj:
 	.text       start:0x80A20430 end:0x80A20540
 	.sbss       start:0x80C7AF78 end:0x80C7AF80
 
-lib/binkwii/fft.c:
+binkwii.a/fft.obj:
 	.text       start:0x80A20540 end:0x80A250C0
 	.sdata2     start:0x80C7B9B0 end:0x80C7B9D8
 
-lib/binkwii/dct.c:
+binkwii.a/dct.obj:
 	.text       start:0x80A250C0 end:0x80A25A90
 	.rodata     start:0x80B40400 end:0x80B42400
 
-lib/binkwii/bitplane.c:
+binkwii.a/bitplane.obj:
 	.text       start:0x80A25A90 end:0x80A26E08
 	.rodata     start:0x80B42400 end:0x80B42800
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C++/MSL_Common/ios.cpp:
+MSL_C++.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C++/MSL_Common/Src/ios.o:
 	extab       start:0x80006740 end:0x80006760
 	extabindex  start:0x8000C9E0 end:0x8000CA10
 	.text       start:0x80A26E08 end:0x80A26F3C
@@ -7255,7 +7255,7 @@ sdk/PowerPC_EABI_Support/MSL/MSL_C++/MSL_Common/ios.cpp:
 	.data       start:0x80C45340 end:0x80C45360
 	.sdata      start:0x80C79048 end:0x80C79068
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C++/MSL_Common/locale.cpp:
+MSL_C++.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C++/MSL_Common/Src/locale.o:
 	extab       start:0x80006760 end:0x800067D8
 	extabindex  start:0x8000CA10 end:0x8000CA34
 	.text       start:0x80A26F3C end:0x80A27150
@@ -7265,97 +7265,97 @@ sdk/PowerPC_EABI_Support/MSL/MSL_C++/MSL_Common/locale.cpp:
 	.sdata      start:0x80C79068 end:0x80C79080
 	.sbss       start:0x80C7AF80 end:0x80C7AF88
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C++/MSL_Common/msl_thread.cpp:
+MSL_C++.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C++/MSL_Common/Src/msl_thread.o:
 	extab       start:0x800067D8 end:0x800067E0
 	extabindex  start:0x8000CA34 end:0x8000CA40
 	.text       start:0x80A27150 end:0x80A271C8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/alloc.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/alloc.o:
 	.text       start:0x80A271C8 end:0x80A28600
 	.rodata     start:0x80B428F0 end:0x80B42908
 	.sbss       start:0x80C7AF88 end:0x80C7AF90
 	.bss        start:0x80D220B0 end:0x80D220E8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/errno.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/errno.o:
 	.sbss       start:0x80C7AF90 end:0x80C7AF98
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/ansi_files.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/ansi_files.o:
 	.text       start:0x80A28600 end:0x80A28710
 	.data       start:0x80C453D0 end:0x80C45510
 	.bss        start:0x80D220E8 end:0x80D223E8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/ansi_fp.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Src/ansi_fp.o:
 	.text       start:0x80A28710 end:0x80A29F90
 	.rodata     start:0x80B42908 end:0x80B429E8
 	.data       start:0x80C45510 end:0x80C45678
 	.sdata2     start:0x80C7B9D8 end:0x80C7BA10
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/arith.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/arith.o:
 	.text       start:0x80A29F90 end:0x80A29FA0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/buffer_io.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/buffer_io.o:
 	.text       start:0x80A29FA0 end:0x80A2A080
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/char_io.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/char_io.o:
 	.text       start:0x80A2A080 end:0x80A2A364
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/ctype.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/ctype.o:
 	.text       start:0x80A2A364 end:0x80A2A3A4
 	.rodata     start:0x80B429E8 end:0x80B42DE8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/locale.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/locale.o:
 	.rodata     start:0x80B42DE8 end:0x80B42EF0
 	.data       start:0x80C45678 end:0x80C45870
 	.sdata2     start:0x80C7BA10 end:0x80C7BA28
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/direct_io.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/direct_io.o:
 	.text       start:0x80A2A3A4 end:0x80A2A6AC
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/file_io.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/file_io.o:
 	.text       start:0x80A2A6AC end:0x80A2A9A8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/FILE_POS.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/FILE_POS.o:
 	.text       start:0x80A2A9A8 end:0x80A2AC18
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/mbstring.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/mbstring.o:
 	.text       start:0x80A2AC18 end:0x80A2AE10
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/mem.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/mem.o:
 	.text       start:0x80A2AE10 end:0x80A2AF80
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/mem_funcs.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/mem_funcs.o:
 	.text       start:0x80A2AF80 end:0x80A2B250
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/math_api.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/math_api.o:
 	.text       start:0x80A2B250 end:0x80A2B344
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/misc_io.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/misc_io.o:
 	.text       start:0x80A2B344 end:0x80A2B354
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/printf.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/printf.o:
 	.text       start:0x80A2B354 end:0x80A2D8E0
 	.rodata     start:0x80B42EF0 end:0x80B42F18
 	.data       start:0x80C45870 end:0x80C45AA0
 	.sdata      start:0x80C79080 end:0x80C79088
 	.sdata2     start:0x80C7BA28 end:0x80C7BA30
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/qsort.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/qsort.o:
 	.text       start:0x80A2D8E0 end:0x80A2DA50
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/rand.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/rand.o:
 	.text       start:0x80A2DA50 end:0x80A2DA78
 	.sdata      start:0x80C79088 end:0x80C79090
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/scanf.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/scanf.o:
 	.text       start:0x80A2DA78 end:0x80A2EF5C
 	.rodata     start:0x80B42F18 end:0x80B42F40
 	.data       start:0x80C45AA0 end:0x80C45D10
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/signal.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/signal.o:
 	.text       start:0x80A2EF5C end:0x80A2F004
 	.bss        start:0x80D223E8 end:0x80D22408
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/string.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/string.o:
 	.text       start:0x80A2F004 end:0x80A2F948
 	.rodata     start:0x80B42F40 end:0x80B432B0
 	.data       start:0x80C45D10 end:0x80C45EA0
@@ -7363,203 +7363,203 @@ sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/string.c:
 	.sdata2     start:0x80C7BA30 end:0x80C7BA38
 	.bss        start:0x80D22408 end:0x80D22430
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/float.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/float.o:
 	.sdata      start:0x80C79098 end:0x80C790A8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/strtold.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/strtold.o:
 	.text       start:0x80A2F948 end:0x80A30CC8
 	.rodata     start:0x80B432B0 end:0x80B432C0
 	.sdata2     start:0x80C7BA38 end:0x80C7BA58
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/wctype.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/wctype.o:
 	.rodata     start:0x80B432C0 end:0x80B438C0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/strtoul.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/strtoul.o:
 	.text       start:0x80A30CC8 end:0x80A319A4
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/time.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/time.o:
 	.text       start:0x80A319A4 end:0x80A319A8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/wmem.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/wmem.o:
 	.text       start:0x80A319A8 end:0x80A31A38
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/wprintf.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/wprintf.o:
 	.text       start:0x80A31A38 end:0x80A33D50
 	.rodata     start:0x80B438C0 end:0x80B438C8
 	.data       start:0x80C45EA0 end:0x80C46140
 	.sdata2     start:0x80C7BA58 end:0x80C7BA60
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/wstring.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/wstring.o:
 	.text       start:0x80A33D50 end:0x80A33E78
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/wchar_io.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/wchar_io.o:
 	.text       start:0x80A33E78 end:0x80A33EF4
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/time.dolphin.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/time.dolphin.o:
 	.text       start:0x80A33EF4 end:0x80A33F1C
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/uart_console_io_gcn.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/uart_console_io_gcn.o:
 	.text       start:0x80A33F1C end:0x80A33FF4
 	.sbss       start:0x80C7AF98 end:0x80C7AFA0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/abort_exit_ppc_eabi.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/abort_exit_ppc_eabi.o:
 	.text       start:0x80A33FF4 end:0x80A34028
 	.sbss       start:0x80C7AFA0 end:0x80C7AFA8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/secure_error.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/secure_error.o:
 	.text       start:0x80A34028 end:0x80A34040
 	.sbss       start:0x80C7AFA8 end:0x80C7AFB0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/math_sun.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Src/math_sun.o:
 	.text       start:0x80A34040 end:0x80A34080
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_acos.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_acos.o:
 	.text       start:0x80A34080 end:0x80A3434C
 	.sdata2     start:0x80C7BA60 end:0x80C7BAE8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_asin.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_asin.o:
 	.text       start:0x80A3434C end:0x80A345E4
 	.sdata2     start:0x80C7BAE8 end:0x80C7BB70
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_atan2.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_atan2.o:
 	.text       start:0x80A345E4 end:0x80A3483C
 	.sdata2     start:0x80C7BB70 end:0x80C7BBC8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_exp.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_exp.o:
 	.text       start:0x80A3483C end:0x80A34A6C
 	.rodata     start:0x80B438C8 end:0x80B438F8
 	.sdata2     start:0x80C7BBC8 end:0x80C7BC40
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_fmod.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_fmod.o:
 	.text       start:0x80A34A6C end:0x80A34DEC
 	.rodata     start:0x80B438F8 end:0x80B43908
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_log.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_log.o:
 	.text       start:0x80A34DEC end:0x80A350A0
 	.sbss       start:0x80C7AFB0 end:0x80C7AFB8
 	.sdata2     start:0x80C7BC40 end:0x80C7BCC0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_log10.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_log10.o:
 	.text       start:0x80A350A0 end:0x80A351B4
 	.sbss       start:0x80C7AFB8 end:0x80C7AFC0
 	.sdata2     start:0x80C7BCC0 end:0x80C7BCF0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_pow.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_pow.o:
 	.text       start:0x80A351B4 end:0x80A359C8
 	.rodata     start:0x80B43908 end:0x80B43938
 	.sdata2     start:0x80C7BCF0 end:0x80C7BE00
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_rem_pio2.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_rem_pio2.o:
 	.text       start:0x80A359C8 end:0x80A35D4C
 	.rodata     start:0x80B43938 end:0x80B43AC0
 	.sdata2     start:0x80C7BE00 end:0x80C7BE58
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/k_cos.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/k_cos.o:
 	.text       start:0x80A35D4C end:0x80A35E5C
 	.sdata2     start:0x80C7BE58 end:0x80C7BEA0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/k_rem_pio2.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/k_rem_pio2.o:
 	.text       start:0x80A35E5C end:0x80A37514
 	.rodata     start:0x80B43AC0 end:0x80B43B10
 	.sdata2     start:0x80C7BEA0 end:0x80C7BEE0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/k_sin.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/k_sin.o:
 	.text       start:0x80A37514 end:0x80A375D4
 	.sdata2     start:0x80C7BEE0 end:0x80C7BF18
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/k_tan.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/k_tan.o:
 	.text       start:0x80A375D4 end:0x80A37824
 	.rodata     start:0x80B43B10 end:0x80B43B78
 	.sdata2     start:0x80C7BF18 end:0x80C7BF50
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_atan.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_atan.o:
 	.text       start:0x80A37824 end:0x80A37A54
 	.rodata     start:0x80B43B78 end:0x80B43C10
 	.sdata2     start:0x80C7BF50 end:0x80C7BF78
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_ceil.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_ceil.o:
 	.text       start:0x80A37A54 end:0x80A37BA0
 	.sdata2     start:0x80C7BF78 end:0x80C7BF88
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_copysign.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_copysign.o:
 	.text       start:0x80A37BA0 end:0x80A37BCC
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_cos.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_cos.o:
 	.text       start:0x80A37BCC end:0x80A37C94
 	.sdata2     start:0x80C7BF88 end:0x80C7BF90
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_floor.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_floor.o:
 	.text       start:0x80A37C94 end:0x80A37DE4
 	.sdata2     start:0x80C7BF90 end:0x80C7BFA0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_frexp.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_frexp.o:
 	.text       start:0x80A37DE4 end:0x80A37E6C
 	.sdata2     start:0x80C7BFA0 end:0x80C7BFA8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_ldexp.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_ldexp.o:
 	.text       start:0x80A37E6C end:0x80A37FD8
 	.sdata2     start:0x80C7BFA8 end:0x80C7BFD0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_modf.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_modf.o:
 	.text       start:0x80A37FD8 end:0x80A380D4
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_rint.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_rint.o:
 	.text       start:0x80A380D4 end:0x80A3823C
 	.rodata     start:0x80B43C10 end:0x80B43C20
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_sin.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_sin.o:
 	.text       start:0x80A3823C end:0x80A38308
 	.sdata2     start:0x80C7BFD0 end:0x80C7BFD8
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_tan.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/s_tan.o:
 	.text       start:0x80A38308 end:0x80A38380
 	.sdata2     start:0x80C7BFD8 end:0x80C7BFE0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_acos.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_acos.o:
 	.text       start:0x80A38380 end:0x80A38384
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_asin.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_asin.o:
 	.text       start:0x80A38384 end:0x80A38388
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_atan2.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_atan2.o:
 	.text       start:0x80A38388 end:0x80A3838C
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_exp.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_exp.o:
 	.text       start:0x80A3838C end:0x80A38390
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_fmod.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_fmod.o:
 	.text       start:0x80A38390 end:0x80A38394
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_log.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_log.o:
 	.text       start:0x80A38394 end:0x80A38398
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_log10.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_log10.o:
 	.text       start:0x80A38398 end:0x80A3839C
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_pow.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_pow.o:
 	.text       start:0x80A3839C end:0x80A383A0
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/math_ppc.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/math_ppc.o:
 	.text       start:0x80A383A0 end:0x80A383A4
 
-sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/extras.c:
+MSL_C.PPCEABI.bare.H.a/Products/Eppc/TempBuildMSL/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/extras.o:
 	.text       start:0x80A383A4 end:0x80A38588
 
-sdk/PowerPC_EABI_Support/Runtime/__mem.cpp:
+Runtime.PPCEABI.H.a/__mem.o:
 	.init       start:0x80004000 end:0x80004380
 	.text       start:0x80A38588 end:0x80A385A4
 
-sdk/PowerPC_EABI_Support/Runtime/__va_arg.cpp:
+Runtime.PPCEABI.H.a/__va_arg.o:
 	.text       start:0x80A385A4 end:0x80A3866C
 
-sdk/PowerPC_EABI_Support/Runtime/global_destructor_chain.cpp:
+Runtime.PPCEABI.H.a/global_destructor_chain.o:
 	.text       start:0x80A3866C end:0x80A386CC
 	.sbss       start:0x80C7AFC0 end:0x80C7AFC8
 
-sdk/PowerPC_EABI_Support/MetroTRK/__exception.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/__exception.o:
 	.init       start:0x80004380 end:0x800062C0
 
-sdk/PowerPC_EABI_Support/Runtime/New.cpp:
+Runtime.PPCEABI.H.a/New.o:
 	extab       start:0x800067E0 end:0x800067E8
 	extabindex  start:0x8000CA40 end:0x8000CA4C
 	.text       start:0x80A386CC end:0x80A38718
@@ -7567,17 +7567,17 @@ sdk/PowerPC_EABI_Support/Runtime/New.cpp:
 	.data       start:0x80C46140 end:0x80C46168
 	.sdata      start:0x80C790A8 end:0x80C790B0
 
-sdk/PowerPC_EABI_Support/Runtime/NMWException.cpp:
+Runtime.PPCEABI.H.a/NMWException.o:
 	extab       start:0x800067E8 end:0x80006838
 	extabindex  start:0x8000CA4C end:0x8000CA94
 	.text       start:0x80A38718 end:0x80A38DD8
 	.sdata      start:0x80C790B0 end:0x80C790B8
 
-sdk/PowerPC_EABI_Support/Runtime/ptmf.cpp:
+Runtime.PPCEABI.H.a/ptmf.o:
 	.text       start:0x80A38DD8 end:0x80A38E94
 	.rodata     start:0x80B43C30 end:0x80B43C40
 
-sdk/PowerPC_EABI_Support/Runtime/MWRTTI.cpp:
+Runtime.PPCEABI.H.a/MWRTTI.o:
 	extab       start:0x80006838 end:0x80006858
 	extabindex  start:0x8000CA94 end:0x8000CAC4
 	.text       start:0x80A38E94 end:0x80A39208
@@ -7585,21 +7585,21 @@ sdk/PowerPC_EABI_Support/Runtime/MWRTTI.cpp:
 	.data       start:0x80C46168 end:0x80C461C0
 	.sdata      start:0x80C790B8 end:0x80C790D0
 
-sdk/PowerPC_EABI_Support/Runtime/runtime.cpp:
+Runtime.PPCEABI.H.a/runtime.o:
 	.text       start:0x80A39208 end:0x80A39B90
 	.rodata     start:0x80B43CA8 end:0x80B43CC0
 
-sdk/PowerPC_EABI_Support/Runtime/__init_cpp_exceptions.cpp:
+Runtime.PPCEABI.H.a/__init_cpp_exceptions.o:
 	.text       start:0x80A39B90 end:0x80A39C00
 	.ctors      start:0x80B34820 end:0x80B34824 rename:.ctors$10
 	.dtors      start:0x80B34B60 end:0x80B34B64 rename:.dtors$10
 	.dtors      start:0x80B34B64 end:0x80B34B68 rename:.dtors$15
 	.sdata      start:0x80C790D0 end:0x80C790D8
 
-sdk/PowerPC_EABI_Support/Runtime/Gecko_setjmp.cpp:
+Runtime.PPCEABI.H.a/Gecko_setjmp.o:
 	.text       start:0x80A39C00 end:0x80A39E14
 
-sdk/PowerPC_EABI_Support/Runtime/Gecko_ExceptionPPC.cpp:
+Runtime.PPCEABI.H.a/Gecko_ExceptionPPC.o:
 	extab       start:0x80006858 end:0x800068CC
 	extabindex  start:0x8000CAC4 end:0x8000CB18
 	.text       start:0x80A39E14 end:0x80A3B560
@@ -7608,570 +7608,570 @@ sdk/PowerPC_EABI_Support/Runtime/Gecko_ExceptionPPC.cpp:
 	.sdata      start:0x80C790D8 end:0x80C790E0
 	.bss        start:0x80D22430 end:0x80D225B0
 
-sdk/PowerPC_EABI_Support/MetroTRK/targsupp.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/targsupp.o:
 	.text       start:0x80A3B560 end:0x80A3B580
 
-sdk/PowerPC_EABI_Support/MetroTRK/custconn/cc_gdev.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/custconn/cc_gdev.o:
 	.text       start:0x80A3B580 end:0x80A3B7F8
 	.sbss       start:0x80C7AFC8 end:0x80C7AFD0
 	.bss        start:0x80D225B0 end:0x80D22AD0
 
-sdk/PowerPC_EABI_Support/MetroTRK/custconn/MWCriticalSection_gc.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/custconn/MWCriticalSection_gc.o:
 	.text       start:0x80A3B7F8 end:0x80A3B834
 
-sdk/PowerPC_EABI_Support/MetroTRK/custconn/CircleBuffer.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/custconn/CircleBuffer.o:
 	.text       start:0x80A3B834 end:0x80A3BA70
 
-sdk/PowerPC_EABI_Support/MetroTRK/flush_cache.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/flush_cache.o:
 	.text       start:0x80A3BA70 end:0x80A3BAA8
 
-sdk/PowerPC_EABI_Support/MetroTRK/main_TRK.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/main_TRK.o:
 	.text       start:0x80A3BAA8 end:0x80A3BAE4
 	.sbss       start:0x80C7AFD0 end:0x80C7AFD8
 
-sdk/PowerPC_EABI_Support/MetroTRK/mainloop.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/mainloop.o:
 	.text       start:0x80A3BAE4 end:0x80A3BBD0
 
-sdk/PowerPC_EABI_Support/MetroTRK/mem_TRK.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/mem_TRK.o:
 	.text       start:0x80A3BBD0 end:0x80A3BE34
 
-sdk/PowerPC_EABI_Support/MetroTRK/dispatch.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/dispatch.o:
 	.text       start:0x80A3BE34 end:0x80A3BF54
 	.data       start:0x80C46278 end:0x80C462E8
 
-sdk/PowerPC_EABI_Support/MetroTRK/dolphin_trk.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/dolphin_trk.o:
 	.text       start:0x80A3BF54 end:0x80A3C278
 	.data       start:0x80C462E8 end:0x80C46328
 	.sbss       start:0x80C7AFD8 end:0x80C7AFE0
 
-sdk/PowerPC_EABI_Support/MetroTRK/dolphin_trk_glue.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/dolphin_trk_glue.o:
 	.text       start:0x80A3C278 end:0x80A3C614
 	.data       start:0x80C46328 end:0x80C46410
 	.sbss       start:0x80C7AFE0 end:0x80C7AFE8
 	.sdata2     start:0x80C7BFE0 end:0x80C7BFE8
 	.bss        start:0x80D22AD0 end:0x80D22AF8
 
-sdk/PowerPC_EABI_Support/MetroTRK/notify.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/notify.o:
 	.text       start:0x80A3C614 end:0x80A3C6A4
 
-sdk/PowerPC_EABI_Support/MetroTRK/nubevent.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/nubevent.o:
 	.text       start:0x80A3C6A4 end:0x80A3C840
 	.data       start:0x80C46410 end:0x80C46430
 	.bss        start:0x80D22AF8 end:0x80D22B20
 
-sdk/PowerPC_EABI_Support/MetroTRK/nubinit.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/nubinit.o:
 	.text       start:0x80A3C840 end:0x80A3C990
 	.data       start:0x80C46430 end:0x80C46450
 	.sbss       start:0x80C7AFE8 end:0x80C7AFF0
 
-sdk/PowerPC_EABI_Support/MetroTRK/serpoll.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/serpoll.o:
 	.text       start:0x80A3C990 end:0x80A3CAD8
 	.sbss       start:0x80C7AFF0 end:0x80C7AFF8
 
-sdk/PowerPC_EABI_Support/MetroTRK/string_TRK.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/string_TRK.o:
 	.text       start:0x80A3CAD8 end:0x80A3CAF4
 
-sdk/PowerPC_EABI_Support/MetroTRK/support.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/support.o:
 	.text       start:0x80A3CAF4 end:0x80A3D118
 	.data       start:0x80C46450 end:0x80C46498
 
-sdk/PowerPC_EABI_Support/MetroTRK/targcont.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/targcont.o:
 	.text       start:0x80A3D118 end:0x80A3D14C
 
-sdk/PowerPC_EABI_Support/MetroTRK/mpc_7xx_603e.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/mpc_7xx_603e.o:
 	.text       start:0x80A3D14C end:0x80A3D474
 
-sdk/PowerPC_EABI_Support/MetroTRK/msg.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/msg.o:
 	.text       start:0x80A3D474 end:0x80A3D4D8
 	.data       start:0x80C46498 end:0x80C464C0
 	.sbss       start:0x80C7AFF8 end:0x80C7B000
 
-sdk/PowerPC_EABI_Support/MetroTRK/msgbuf.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/msgbuf.o:
 	.text       start:0x80A3D4D8 end:0x80A3DCE4
 	.data       start:0x80C464C0 end:0x80C464E8
 	.bss        start:0x80D22B20 end:0x80D244C8
 
-sdk/PowerPC_EABI_Support/MetroTRK/msghndlr.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/msghndlr.o:
 	.text       start:0x80A3DCE4 end:0x80A3EC68
 	.data       start:0x80C464E8 end:0x80C46550
 	.sbss       start:0x80C7B000 end:0x80C7B008
 
-sdk/PowerPC_EABI_Support/MetroTRK/mslsupp.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/mslsupp.o:
 	.text       start:0x80A3EC68 end:0x80A3EDF4
 
-sdk/PowerPC_EABI_Support/MetroTRK/targimpl.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/targimpl.o:
 	.text       start:0x80A3EDF4 end:0x80A40618
 	.rodata     start:0x80B43D28 end:0x80B43DB0
 	.data       start:0x80C46550 end:0x80C46560
 	.sbss       start:0x80C7B008 end:0x80C7B010
 	.bss        start:0x80D244C8 end:0x80D24A70
 
-sdk/PowerPC_EABI_Support/MetroTRK/target_options.c:
+TRK_Hollywood_Revolution.a/Data/wiiProj/metrotrk/metrotrk/target_options.o:
 	.text       start:0x80A40618 end:0x80A40628
 	.sbss       start:0x80C7B010 end:0x80C7B018
 
-sdk/NdevExi2A/DebuggerDriver.c:
+NdevExi2A.a/DebuggerDriver.o:
 	.text       start:0x80A40628 end:0x80A4095C
 	.sdata      start:0x80C790E0 end:0x80C790E8
 	.sbss       start:0x80C7B018 end:0x80C7B030
 
-sdk/NdevExi2A/exi2.c:
+NdevExi2A.a/exi2.o:
 	.text       start:0x80A4095C end:0x80A410F0
 
-sdk/RVL_SDK/ESP/esp.c:
+ESP.a/esp.o:
 	.text       start:0x80A410F0 end:0x80A42A40
 	.sdata      start:0x80C790E8 end:0x80C790F8
 
-sdk/RVL_SDK/ai/ai.c:
+ai.a/ai.o:
 	.text       start:0x80A42A40 end:0x80A43020
 	.data       start:0x80C46560 end:0x80C465A8
 	.sdata      start:0x80C790F8 end:0x80C79100
 	.sbss       start:0x80C7B030 end:0x80C7B070
 
-sdk/RVL_SDK/arc/arc.c:
+arc.a/arc.o:
 	.text       start:0x80A43020 end:0x80A43C30
 	.data       start:0x80C465A8 end:0x80C46618
 	.sdata      start:0x80C79100 end:0x80C79108
 
-sdk/RVL_SDK/ax/AX.c:
+ax.a/AX.o:
 	.text       start:0x80A43C30 end:0x80A43D70
 	.data       start:0x80C46618 end:0x80C46660
 	.sdata      start:0x80C79108 end:0x80C79110
 	.sbss       start:0x80C7B070 end:0x80C7B078
 
-sdk/RVL_SDK/ax/AXAlloc.c:
+ax.a/AXAlloc.o:
 	.text       start:0x80A43D70 end:0x80A44270
 	.sbss       start:0x80C7B078 end:0x80C7B080
 	.bss        start:0x80D24A70 end:0x80D24B80
 
-sdk/RVL_SDK/ax/AXAux.c:
+ax.a/AXAux.o:
 	.text       start:0x80A44270 end:0x80A44AF0
 	.sbss       start:0x80C7B080 end:0x80C7B0C8
 	.bss        start:0x80D24B80 end:0x80D27D00
 
-sdk/RVL_SDK/ax/AXCL.c:
+ax.a/AXCL.o:
 	.text       start:0x80A44AF0 end:0x80A455F0
 	.sbss       start:0x80C7B0C8 end:0x80C7B0F0
 	.bss        start:0x80D27D00 end:0x80D27E00
 
-sdk/RVL_SDK/ax/AXOut.c:
+ax.a/AXOut.o:
 	.text       start:0x80A455F0 end:0x80A45D40
 	.sbss       start:0x80C7B0F0 end:0x80C7B130
 	.bss        start:0x80D27E00 end:0x80D28C00
 
-sdk/RVL_SDK/ax/AXSPB.c:
+ax.a/AXSPB.o:
 	.text       start:0x80A45D40 end:0x80A46180
 	.sbss       start:0x80C7B130 end:0x80C7B180
 	.bss        start:0x80D28C00 end:0x80D28C80
 
-sdk/RVL_SDK/ax/AXVPB.c:
+ax.a/AXVPB.o:
 	.text       start:0x80A46180 end:0x80A47200
 	.data       start:0x80C46660 end:0x80C46700
 	.sbss       start:0x80C7B180 end:0x80C7B1A0
 	.sdata2     start:0x80C7BFE8 end:0x80C7BFF0
 	.bss        start:0x80D28C80 end:0x80D3A380
 
-sdk/RVL_SDK/ax/AXComp.c:
+ax.a/AXComp.o:
 	.data       start:0x80C46700 end:0x80C476C0
 
-sdk/RVL_SDK/ax/DSPCode.c:
+ax.a/DSPCode.o:
 	.data       start:0x80C476C0 end:0x80C496C0
 	.sdata      start:0x80C79110 end:0x80C79118
 
-sdk/RVL_SDK/ax/AXProf.c:
+ax.a/AXProf.o:
 	.text       start:0x80A47200 end:0x80A47240
 	.sbss       start:0x80C7B1A0 end:0x80C7B1B0
 
-sdk/RVL_SDK/axfx/AXFXReverbHi.c:
+axfx.a/AXFXReverbHi.o:
 	.text       start:0x80A47240 end:0x80A47360
 	.sdata2     start:0x80C7BFF0 end:0x80C7BFF8
 
-sdk/RVL_SDK/axfx/AXFXReverbHiExp.c:
+axfx.a/AXFXReverbHiExp.o:
 	.text       start:0x80A47360 end:0x80A48260
 	.data       start:0x80C496C0 end:0x80C49860
 	.sdata2     start:0x80C7BFF8 end:0x80C7C038
 
-sdk/RVL_SDK/axfx/AXFXDelay.c:
+axfx.a/AXFXDelay.o:
 	.text       start:0x80A48260 end:0x80A488F0
 	.sdata2     start:0x80C7C038 end:0x80C7C048
 
-sdk/RVL_SDK/axfx/AXFXChorus.c:
+axfx.a/AXFXChorus.o:
 	.text       start:0x80A488F0 end:0x80A48A70
 	.sdata2     start:0x80C7C048 end:0x80C7C060
 
-sdk/RVL_SDK/axfx/AXFXChorusExp.c:
+axfx.a/AXFXChorusExp.o:
 	.text       start:0x80A48A70 end:0x80A49500
 	.sdata2     start:0x80C7C060 end:0x80C7C090
 
-sdk/RVL_SDK/axfx/AXFXLfoTable.c:
+axfx.a/AXFXLfoTable.o:
 	.text       start:0x80A49500 end:0x80A49510
 	.data       start:0x80C49860 end:0x80C49A60
 
-sdk/RVL_SDK/axfx/AXFXSrcCoef.c:
+axfx.a/AXFXSrcCoef.o:
 	.text       start:0x80A49510 end:0x80A49530
 	.data       start:0x80C49A60 end:0x80C4A260
 
-sdk/RVL_SDK/axfx/AXFXHooks.c:
+axfx.a/AXFXHooks.o:
 	.text       start:0x80A49530 end:0x80A49580
 	.sdata      start:0x80C79118 end:0x80C79120
 
-sdk/RVL_SDK/base/PPCArch.c:
+base.a/PPCArch.o:
 	.text       start:0x80A49580 end:0x80A497A0
 	.data       start:0x80C4A260 end:0x80C4A298
 
-sdk/RVL_SDK/bte/gki_buffer.c:
+bte.a/gki_buffer.o:
 	.text       start:0x80A497A0 end:0x80A4AC40
 	.data       start:0x80C4A298 end:0x80C4A3E0
 
-sdk/RVL_SDK/bte/gki_time.c:
+bte.a/gki_time.o:
 	.text       start:0x80A4AC40 end:0x80A4B1D0
 
-sdk/RVL_SDK/bte/gki_ppc.c:
+bte.a/gki_ppc.o:
 	.text       start:0x80A4B1D0 end:0x80A4B4E0
 	.bss        start:0x80D3A380 end:0x80D62E60
 
-sdk/RVL_SDK/bte/hcisu_h2.c:
+bte.a/hcisu_h2.o:
 	.text       start:0x80A4B4E0 end:0x80A4BBA0
 	.rodata     start:0x80B43DB0 end:0x80B43DC8
 	.data       start:0x80C4A3E0 end:0x80C4A450
 	.sdata2     start:0x80C7C090 end:0x80C7C0A0
 	.bss        start:0x80D62E60 end:0x80D62EA0
 
-sdk/RVL_SDK/bte/uusb_ppc.c:
+bte.a/uusb_ppc.o:
 	.text       start:0x80A4BBA0 end:0x80A4C820
 	.sdata      start:0x80C79120 end:0x80C79130
 	.sbss       start:0x80C7B1B0 end:0x80C7B1C8
 	.bss        start:0x80D62EA0 end:0x80D64F00
 
-sdk/RVL_SDK/bte/bta_dm_cfg.c:
+bte.a/bta_dm_cfg.o:
 	.rodata     start:0x80B43DC8 end:0x80B43E58
 	.sdata      start:0x80C79130 end:0x80C79148
 	.sbss2      start:0x80C7C4C0 end:0x80C7C4C8
 
-sdk/RVL_SDK/bte/bta_hh_cfg.c:
+bte.a/bta_hh_cfg.o:
 	.rodata     start:0x80B43E58 end:0x80B43E68
 	.sdata      start:0x80C79148 end:0x80C79158
 
-sdk/RVL_SDK/bte/bta_sys_cfg.c:
+bte.a/bta_sys_cfg.o:
 	.sdata      start:0x80C79158 end:0x80C79160
 	.sdata2     start:0x80C7C0A0 end:0x80C7C0A8
 
-sdk/RVL_SDK/bte/bte_hcisu.c:
+bte.a/bte_hcisu.o:
 	.text       start:0x80A4C820 end:0x80A4C8F0
 	.sbss       start:0x80C7B1C8 end:0x80C7B1D0
 
-sdk/RVL_SDK/bte/bte_init.c:
+bte.a/bte_init.o:
 	.text       start:0x80A4C8F0 end:0x80A4C920
 
-sdk/RVL_SDK/bte/bte_logmsg.c:
+bte.a/bte_logmsg.o:
 	.text       start:0x80A4C920 end:0x80A4CAC0
 	.sdata      start:0x80C79160 end:0x80C79168
 	.bss        start:0x80D64F00 end:0x80D656E0
 
-sdk/RVL_SDK/bte/bte_main.c:
+bte.a/bte_main.o:
 	.text       start:0x80A4CAC0 end:0x80A4CC30
 	.sdata      start:0x80C79168 end:0x80C79170
 	.sbss       start:0x80C7B1D0 end:0x80C7B1D8
 	.bss        start:0x80D656E0 end:0x80D66710
 
-sdk/RVL_SDK/bte/btu_task1.c:
+bte.a/btu_task1.o:
 	.text       start:0x80A4CC30 end:0x80A4D074
 	.sdata      start:0x80C79170 end:0x80C79178
 	.sbss       start:0x80C7B1D8 end:0x80C7B1E0
 	.bss        start:0x80D66710 end:0x80D66798
 
-sdk/RVL_SDK/bte/bd.c:
+bte.a/bd.o:
 	.text       start:0x80A4D074 end:0x80A4D148
 	.sbss2      start:0x80C7C4C8 end:0x80C7C4D0
 
-sdk/RVL_SDK/bte/bta_sys_conn.c:
+bte.a/bta_sys_conn.o:
 	.text       start:0x80A4D148 end:0x80A4D39C
 
-sdk/RVL_SDK/bte/bta_sys_main.c:
+bte.a/bta_sys_main.o:
 	.text       start:0x80A4D39C end:0x80A4D5E0
 	.data       start:0x80C4A450 end:0x80C4A488
 	.sbss       start:0x80C7B1E0 end:0x80C7B1E8
 	.bss        start:0x80D66798 end:0x80D66828
 
-sdk/RVL_SDK/bte/ptim.c:
+bte.a/ptim.o:
 	.text       start:0x80A4D5E0 end:0x80A4D7C0
 
-sdk/RVL_SDK/bte/utl.c:
+bte.a/utl.o:
 	.text       start:0x80A4D7C0 end:0x80A4D804
 
-sdk/RVL_SDK/bte/bta_dm_act.c:
+bte.a/bta_dm_act.o:
 	.text       start:0x80A4D804 end:0x80A4FB40
 	.rodata     start:0x80B43E68 end:0x80B43F10
 	.data       start:0x80C4A488 end:0x80C4A5C8
 	.sdata2     start:0x80C7C0A8 end:0x80C7C0B0
 	.bss        start:0x80D66828 end:0x80D66858
 
-sdk/RVL_SDK/bte/bta_dm_api.c:
+bte.a/bta_dm_api.o:
 	.text       start:0x80A4FB40 end:0x80A4FFAC
 	.sdata2     start:0x80C7C0B0 end:0x80C7C0C0
 
-sdk/RVL_SDK/bte/bta_dm_main.c:
+bte.a/bta_dm_main.o:
 	.text       start:0x80A4FFAC end:0x80A5010C
 	.rodata     start:0x80B43F10 end:0x80B44038
 	.bss        start:0x80D66858 end:0x80D669D8
 
-sdk/RVL_SDK/bte/bta_dm_pm.c:
+bte.a/bta_dm_pm.o:
 	.text       start:0x80A5010C end:0x80A50B28
 	.data       start:0x80C4A5C8 end:0x80C4A618
 	.bss        start:0x80D669D8 end:0x80D66A08
 
-sdk/RVL_SDK/bte/bta_hh_act.c:
+bte.a/bta_hh_act.o:
 	.text       start:0x80A50B28 end:0x80A52270
 	.data       start:0x80C4A618 end:0x80C4AB10
 	.sdata      start:0x80C79178 end:0x80C79180
 
-sdk/RVL_SDK/bte/bta_hh_api.c:
+bte.a/bta_hh_api.o:
 	.text       start:0x80A52270 end:0x80A52640
 	.data       start:0x80C4AB10 end:0x80C4AB40
 	.sdata2     start:0x80C7C0C0 end:0x80C7C0C8
 
-sdk/RVL_SDK/bte/bta_hh_main.c:
+bte.a/bta_hh_main.o:
 	.text       start:0x80A52640 end:0x80A52B94
 	.rodata     start:0x80B44038 end:0x80B440C0
 	.data       start:0x80C4AB40 end:0x80C4AE20
 	.bss        start:0x80D66A08 end:0x80D66C38
 
-sdk/RVL_SDK/bte/bta_hh_utils.c:
+bte.a/bta_hh_utils.o:
 	.text       start:0x80A52B94 end:0x80A52F40
 	.data       start:0x80C4AE20 end:0x80C4B0E0
 
-sdk/RVL_SDK/bte/btm_acl.c:
+bte.a/btm_acl.o:
 	.text       start:0x80A52F40 end:0x80A54C84
 	.data       start:0x80C4B0E0 end:0x80C4B500
 
-sdk/RVL_SDK/bte/btm_dev.c:
+bte.a/btm_dev.o:
 	.text       start:0x80A54C84 end:0x80A55350
 
-sdk/RVL_SDK/bte/btm_devctl.c:
+bte.a/btm_devctl.o:
 	.text       start:0x80A55350 end:0x80A56CD8
 	.data       start:0x80C4B500 end:0x80C4B760
 	.sdata      start:0x80C79180 end:0x80C79198
 
-sdk/RVL_SDK/bte/btm_discovery.c:
+bte.a/btm_discovery.o:
 	.text       start:0x80A56CD8 end:0x80A56E0C
 
-sdk/RVL_SDK/bte/btm_inq.c:
+bte.a/btm_inq.o:
 	.text       start:0x80A56E0C end:0x80A588A4
 	.data       start:0x80C4B760 end:0x80C4B970
 	.sdata2     start:0x80C7C0C8 end:0x80C7C0D0
 
-sdk/RVL_SDK/bte/btm_main.c:
+bte.a/btm_main.o:
 	.text       start:0x80A588A4 end:0x80A58900
 	.bss        start:0x80D66C38 end:0x80D69400
 
-sdk/RVL_SDK/bte/btm_pm.c:
+bte.a/btm_pm.o:
 	.text       start:0x80A58900 end:0x80A59594
 	.rodata     start:0x80B440C0 end:0x80B440D0
 	.data       start:0x80C4B970 end:0x80C4B9B0
 	.sdata2     start:0x80C7C0D0 end:0x80C7C0D8
 
-sdk/RVL_SDK/bte/btm_sco.c:
+bte.a/btm_sco.o:
 	.text       start:0x80A59594 end:0x80A5A3CC
 	.rodata     start:0x80B440D0 end:0x80B440E0
 	.data       start:0x80C4B9B0 end:0x80C4BCB0
 
-sdk/RVL_SDK/bte/btm_sec.c:
+bte.a/btm_sec.o:
 	.text       start:0x80A5A3CC end:0x80A5D390
 	.data       start:0x80C4BCB0 end:0x80C4C6C0
 	.sdata2     start:0x80C7C0D8 end:0x80C7C0E0
 
-sdk/RVL_SDK/bte/btu_hcif.c:
+bte.a/btu_hcif.o:
 	.text       start:0x80A5D390 end:0x80A5E5EC
 	.data       start:0x80C4C6C0 end:0x80C4C750
 
-sdk/RVL_SDK/bte/btu_init.c:
+bte.a/btu_init.o:
 	.text       start:0x80A5E5EC end:0x80A5E664
 	.sdata2     start:0x80C7C0E0 end:0x80C7C0E8
 
-sdk/RVL_SDK/bte/wbt_ext.c:
+bte.a/wbt_ext.o:
 	.text       start:0x80A5E664 end:0x80A5E744
 
-sdk/RVL_SDK/bte/gap_api.c:
+bte.a/gap_api.o:
 	.text       start:0x80A5E744 end:0x80A5E7A4
 
-sdk/RVL_SDK/bte/gap_conn.c:
+bte.a/gap_conn.o:
 	.text       start:0x80A5E7A4 end:0x80A5F2E0
 	.data       start:0x80C4C750 end:0x80C4C820
 	.sdata      start:0x80C79198 end:0x80C791A0
 
-sdk/RVL_SDK/bte/gap_utils.c:
+bte.a/gap_utils.o:
 	.text       start:0x80A5F2E0 end:0x80A5F8FC
 	.data       start:0x80C4C820 end:0x80C4CB10
 	.bss        start:0x80D69400 end:0x80D697B0
 
-sdk/RVL_SDK/bte/hcicmds.c:
+bte.a/hcicmds.o:
 	.text       start:0x80A5F8FC end:0x80A62018
 	.rodata     start:0x80B440E0 end:0x80B440F0
 
-sdk/RVL_SDK/bte/hidd_api.c:
+bte.a/hidd_api.o:
 	.text       start:0x80A62018 end:0x80A62080
 
-sdk/RVL_SDK/bte/hidd_conn.c:
+bte.a/hidd_conn.o:
 	.text       start:0x80A62080 end:0x80A62140
 	.data       start:0x80C4CB10 end:0x80C4CB40
 
-sdk/RVL_SDK/bte/hidd_mgmt.c:
+bte.a/hidd_mgmt.o:
 	.text       start:0x80A62140 end:0x80A62208
 	.data       start:0x80C4CB40 end:0x80C4CB60
 	.bss        start:0x80D697B0 end:0x80D698F8
 
-sdk/RVL_SDK/bte/hidd_pm.c:
+bte.a/hidd_pm.o:
 	.text       start:0x80A62208 end:0x80A62584
 
-sdk/RVL_SDK/bte/hidh_api.c:
+bte.a/hidh_api.o:
 	.text       start:0x80A62584 end:0x80A63304
 	.data       start:0x80C4CB60 end:0x80C4CC78
 	.bss        start:0x80D698F8 end:0x80D69D00
 
-sdk/RVL_SDK/bte/hidh_conn.c:
+bte.a/hidh_conn.o:
 	.text       start:0x80A63304 end:0x80A65344
 	.rodata     start:0x80B440F0 end:0x80B44118
 	.data       start:0x80C4CC78 end:0x80C4D060
 
-sdk/RVL_SDK/bte/l2c_api.c:
+bte.a/l2c_api.o:
 	.text       start:0x80A65344 end:0x80A65F10
 	.data       start:0x80C4D060 end:0x80C4D7F0
 
-sdk/RVL_SDK/bte/l2c_csm.c:
+bte.a/l2c_csm.o:
 	.text       start:0x80A65F10 end:0x80A673EC
 	.data       start:0x80C4D7F0 end:0x80C4E028
 
-sdk/RVL_SDK/bte/l2c_link.c:
+bte.a/l2c_link.o:
 	.text       start:0x80A673EC end:0x80A68578
 	.data       start:0x80C4E028 end:0x80C4E298
 
-sdk/RVL_SDK/bte/l2c_main.c:
+bte.a/l2c_main.o:
 	.text       start:0x80A68578 end:0x80A695A8
 	.data       start:0x80C4E298 end:0x80C4E598
 	.bss        start:0x80D69D00 end:0x80D6A4E8
 
-sdk/RVL_SDK/bte/l2c_utils.c:
+bte.a/l2c_utils.o:
 	.text       start:0x80A695A8 end:0x80A6B46C
 	.data       start:0x80C4E598 end:0x80C4E680
 	.sdata      start:0x80C791A0 end:0x80C791B0
 
-sdk/RVL_SDK/bte/port_api.c:
+bte.a/port_api.o:
 	.text       start:0x80A6B46C end:0x80A6B4BC
 
-sdk/RVL_SDK/bte/port_rfc.c:
+bte.a/port_rfc.o:
 	.text       start:0x80A6B4BC end:0x80A6C8B8
 	.data       start:0x80C4E680 end:0x80C4E9B0
 
-sdk/RVL_SDK/bte/port_utils.c:
+bte.a/port_utils.o:
 	.text       start:0x80A6C8B8 end:0x80A6CE90
 	.data       start:0x80C4E9B0 end:0x80C4EAF8
 
-sdk/RVL_SDK/bte/rfc_l2cap_if.c:
+bte.a/rfc_l2cap_if.o:
 	.text       start:0x80A6CE90 end:0x80A6D7C4
 	.data       start:0x80C4EAF8 end:0x80C4EC38
 
-sdk/RVL_SDK/bte/rfc_mx_fsm.c:
+bte.a/rfc_mx_fsm.o:
 	.text       start:0x80A6D7C4 end:0x80A6E408
 	.data       start:0x80C4EC38 end:0x80C4EEF0
 
-sdk/RVL_SDK/bte/rfc_port_fsm.c:
+bte.a/rfc_port_fsm.o:
 	.text       start:0x80A6E408 end:0x80A6F5A8
 	.data       start:0x80C4EEF0 end:0x80C4F218
 
-sdk/RVL_SDK/bte/rfc_port_if.c:
+bte.a/rfc_port_if.o:
 	.text       start:0x80A6F5A8 end:0x80A6FAD4
 	.bss        start:0x80D6A4E8 end:0x80D6A900
 
-sdk/RVL_SDK/bte/rfc_ts_frames.c:
+bte.a/rfc_ts_frames.o:
 	.text       start:0x80A6FAD4 end:0x80A7111C
 	.data       start:0x80C4F218 end:0x80C4F2F0
 	.sdata      start:0x80C791B0 end:0x80C791C0
 
-sdk/RVL_SDK/bte/rfc_utils.c:
+bte.a/rfc_utils.o:
 	.text       start:0x80A7111C end:0x80A718FC
 	.rodata     start:0x80B44118 end:0x80B44218
 	.data       start:0x80C4F2F0 end:0x80C4F380
 
-sdk/RVL_SDK/bte/sdp_api.c:
+bte.a/sdp_api.o:
 	.text       start:0x80A718FC end:0x80A72764
 	.data       start:0x80C4F380 end:0x80C4F3D0
 
-sdk/RVL_SDK/bte/sdp_db.c:
+bte.a/sdp_db.o:
 	.text       start:0x80A72764 end:0x80A73430
 	.data       start:0x80C4F3D0 end:0x80C4F468
 
-sdk/RVL_SDK/bte/sdp_discovery.c:
+bte.a/sdp_discovery.o:
 	.text       start:0x80A73430 end:0x80A746A8
 	.data       start:0x80C4F468 end:0x80C4F5C8
 
-sdk/RVL_SDK/bte/sdp_main.c:
+bte.a/sdp_main.o:
 	.text       start:0x80A746A8 end:0x80A75214
 	.data       start:0x80C4F5C8 end:0x80C4F928
 	.bss        start:0x80D6A900 end:0x80D6EF40
 
-sdk/RVL_SDK/bte/sdp_server.c:
+bte.a/sdp_server.o:
 	.text       start:0x80A75214 end:0x80A75F24
 	.data       start:0x80C4F928 end:0x80C4F968
 
-sdk/RVL_SDK/bte/sdp_utils.c:
+bte.a/sdp_utils.o:
 	.text       start:0x80A75F24 end:0x80A76F70
 	.rodata     start:0x80B44218 end:0x80B44228
 	.data       start:0x80C4F968 end:0x80C4FA60
 
-sdk/RVL_SDK/cnt/cnt.c:
+cnt.a/cnt.o:
 	.text       start:0x80A76F70 end:0x80A77F30
 	.rodata     start:0x80B44228 end:0x80B444A0
 	.data       start:0x80C4FA60 end:0x80C4FBF0
 	.sdata      start:0x80C791C0 end:0x80C791D0
 	.sbss       start:0x80C7B1E8 end:0x80C7B1F0
 
-sdk/RVL_SDK/cnt/cntFatal.c:
+cnt.a/cntFatal.o:
 	.text       start:0x80A77F30 end:0x80A78070
 	.rodata     start:0x80B444A0 end:0x80B445B0
 	.data       start:0x80C4FBF0 end:0x80C50238
 	.sdata2     start:0x80C7C0E8 end:0x80C7C0F0
 
-sdk/RVL_SDK/dsp/dsp.c:
+dsp.a/dsp.o:
 	.text       start:0x80A78070 end:0x80A78310
 	.data       start:0x80C50238 end:0x80C502B8
 	.sdata      start:0x80C791D0 end:0x80C791D8
 	.sbss       start:0x80C7B1F0 end:0x80C7B1F8
 
-sdk/RVL_SDK/dsp/dsp_debug.c:
+dsp.a/dsp_debug.o:
 	.text       start:0x80A78310 end:0x80A78360
 
-sdk/RVL_SDK/dsp/dsp_task.c:
+dsp.a/dsp_task.o:
 	.text       start:0x80A78360 end:0x80A78C00
 	.data       start:0x80C502B8 end:0x80C503F8
 	.sbss       start:0x80C7B1F8 end:0x80C7B210
 
-sdk/RVL_SDK/dvd/dvdfs.c:
+dvd.a/dvdfs.o:
 	.text       start:0x80A78C00 end:0x80A79560
 	.data       start:0x80C503F8 end:0x80C50560
 	.sdata      start:0x80C791D8 end:0x80C791E8
 	.sbss       start:0x80C7B210 end:0x80C7B240
 
-sdk/RVL_SDK/dvd/dvd.c:
+dvd.a/dvd.o:
 	.text       start:0x80A79560 end:0x80A7E260
 	.data       start:0x80C50560 end:0x80C50970
 	.sdata      start:0x80C791E8 end:0x80C79200
 	.sbss       start:0x80C7B240 end:0x80C7B2D8
 	.bss        start:0x80D6EF40 end:0x80D73BF0
 
-sdk/RVL_SDK/dvd/dvdqueue.c:
+dvd.a/dvdqueue.o:
 	.text       start:0x80A7E260 end:0x80A7E4E0
 	.bss        start:0x80D73BF0 end:0x80D73C20
 
-sdk/RVL_SDK/dvd/dvderror.c:
+dvd.a/dvderror.o:
 	.text       start:0x80A7E4E0 end:0x80A7EF00
 	.data       start:0x80C50970 end:0x80C509A0
 	.sbss       start:0x80C7B2D8 end:0x80C7B2E8
 	.bss        start:0x80D73C20 end:0x80D73E80
 
-sdk/RVL_SDK/dvd/dvdidutils.c:
+dvd.a/dvdidutils.o:
 	.text       start:0x80A7EF00 end:0x80A7EFF0
 
-sdk/RVL_SDK/dvd/dvdFatal.c:
+dvd.a/dvdFatal.o:
 	.text       start:0x80A7EFF0 end:0x80A7F160
 	.rodata     start:0x80B445B0 end:0x80B445E8
 	.data       start:0x80C509A0 end:0x80C51168
@@ -8179,7 +8179,7 @@ sdk/RVL_SDK/dvd/dvdFatal.c:
 	.sbss       start:0x80C7B2E8 end:0x80C7B2F0
 	.sdata2     start:0x80C7C0F0 end:0x80C7C0F8
 
-sdk/RVL_SDK/dvd/dvdDeviceError.c:
+dvd.a/dvdDeviceError.o:
 	.text       start:0x80A7F160 end:0x80A7F3F0
 	.rodata     start:0x80B445E8 end:0x80B44608
 	.data       start:0x80C51168 end:0x80C51300
@@ -8188,39 +8188,39 @@ sdk/RVL_SDK/dvd/dvdDeviceError.c:
 	.sdata2     start:0x80C7C0F8 end:0x80C7C100
 	.bss        start:0x80D73E80 end:0x80D73EA0
 
-sdk/RVL_SDK/dvd/dvd_broadway.c:
+dvd.a/dvd_broadway.o:
 	.text       start:0x80A7F3F0 end:0x80A81AA0
 	.data       start:0x80C51300 end:0x80C52208
 	.sdata      start:0x80C79210 end:0x80C79220
 	.sbss       start:0x80C7B2F8 end:0x80C7B320
 	.bss        start:0x80D73EA0 end:0x80D74060
 
-sdk/RVL_SDK/euart/euart.c:
+euart.a/euart.o:
 	.text       start:0x80A81AA0 end:0x80A81E20
 	.sbss       start:0x80C7B320 end:0x80C7B330
 
-sdk/RVL_SDK/exi/EXIBios.c:
+exi.a/EXIBios.o:
 	.text       start:0x80A81E20 end:0x80A83720
 	.data       start:0x80C52208 end:0x80C52250
 	.sdata      start:0x80C79220 end:0x80C79228
 	.sbss       start:0x80C7B330 end:0x80C7B338
 	.bss        start:0x80D74060 end:0x80D74120
 
-sdk/RVL_SDK/exi/EXIUart.c:
+exi.a/EXIUart.o:
 	.text       start:0x80A83720 end:0x80A83A60
 	.sbss       start:0x80C7B338 end:0x80C7B348
 
-sdk/RVL_SDK/exi/EXICommon.c:
+exi.a/EXICommon.o:
 	.text       start:0x80A83A60 end:0x80A83BF0
 	.sdata2     start:0x80C7C100 end:0x80C7C108
 
-sdk/RVL_SDK/fs/fs.c:
+fs.a/fs.o:
 	.text       start:0x80A83BF0 end:0x80A853B0
 	.data       start:0x80C52250 end:0x80C52280
 	.sdata      start:0x80C79228 end:0x80C79238
 	.sbss       start:0x80C7B348 end:0x80C7B360
 
-sdk/RVL_SDK/gx/GXInit.c:
+gx.a/GXInit.o:
 	.text       start:0x80A853B0 end:0x80A86540
 	.data       start:0x80C52280 end:0x80C524C0
 	.sdata      start:0x80C79238 end:0x80C79240
@@ -8228,107 +8228,107 @@ sdk/RVL_SDK/gx/GXInit.c:
 	.sdata2     start:0x80C7C108 end:0x80C7C130
 	.bss        start:0x80D74120 end:0x80D747A0
 
-sdk/RVL_SDK/gx/GXFifo.c:
+gx.a/GXFifo.o:
 	.text       start:0x80A86540 end:0x80A874E0
 	.data       start:0x80C524C0 end:0x80C524F0
 	.sbss       start:0x80C7B388 end:0x80C7B3A8
 	.bss        start:0x80D747A0 end:0x80D74800
 
-sdk/RVL_SDK/gx/GXAttr.c:
+gx.a/GXAttr.o:
 	.text       start:0x80A874E0 end:0x80A88030
 	.data       start:0x80C524F0 end:0x80C52638
 	.sdata      start:0x80C79240 end:0x80C79250
 
-sdk/RVL_SDK/gx/GXMisc.c:
+gx.a/GXMisc.o:
 	.text       start:0x80A88030 end:0x80A88950
 	.sbss       start:0x80C7B3A8 end:0x80C7B3C0
 
-sdk/RVL_SDK/gx/GXGeometry.c:
+gx.a/GXGeometry.o:
 	.text       start:0x80A88950 end:0x80A88F60
 
-sdk/RVL_SDK/gx/GXFrameBuf.c:
+gx.a/GXFrameBuf.o:
 	.text       start:0x80A88F60 end:0x80A899E0
 	.data       start:0x80C52638 end:0x80C527A0
 	.sdata2     start:0x80C7C130 end:0x80C7C140
 
-sdk/RVL_SDK/gx/GXLight.c:
+gx.a/GXLight.o:
 	.text       start:0x80A899E0 end:0x80A89FD0
 	.sdata2     start:0x80C7C140 end:0x80C7C170
 
-sdk/RVL_SDK/gx/GXTexture.c:
+gx.a/GXTexture.o:
 	.text       start:0x80A89FD0 end:0x80A8B130
 	.data       start:0x80C527A0 end:0x80C529C8
 	.sdata      start:0x80C79250 end:0x80C79298
 	.sdata2     start:0x80C7C170 end:0x80C7C1A8
 
-sdk/RVL_SDK/gx/GXBump.c:
+gx.a/GXBump.o:
 	.text       start:0x80A8B130 end:0x80A8B640
 	.sdata2     start:0x80C7C1A8 end:0x80C7C1B0
 
-sdk/RVL_SDK/gx/GXTev.c:
+gx.a/GXTev.o:
 	.text       start:0x80A8B640 end:0x80A8BD10
 	.data       start:0x80C529C8 end:0x80C52A40
 
-sdk/RVL_SDK/gx/GXPixel.c:
+gx.a/GXPixel.o:
 	.text       start:0x80A8BD10 end:0x80A8C330
 	.data       start:0x80C52A40 end:0x80C52A60
 	.sdata2     start:0x80C7C1B0 end:0x80C7C1E8
 
-sdk/RVL_SDK/gx/GXDisplayList.c:
+gx.a/GXDisplayList.o:
 	.text       start:0x80A8C330 end:0x80A8C3B0
 
-sdk/RVL_SDK/gx/GXTransform.c:
+gx.a/GXTransform.o:
 	.text       start:0x80A8C3B0 end:0x80A8C930
 	.sdata2     start:0x80C7C1E8 end:0x80C7C1F8
 
-sdk/RVL_SDK/gx/GXPerf.c:
+gx.a/GXPerf.o:
 	.text       start:0x80A8C930 end:0x80A8D160
 	.data       start:0x80C52A60 end:0x80C52B48
 
-sdk/RVL_SDK/hid/hid_api.c:
+hid.a/hid_api.o:
 	.text       start:0x80A8D160 end:0x80A8D1F0
 
-sdk/RVL_SDK/hid/hid_ios.c:
+hid.a/hid_ios.o:
 	.text       start:0x80A8D1F0 end:0x80A8DAB0
 
-sdk/RVL_SDK/hid/hid_client.c:
+hid.a/hid_client.o:
 	.text       start:0x80A8DAB0 end:0x80A8DDB0
 
-sdk/RVL_SDK/hid/hid_device.c:
+hid.a/hid_device.o:
 	.text       start:0x80A8DDB0 end:0x80A8E250
 
-sdk/RVL_SDK/hid/hid_interface.c:
+hid.a/hid_interface.o:
 	.text       start:0x80A8E250 end:0x80A8E370
 
-sdk/RVL_SDK/hid/hid_open_close.c:
+hid.a/hid_open_close.o:
 	.text       start:0x80A8E370 end:0x80A8E750
 	.data       start:0x80C52B48 end:0x80C52BA0
 	.sdata      start:0x80C79298 end:0x80C792A0
 	.sbss       start:0x80C7B3C0 end:0x80C7B3C8
 
-sdk/RVL_SDK/hid/hid_task.c:
+hid.a/hid_task.o:
 	.text       start:0x80A8E750 end:0x80A8E860
 
-sdk/RVL_SDK/ipc/ipcMain.c:
+ipc.a/ipcMain.o:
 	.text       start:0x80A8E860 end:0x80A8E950
 	.sbss       start:0x80C7B3C8 end:0x80C7B3E0
 
-sdk/RVL_SDK/ipc/ipcclt.c:
+ipc.a/ipcclt.o:
 	.text       start:0x80A8E950 end:0x80A903B0
 	.sdata      start:0x80C792A0 end:0x80C792A8
 	.sbss       start:0x80C7B3E0 end:0x80C7B3F0
 	.bss        start:0x80D74800 end:0x80D74940
 
-sdk/RVL_SDK/ipc/memory.c:
+ipc.a/memory.o:
 	.text       start:0x80A903B0 end:0x80A908F0
 	.bss        start:0x80D74940 end:0x80D749C0
 
-sdk/RVL_SDK/ipc/ipcProfile.c:
+ipc.a/ipcProfile.o:
 	.text       start:0x80A908F0 end:0x80A90D00
 	.sbss       start:0x80C7B3F0 end:0x80C7B3F8
 	.bss        start:0x80D749C0 end:0x80D78440
 
-sdk/RVL_SDK/kpad/KPAD.c:
+kpad.a/KPAD.o:
 	.text       start:0x80A90D00 end:0x80A95B40
 	.data       start:0x80C52BA0 end:0x80C52C60
 	.sdata      start:0x80C792A8 end:0x80C79328
@@ -8336,45 +8336,45 @@ sdk/RVL_SDK/kpad/KPAD.c:
 	.sdata2     start:0x80C7C1F8 end:0x80C7C288
 	.bss        start:0x80D78440 end:0x80D79EE0
 
-sdk/RVL_SDK/kpad/KMPLS.c:
+kpad.a/KMPLS.o:
 	.text       start:0x80A95B40 end:0x80A97C60
 	.data       start:0x80C52C60 end:0x80C52CA8
 	.sbss       start:0x80C7B448 end:0x80C7B450
 	.sdata2     start:0x80C7C288 end:0x80C7C310
 
-sdk/RVL_SDK/kpad/KZMplsTestSub.c:
+kpad.a/KZMplsTestSub.o:
 	.text       start:0x80A97C60 end:0x80A98670
 	.data       start:0x80C52CA8 end:0x80C52CD0
 	.sdata2     start:0x80C7C310 end:0x80C7C320
 
-sdk/RVL_SDK/kbd/kbd_lib.c:
+kbd.a/kbd_lib.o:
 	.text       start:0x80A98670 end:0x80A9A070
 	.data       start:0x80C52CD0 end:0x80C531F8
 	.sdata      start:0x80C79328 end:0x80C79330
 	.sbss       start:0x80C7B450 end:0x80C7B458
 
-sdk/RVL_SDK/kbd/kbd_lib_led.c:
+kbd.a/kbd_lib_led.o:
 	.text       start:0x80A9A070 end:0x80A9A170
 	.sbss       start:0x80C7B458 end:0x80C7B460
 	.bss        start:0x80D79EE0 end:0x80D7A0E0
 
-sdk/RVL_SDK/kbd/kbd_lib_init.c:
+kbd.a/kbd_lib_init.o:
 	.text       start:0x80A9A170 end:0x80A9A240
 	.bss        start:0x80D7A0E0 end:0x80D7A160
 
-sdk/RVL_SDK/kbd/kbd_lib_maps_us.c:
+kbd.a/kbd_lib_maps_us.o:
 	.text       start:0x80A9A240 end:0x80A9A340
 	.data       start:0x80C531F8 end:0x80C53EA0
 
-sdk/RVL_SDK/kbd/kbd_lib_maps_jp.c:
+kbd.a/kbd_lib_maps_jp.o:
 	.text       start:0x80A9A340 end:0x80A9A3A0
 	.data       start:0x80C53EA0 end:0x80C54680
 
-sdk/RVL_SDK/kbd/kbd_lib_maps_eu.c:
+kbd.a/kbd_lib_maps_eu.o:
 	.text       start:0x80A9A3A0 end:0x80A9A600
 	.data       start:0x80C54680 end:0x80C56F00
 
-sdk/RVL_SDK/kpr/kpr_lib.c:
+kpr.a/kpr_lib.o:
 	.text       start:0x80A9A600 end:0x80A9B190
 	.rodata     start:0x80B44608 end:0x80B45408
 	.data       start:0x80C56F00 end:0x80C56F78
@@ -8382,55 +8382,55 @@ sdk/RVL_SDK/kpr/kpr_lib.c:
 	.sbss       start:0x80C7B460 end:0x80C7B470
 	.sdata2     start:0x80C7C320 end:0x80C7C328
 
-sdk/RVL_SDK/mem/mem_heapCommon.c:
+mem.a/mem_heapCommon.o:
 	.text       start:0x80A9B190 end:0x80A9B600
 	.sbss       start:0x80C7B470 end:0x80C7B478
 	.bss        start:0x80D7A160 end:0x80D7A1A0
 
-sdk/RVL_SDK/mem/mem_expHeap.c:
+mem.a/mem_expHeap.o:
 	.text       start:0x80A9B600 end:0x80A9BEE0
 
-sdk/RVL_SDK/mem/mem_allocator.c:
+mem.a/mem_allocator.o:
 	.text       start:0x80A9BEE0 end:0x80A9BF40
 	.sdata2     start:0x80C7C328 end:0x80C7C330
 
-sdk/RVL_SDK/mem/mem_list.c:
+mem.a/mem_list.o:
 	.text       start:0x80A9BF40 end:0x80A9C060
 
-sdk/RVL_SDK/mix/mix.c:
+mix.a/mix.o:
 	.text       start:0x80A9C060 end:0x80A9F1E0
 	.data       start:0x80C56F78 end:0x80C57B20
 	.sbss       start:0x80C7B478 end:0x80C7B488
 
-sdk/RVL_SDK/mix/remote.c:
+mix.a/remote.o:
 	.text       start:0x80A9F1E0 end:0x80A9F680
 	.sbss       start:0x80C7B488 end:0x80C7B490
 
-sdk/RVL_SDK/mtx/mtx.c:
+mtx.a/mtx.o:
 	.text       start:0x80A9F680 end:0x80A9FC60
 	.sdata      start:0x80C79338 end:0x80C79340
 	.sdata2     start:0x80C7C330 end:0x80C7C348
 
-sdk/RVL_SDK/mtx/mtxvec.c:
+mtx.a/mtxvec.o:
 	.text       start:0x80A9FC60 end:0x80A9FD20
 
-sdk/RVL_SDK/mtx/mtx44.c:
+mtx.a/mtx44.o:
 	.text       start:0x80A9FD20 end:0x80A9FDC0
 	.sdata2     start:0x80C7C348 end:0x80C7C358
 
-sdk/RVL_SDK/mtx/vec.c:
+mtx.a/vec.o:
 	.text       start:0x80A9FDC0 end:0x80A9FF40
 	.sdata2     start:0x80C7C358 end:0x80C7C368
 
-sdk/RVL_SDK/nand/nand.c:
+nand.a/nand.o:
 	.text       start:0x80A9FF40 end:0x80AA17B0
 	.rodata     start:0x80B45408 end:0x80B45450
 	.sdata      start:0x80C79340 end:0x80C79350
 
-sdk/RVL_SDK/nand/NANDOpenClose.c:
+nand.a/NANDOpenClose.o:
 	.text       start:0x80AA17B0 end:0x80AA1CC0
 
-sdk/RVL_SDK/nand/NANDCore.c:
+nand.a/NANDCore.o:
 	.text       start:0x80AA1CC0 end:0x80AA2F80
 	.rodata     start:0x80B45450 end:0x80B45598
 	.data       start:0x80C57B20 end:0x80C57C70
@@ -8438,42 +8438,42 @@ sdk/RVL_SDK/nand/NANDCore.c:
 	.sbss       start:0x80C7B490 end:0x80C7B498
 	.bss        start:0x80D7A1A0 end:0x80D7A200
 
-sdk/RVL_SDK/nand/NANDSecret.c:
+nand.a/NANDSecret.o:
 	.text       start:0x80AA2F80 end:0x80AA30D0
 
-sdk/RVL_SDK/nand/NANDCheck.c:
+nand.a/NANDCheck.o:
 	.text       start:0x80AA30D0 end:0x80AA3300
 	.data       start:0x80C57C70 end:0x80C57D20
 	.sdata      start:0x80C79378 end:0x80C79388
 
-sdk/RVL_SDK/nand/NANDLogging.c:
+nand.a/NANDLogging.o:
 	.text       start:0x80AA3300 end:0x80AA3950
 	.data       start:0x80C57D20 end:0x80C57D68
 	.sdata      start:0x80C79388 end:0x80C79390
 	.sbss       start:0x80C7B498 end:0x80C7B4A0
 	.bss        start:0x80D7A200 end:0x80D7A500
 
-sdk/RVL_SDK/nand/NANDErrorMessage.c:
+nand.a/NANDErrorMessage.o:
 	.text       start:0x80AA3950 end:0x80AA3C48
 	.rodata     start:0x80B45598 end:0x80B457B0
 	.data       start:0x80C57D68 end:0x80C59998
 	.sbss       start:0x80C7B4A0 end:0x80C7B4A8
 	.sdata2     start:0x80C7C368 end:0x80C7C398
 
-sdk/RevoEX/ncd/ncdsystem.c:
+ncd.a/ncdsystem.o:
 	.text       start:0x80AA3C48 end:0x80AA44D0
 	.data       start:0x80C59998 end:0x80C59A88
 	.sdata      start:0x80C79390 end:0x80C79398
 	.sbss       start:0x80C7B4A8 end:0x80C7B4B0
 	.bss        start:0x80D7A500 end:0x80D7A560
 
-sdk/RVL_SDK/tpl/TPL.c:
+tpl.a/TPL.o:
 	.text       start:0x80AA44D0 end:0x80AA46F0
 	.data       start:0x80C59A88 end:0x80C59AB8
 	.sdata      start:0x80C79398 end:0x80C793A0
 	.sdata2     start:0x80C7C398 end:0x80C7C3A0
 
-sdk/RVL_SDK/os/OS.c:
+os.a/OS.o:
 	.text       start:0x80AA46F0 end:0x80AA5BD0
 	.data       start:0x80C59AB8 end:0x80C59EC8
 	.sdata      start:0x80C793A0 end:0x80C793D0
@@ -8481,148 +8481,148 @@ sdk/RVL_SDK/os/OS.c:
 	.sdata2     start:0x80C7C3A0 end:0x80C7C3A8
 	.bss        start:0x80D7A560 end:0x80D7A5D0
 
-sdk/RVL_SDK/os/OSAlarm.c:
+os.a/OSAlarm.o:
 	.text       start:0x80AA5BD0 end:0x80AA6550
 	.data       start:0x80C59EC8 end:0x80C59ED8
 	.sbss       start:0x80C7B4F8 end:0x80C7B500
 
-sdk/RVL_SDK/os/OSAlloc.c:
+os.a/OSAlloc.o:
 	.text       start:0x80AA6550 end:0x80AA6780
 	.sdata      start:0x80C793D0 end:0x80C793D8
 	.sbss       start:0x80C7B500 end:0x80C7B508
 
-sdk/RVL_SDK/os/OSArena.c:
+os.a/OSArena.o:
 	.text       start:0x80AA6780 end:0x80AA6880
 	.sdata      start:0x80C793D8 end:0x80C793E0
 	.sbss       start:0x80C7B508 end:0x80C7B510
 
-sdk/RVL_SDK/os/OSAudioSystem.c:
+os.a/OSAudioSystem.o:
 	.text       start:0x80AA6880 end:0x80AA6D40
 	.data       start:0x80C59ED8 end:0x80C59F58
 
-sdk/RVL_SDK/os/OSCache.c:
+os.a/OSCache.o:
 	.text       start:0x80AA6D40 end:0x80AA7290
 	.data       start:0x80C59F58 end:0x80C5A0E0
 
-sdk/RVL_SDK/os/OSContext.c:
+os.a/OSContext.o:
 	.text       start:0x80AA7290 end:0x80AA7B60
 	.data       start:0x80C5A0E0 end:0x80C5A298
 
-sdk/RVL_SDK/os/OSError.c:
+os.a/OSError.o:
 	.text       start:0x80AA7B60 end:0x80AA82B0
 	.data       start:0x80C5A298 end:0x80C5A578
 	.sdata      start:0x80C793E0 end:0x80C793E8
 	.bss        start:0x80D7A5D0 end:0x80D7A620
 
-sdk/RVL_SDK/os/OSExec.c:
+os.a/OSExec.o:
 	.text       start:0x80AA82B0 end:0x80AA9A00
 	.data       start:0x80C5A578 end:0x80C5A8C8
 	.sdata      start:0x80C793E8 end:0x80C793F8
 	.sbss       start:0x80C7B510 end:0x80C7B528
 	.bss        start:0x80D7A620 end:0x80D7A640
 
-sdk/RVL_SDK/os/OSFatal.c:
+os.a/OSFatal.o:
 	.text       start:0x80AA9A00 end:0x80AAA630
 	.sdata      start:0x80C793F8 end:0x80C79400
 	.sdata2     start:0x80C7C3A8 end:0x80C7C3E8
 	.bss        start:0x80D7A640 end:0x80D7A920
 
-sdk/RVL_SDK/os/OSFont.c:
+os.a/OSFont.o:
 	.text       start:0x80AAA630 end:0x80AAB8C0
 	.data       start:0x80C5A8C8 end:0x80C5B3D8
 	.sdata      start:0x80C79400 end:0x80C79408
 	.sbss       start:0x80C7B528 end:0x80C7B538
 	.sdata2     start:0x80C7C3E8 end:0x80C7C3F0
 
-sdk/RVL_SDK/os/OSInterrupt.c:
+os.a/OSInterrupt.o:
 	.text       start:0x80AAB8C0 end:0x80AAC090
 	.data       start:0x80C5B3D8 end:0x80C5B408
 	.sbss       start:0x80C7B538 end:0x80C7B550
 
-sdk/RVL_SDK/os/OSLink.c:
+os.a/OSLink.o:
 	.text       start:0x80AAC090 end:0x80AAC0B0
 
-sdk/RVL_SDK/os/OSMessage.c:
+os.a/OSMessage.o:
 	.text       start:0x80AAC0B0 end:0x80AAC390
 
-sdk/RVL_SDK/os/OSMemory.c:
+os.a/OSMemory.o:
 	.text       start:0x80AAC390 end:0x80AACBB0
 	.data       start:0x80C5B408 end:0x80C5B418
 	.sbss       start:0x80C7B550 end:0x80C7B558
 
-sdk/RVL_SDK/os/OSMutex.c:
+os.a/OSMutex.o:
 	.text       start:0x80AACBB0 end:0x80AAD190
 
-sdk/RVL_SDK/os/OSReboot.c:
+os.a/OSReboot.o:
 	.text       start:0x80AAD190 end:0x80AAD220
 	.sbss       start:0x80C7B558 end:0x80C7B560
 
-sdk/RVL_SDK/os/OSReset.c:
+os.a/OSReset.o:
 	.text       start:0x80AAD220 end:0x80AADB50
 	.data       start:0x80C5B418 end:0x80C5B680
 	.sbss       start:0x80C7B560 end:0x80C7B570
 
-sdk/RVL_SDK/os/OSRtc.c:
+os.a/OSRtc.o:
 	.text       start:0x80AADB50 end:0x80AAE600
 	.bss        start:0x80D7A920 end:0x80D7A978
 
-sdk/RVL_SDK/os/OSSemaphore.c:
+os.a/OSSemaphore.o:
 	.text       start:0x80AAE600 end:0x80AAE730
 
-sdk/RVL_SDK/os/OSSync.c:
+os.a/OSSync.o:
 	.text       start:0x80AAE730 end:0x80AAE7B0
 
-sdk/RVL_SDK/os/OSThread.c:
+os.a/OSThread.o:
 	.text       start:0x80AAE7B0 end:0x80AB0790
 	.data       start:0x80C5B680 end:0x80C5BE90
 	.sdata      start:0x80C79408 end:0x80C79410
 	.sbss       start:0x80C7B570 end:0x80C7B580
 	.bss        start:0x80D7A978 end:0x80D7B380
 
-sdk/RVL_SDK/os/OSTime.c:
+os.a/OSTime.o:
 	.text       start:0x80AB0790 end:0x80AB0E60
 	.data       start:0x80C5BE90 end:0x80C5BEF0
 
-sdk/RVL_SDK/os/OSUtf.c:
+os.a/OSUtf.o:
 	.text       start:0x80AB0E60 end:0x80AB10B0
 	.data       start:0x80C5BEF0 end:0x80C67D30
 
-sdk/RVL_SDK/os/OSIpc.c:
+os.a/OSIpc.o:
 	.text       start:0x80AB10B0 end:0x80AB10F0
 	.sdata      start:0x80C79410 end:0x80C79418
 	.sbss       start:0x80C7B580 end:0x80C7B588
 
-sdk/RVL_SDK/os/OSStateTM.c:
+os.a/OSStateTM.o:
 	.text       start:0x80AB10F0 end:0x80AB1840
 	.data       start:0x80C67D30 end:0x80C67DF8
 	.sbss       start:0x80C7B588 end:0x80C7B5A8
 	.bss        start:0x80D7B380 end:0x80D7B440
 
-sdk/RVL_SDK/os/__start.c:
+os.a/__start.o:
 	.init       start:0x800062C0 end:0x80006620
 	.sbss       start:0x80C7B5A8 end:0x80C7B5B0
 
-sdk/RVL_SDK/os/OSPlayRecord.c:
+os.a/OSPlayRecord.o:
 	.text       start:0x80AB1840 end:0x80AB1F60
 	.data       start:0x80C67DF8 end:0x80C67E40
 	.sdata      start:0x80C79418 end:0x80C79420
 	.sbss       start:0x80C7B5B0 end:0x80C7B5D0
 	.bss        start:0x80D7B440 end:0x80D7B640
 
-sdk/RVL_SDK/os/OSStateFlags.c:
+os.a/OSStateFlags.o:
 	.text       start:0x80AB1F60 end:0x80AB2180
 	.data       start:0x80C67E40 end:0x80C67E68
 	.bss        start:0x80D7B640 end:0x80D7B660
 
-sdk/RVL_SDK/os/OSNet.c:
+os.a/OSNet.o:
 	.text       start:0x80AB2180 end:0x80AB2240
 	.data       start:0x80C67E68 end:0x80C67FD0
 
-sdk/RVL_SDK/os/OSNandbootInfo.c:
+os.a/OSNandbootInfo.o:
 	.text       start:0x80AB2240 end:0x80AB2450
 	.data       start:0x80C67FD0 end:0x80C67FF0
 
-sdk/RVL_SDK/os/OSPlayTime.c:
+os.a/OSPlayTime.o:
 	.text       start:0x80AB2450 end:0x80AB2C30
 	.data       start:0x80C67FF0 end:0x80C68030
 	.sdata      start:0x80C79420 end:0x80C79428
@@ -8630,27 +8630,27 @@ sdk/RVL_SDK/os/OSPlayTime.c:
 	.sdata2     start:0x80C7C3F0 end:0x80C7C400
 	.bss        start:0x80D7B660 end:0x80D7B6A0
 
-sdk/RVL_SDK/os/OSCrc.c:
+os.a/OSCrc.o:
 	.text       start:0x80AB2C30 end:0x80AB2D70
 	.rodata     start:0x80B457B0 end:0x80B457F0
 
-sdk/RVL_SDK/os/OSLaunch.c:
+os.a/OSLaunch.o:
 	.text       start:0x80AB2D70 end:0x80AB2F80
 
-sdk/RVL_SDK/os/__ppc_eabi_init.c:
+os.a/__ppc_eabi_init.o:
 	.init       start:0x80006620 end:0x80006684
 	.text       start:0x80AB2F80 end:0x80AB3040
 
-sdk/RVL_SDK/pad/Pad.c:
+pad.a/Pad.o:
 	.text       start:0x80AB3040 end:0x80AB30A0
 	.sbss       start:0x80C7B5E8 end:0x80C7B5F0
 
-sdk/RVL_SDK/rso/RSOLink.c:
+rso.a/RSOLink.o:
 	.text       start:0x80AB30A0 end:0x80AB4FA0
 	.data       start:0x80C68030 end:0x80C68148
 	.sbss       start:0x80C7B5F0 end:0x80C7B5F8
 
-sdk/RVL_SDK/sc/scsystem.c:
+sc.a/scsystem.o:
 	.text       start:0x80AB4FA0 end:0x80AB6A30
 	.rodata     start:0x80B457F0 end:0x80B45848
 	.data       start:0x80C68148 end:0x80C68340
@@ -8658,65 +8658,65 @@ sdk/RVL_SDK/sc/scsystem.c:
 	.sbss       start:0x80C7B5F8 end:0x80C7B610
 	.bss        start:0x80D7B6A0 end:0x80D83840
 
-sdk/RVL_SDK/sc/scapi.c:
+sc.a/scapi.o:
 	.text       start:0x80AB6A30 end:0x80AB7180
 	.data       start:0x80C68340 end:0x80C68370
 	.bss        start:0x80D83840 end:0x80D84848
 
-sdk/RVL_SDK/sc/scapi_prdinfo.c:
+sc.a/scapi_prdinfo.o:
 	.text       start:0x80AB7180 end:0x80AB74E0
 	.data       start:0x80C68370 end:0x80C683D0
 	.sdata      start:0x80C79538 end:0x80C79560
 	.sbss       start:0x80C7B610 end:0x80C7B618
 
-sdk/RVL_SDK/scutil/idToIsoA2.c:
+scutil.a/idToIsoA2.o:
 	.text       start:0x80AB74E0 end:0x80AB7540
 	.data       start:0x80C683D0 end:0x80C68698
 	.sdata      start:0x80C79560 end:0x80C79730
 
-sdk/RVL_SDK/si/SIBios.c:
+si.a/SIBios.o:
 	.text       start:0x80AB7540 end:0x80AB8580
 	.data       start:0x80C68698 end:0x80C68708
 	.sdata      start:0x80C79730 end:0x80C79738
 	.sbss       start:0x80C7B618 end:0x80C7B628
 	.bss        start:0x80D84848 end:0x80D84A68
 
-sdk/RVL_SDK/si/SISamplingRate.c:
+si.a/SISamplingRate.o:
 	.text       start:0x80AB8580 end:0x80AB8670
 	.data       start:0x80C68708 end:0x80C687A0
 	.sbss       start:0x80C7B628 end:0x80C7B630
 
-sdk/RVL_SDK/usb/usb.c:
+usb.a/usb.o:
 	.text       start:0x80AB8670 end:0x80ABA890
 	.data       start:0x80C687A0 end:0x80C68FD0
 	.sdata      start:0x80C79738 end:0x80C79748
 	.sbss       start:0x80C7B630 end:0x80C7B640
 
-sdk/RVL_SDK/vi/vi.c:
+vi.a/vi.o:
 	.text       start:0x80ABA890 end:0x80ABD2A0
 	.data       start:0x80C68FD0 end:0x80C69528
 	.sdata      start:0x80C79748 end:0x80C79768
 	.sbss       start:0x80C7B640 end:0x80C7B6F0
 	.bss        start:0x80D84A68 end:0x80D84BD8
 
-sdk/RVL_SDK/vi/i2c.c:
+vi.a/i2c.o:
 	.text       start:0x80ABD2A0 end:0x80ABDBC0
 	.sdata      start:0x80C79768 end:0x80C79770
 	.sbss       start:0x80C7B6F0 end:0x80C7B6F8
 
-sdk/RVL_SDK/vi/vi3in1.c:
+vi.a/vi3in1.o:
 	.text       start:0x80ABDBC0 end:0x80ABF2EC
 	.data       start:0x80C69528 end:0x80C69B38
 	.sdata      start:0x80C79770 end:0x80C79780
 	.sbss       start:0x80C7B6F8 end:0x80C7B710
 	.bss        start:0x80D84BD8 end:0x80D84C00
 
-sdk/RVL_SDK/wenc/wenc.c:
+wenc.a/wenc.o:
 	.text       start:0x80ABF2EC end:0x80ABF5D0
 	.rodata     start:0x80B45848 end:0x80B45888
 	.sdata2     start:0x80C7C400 end:0x80C7C408
 
-sdk/RVL_SDK/wpad/WPAD.c:
+wpad.a/WPAD.o:
 	.text       start:0x80ABF5D0 end:0x80ACA050
 	.rodata     start:0x80B45888 end:0x80B45958
 	.data       start:0x80C69B38 end:0x80C69DC0
@@ -8725,7 +8725,7 @@ sdk/RVL_SDK/wpad/WPAD.c:
 	.sdata2     start:0x80C7C408 end:0x80C7C410
 	.bss        start:0x80D84C00 end:0x80D88BE0
 
-sdk/RVL_SDK/wpad/WPADHIDParser.c:
+wpad.a/WPADHIDParser.o:
 	.text       start:0x80ACA050 end:0x80ACF1F0
 	.rodata     start:0x80B45958 end:0x80B45988
 	.data       start:0x80C69DC0 end:0x80C69EB8
@@ -8733,18 +8733,18 @@ sdk/RVL_SDK/wpad/WPADHIDParser.c:
 	.sdata2     start:0x80C7C410 end:0x80C7C488
 	.bss        start:0x80D88BE0 end:0x80D88C40
 
-sdk/RVL_SDK/wpad/WPADEncrypt.c:
+wpad.a/WPADEncrypt.o:
 	.text       start:0x80ACF1F0 end:0x80AD00B0
 	.data       start:0x80C69EB8 end:0x80C6B118
 	.sbss       start:0x80C7B788 end:0x80C7B790
 
-sdk/RVL_SDK/wpad/WPADMem.c:
+wpad.a/WPADMem.o:
 	.text       start:0x80AD00B0 end:0x80AD01C0
 
-sdk/RVL_SDK/wpad/lint.c:
+wpad.a/lint.o:
 	.text       start:0x80AD01C0 end:0x80AD0A30
 
-sdk/RVL_SDK/wpad/WUD.c:
+wpad.a/WUD.o:
 	.text       start:0x80AD0A30 end:0x80AD6180
 	.data       start:0x80C6B118 end:0x80C6B460
 	.sdata      start:0x80C79798 end:0x80C797A8
@@ -8752,53 +8752,53 @@ sdk/RVL_SDK/wpad/WUD.c:
 	.sdata2     start:0x80C7C488 end:0x80C7C490
 	.bss        start:0x80D88C40 end:0x80D8ADE8
 
-sdk/RVL_SDK/wpad/WUDHidHost.c:
+wpad.a/WUDHidHost.o:
 	.text       start:0x80AD6180 end:0x80AD65F0
 	.data       start:0x80C6B460 end:0x80C6B4A0
 
-sdk/RVL_SDK/wpadDrm/WPADDrm.c:
+wpadDrm.a/WPADDrm.o:
 	.text       start:0x80AD65F0 end:0x80AD6600
 	.data       start:0x80C6B4A0 end:0x80C6B4F0
 	.sdata      start:0x80C797A8 end:0x80C797B8
 
-sdk/RVL_SDK/wpadGtr/WPADGtr.c:
+wpadGtr.a/WPADGtr.o:
 	.text       start:0x80AD6600 end:0x80AD6610
 	.data       start:0x80C6B4F0 end:0x80C6B540
 	.sdata      start:0x80C797B8 end:0x80C797C8
 
-sdk/ec/ec_md5c.cpp:
+ec.a/ec_md5c.o:
 	.text       start:0x80AD6610 end:0x80AD7220
 	.data       start:0x80C6B540 end:0x80C6B580
 
-sdk/ec/shr_th_bw.cpp:
+ec.a/shr_th_bw.o:
 	.text       start:0x80AD7220 end:0x80AD7590
 	.data       start:0x80C6B580 end:0x80C6B5E8
 
-sdk/ec/shr_time_bw.cpp:
+ec.a/shr_time_bw.o:
 	.text       start:0x80AD7590 end:0x80AD75C0
 
-sdk/ec/ec_asyncOp.cpp:
+ec.a/ec_asyncOp.o:
 	extab       start:0x800068CC end:0x8000886C
 	extabindex  start:0x8000CB18 end:0x8000CECC
 	.text       start:0x80AD75C0 end:0x80ADB7D0
 	.data       start:0x80C6B5E8 end:0x80C6C058
 	.bss        start:0x80D8ADE8 end:0x80D8B188
 
-sdk/ec/ec_misc.cpp:
+ec.a/ec_misc.o:
 	extab       start:0x8000886C end:0x8000897C
 	extabindex  start:0x8000CECC end:0x8000CF74
 	.text       start:0x80ADB7D0 end:0x80ADC800
 	.data       start:0x80C6C058 end:0x80C6C968
 	.bss        start:0x80D8B188 end:0x80D8B198
 
-sdk/ec/ec_getTitle.cpp:
+ec.a/ec_getTitle.o:
 	extab       start:0x8000897C end:0x80008A8C
 	extabindex  start:0x8000CF74 end:0x8000CFBC
 	.text       start:0x80ADC800 end:0x80ADD9E0
 	.data       start:0x80C6C968 end:0x80C6D080
 	.bss        start:0x80D8B198 end:0x80D8BDA0
 
-sdk/ec/ec_purchaseTitle.cpp:
+ec.a/ec_purchaseTitle.o:
 	extab       start:0x80008A8C end:0x800094F4
 	extabindex  start:0x8000CFBC end:0x8000D0E8
 	.text       start:0x80ADD9E0 end:0x80ADF700
@@ -8806,45 +8806,45 @@ sdk/ec/ec_purchaseTitle.cpp:
 	.data       start:0x80C6D080 end:0x80C6D818
 	.bss        start:0x80D8BDA0 end:0x80D8BDA8
 
-sdk/ec/ec_checkReg.cpp:
+ec.a/ec_checkReg.o:
 	extab       start:0x800094F4 end:0x80009650
 	extabindex  start:0x8000D0E8 end:0x8000D10C
 	.text       start:0x80ADF700 end:0x80ADFAC0
 	.data       start:0x80C6D818 end:0x80C6D8B0
 	.bss        start:0x80D8BDA8 end:0x80D8BDB0
 
-sdk/ec/ec_mem.cpp:
+ec.a/ec_mem.o:
 	extab       start:0x80009650 end:0x800096B4
 	extabindex  start:0x8000D10C end:0x8000D154
 	.text       start:0x80ADFAC0 end:0x80ADFE90
 	.data       start:0x80C6D8B0 end:0x80C6DA50
 	.bss        start:0x80D8BDB0 end:0x80D8BDE0
 
-sdk/ec/ec_soap.cpp:
+ec.a/ec_soap.o:
 	extab       start:0x800096B4 end:0x8000A44C
 	extabindex  start:0x8000D154 end:0x8000D4A8
 	.text       start:0x80ADFE90 end:0x80AE5FC0
 	.rodata     start:0x80B459C8 end:0x80B45C00
 	.data       start:0x80C6DA50 end:0x80C6E678
 
-sdk/ec/ec_base64.cpp:
+ec.a/ec_base64.o:
 	.text       start:0x80AE5FC0 end:0x80AE64D0
 	.data       start:0x80C6E678 end:0x80C6E680
 	.bss        start:0x80D8BDE0 end:0x80D8BF28
 
-sdk/ec/ec_string.cpp:
+ec.a/ec_string.o:
 	extab       start:0x8000A44C end:0x8000A61C
 	extabindex  start:0x8000D4A8 end:0x8000D604
 	.text       start:0x80AE64D0 end:0x80AE7F50
 	.data       start:0x80C6E680 end:0x80C6EB38
 	.bss        start:0x80D8BF28 end:0x80D8BF40
 
-sdk/ec/ec_md5.cpp:
+ec.a/ec_md5.o:
 	extab       start:0x8000A61C end:0x8000A624
 	extabindex  start:0x8000D604 end:0x8000D610
 	.text       start:0x80AE7F50 end:0x80AE8010
 
-sdk/ec/ec_content.cpp:
+ec.a/ec_content.o:
 	extab       start:0x8000A624 end:0x8000AB38
 	extabindex  start:0x8000D610 end:0x8000D6F4
 	.text       start:0x80AE8010 end:0x80AE9EB0
@@ -8852,519 +8852,519 @@ sdk/ec/ec_content.cpp:
 	.data       start:0x80C6EB38 end:0x80C6F1D8
 	.bss        start:0x80D8BF40 end:0x80D984B0
 
-sdk/ec/ec_chkDevStat.cpp:
+ec.a/ec_chkDevStat.o:
 	extab       start:0x8000AB38 end:0x8000AD44
 	extabindex  start:0x8000D6F4 end:0x8000D730
 	.text       start:0x80AE9EB0 end:0x80AEA750
 	.data       start:0x80C6F1D8 end:0x80C6F820
 	.bss        start:0x80D984B0 end:0x80D984B8
 
-sdk/ec/ec_register.cpp:
+ec.a/ec_register.o:
 	extab       start:0x8000AD44 end:0x8000B328
 	extabindex  start:0x8000D730 end:0x8000D7C0
 	.text       start:0x80AEA750 end:0x80AEBBE0
 	.data       start:0x80C6F820 end:0x80C700A0
 	.bss        start:0x80D984B8 end:0x80D984C0
 
-sdk/ec/ec_csup.cpp:
+ec.a/ec_csup.o:
 	.text       start:0x80AEBBE0 end:0x80AEBD50
 
-sdk/ec/ec_connect.cpp:
+ec.a/ec_connect.o:
 	extab       start:0x8000B328 end:0x8000B548
 	extabindex  start:0x8000D7C0 end:0x8000D7E4
 	.text       start:0x80AEBD50 end:0x80AEC4D0
 	.data       start:0x80C700A0 end:0x80C70660
 	.bss        start:0x80D984C0 end:0x80D984C8
 
-sdk/ec/ec_api.cpp:
+ec.a/ec_api.o:
 	extab       start:0x8000B548 end:0x8000B78C
 	extabindex  start:0x8000D7E4 end:0x8000D868
 	.text       start:0x80AEC4D0 end:0x80AEDD40
 	.data       start:0x80C70660 end:0x80C70CA0
 
-sdk/ec/ec_dk.cpp:
+ec.a/ec_dk.o:
 	extab       start:0x8000B78C end:0x8000B9A0
 	extabindex  start:0x8000D868 end:0x8000D934
 	.text       start:0x80AEDD40 end:0x80AEEF00
 	.data       start:0x80C70CA0 end:0x80C71260
 	.bss        start:0x80D984C8 end:0x80DA04C8
 
-sdk/ec/ec_downloadContents.cpp:
+ec.a/ec_downloadContents.o:
 	extab       start:0x8000B9A0 end:0x8000BA88
 	extabindex  start:0x8000D934 end:0x8000D988
 	.text       start:0x80AEEF00 end:0x80AEF5D0
 	.data       start:0x80C71260 end:0x80C717B8
 	.bss        start:0x80DA04C8 end:0x80DA04D0
 
-sdk/ec/ec_deleteContents.cpp:
+ec.a/ec_deleteContents.o:
 	extab       start:0x8000BA88 end:0x8000BAC4
 	extabindex  start:0x8000D988 end:0x8000D994
 	.text       start:0x80AEF5D0 end:0x80AEF880
 	.data       start:0x80C717B8 end:0x80C71978
 	.bss        start:0x80DA04D0 end:0x80DA04D8
 
-sdk/ec/ec_listTitleContents.cpp:
+ec.a/ec_listTitleContents.o:
 	extab       start:0x8000BAC4 end:0x8000BBB8
 	extabindex  start:0x8000D994 end:0x8000D9DC
 	.text       start:0x80AEF880 end:0x80AF01A0
 	.data       start:0x80C71978 end:0x80C71EE8
 	.bss        start:0x80DA04D8 end:0x80DA04E0
 
-sdk/ec/ec_list.cpp:
+ec.a/ec_list.o:
 	extab       start:0x8000BBB8 end:0x8000BBC0
 	extabindex  start:0x8000D9DC end:0x8000D9E8
 	.text       start:0x80AF01A0 end:0x80AF0240
 	.data       start:0x80C71EE8 end:0x80C71F10
 
-sdk/ec/ec_listCatalog.cpp:
+ec.a/ec_listCatalog.o:
 	extab       start:0x8000BBC0 end:0x8000BD78
 	extabindex  start:0x8000D9E8 end:0x8000DA24
 	.text       start:0x80AF0240 end:0x80AF0D30
 	.data       start:0x80C71F10 end:0x80C724F0
 
-sdk/ec/ec_listTitles.cpp:
+ec.a/ec_listTitles.o:
 	extab       start:0x8000BD78 end:0x8000BD80
 	extabindex  start:0x8000DA24 end:0x8000DA30
 	.text       start:0x80AF0D30 end:0x80AF0DA0
 	.data       start:0x80C724F0 end:0x80C72710
 	.bss        start:0x80DA04E0 end:0x80DA04E8
 
-sdk/ec/ec_listContentSets.cpp:
+ec.a/ec_listContentSets.o:
 	extab       start:0x8000BD80 end:0x8000BDC4
 	extabindex  start:0x8000DA30 end:0x8000DA48
 	.text       start:0x80AF0DA0 end:0x80AF0FA0
 	.data       start:0x80C72710 end:0x80C72950
 	.bss        start:0x80DA04E8 end:0x80DA04F0
 
-sdk/ec/ec_getTitleResReq.cpp:
+ec.a/ec_getTitleResReq.o:
 	extab       start:0x8000BDC4 end:0x8000BE88
 	extabindex  start:0x8000DA48 end:0x8000DA84
 	.text       start:0x80AF0FA0 end:0x80AF1500
 	.data       start:0x80C72950 end:0x80C72EB0
 	.bss        start:0x80DA04F0 end:0x80DA04F8
 
-sdk/ec/ec_getContentsResReq.cpp:
+ec.a/ec_getContentsResReq.o:
 	extab       start:0x8000BE88 end:0x8000BEFC
 	extabindex  start:0x8000DA84 end:0x8000DAC0
 	.text       start:0x80AF1500 end:0x80AF1850
 	.data       start:0x80C72EB0 end:0x80C73000
 	.bss        start:0x80DA04F8 end:0x80DA0500
 
-sdk/ec/ec_listServiceItems.cpp:
+ec.a/ec_listServiceItems.o:
 	extab       start:0x8000BEFC end:0x8000BF0C
 	extabindex  start:0x8000DAC0 end:0x8000DAD8
 	.text       start:0x80AF1850 end:0x80AF1900
 	.data       start:0x80C73000 end:0x80C73278
 	.bss        start:0x80DA0500 end:0x80DA0508
 
-sdk/ec/ec_listPurchaseHistory.cpp:
+ec.a/ec_listPurchaseHistory.o:
 	extab       start:0x8000BF0C end:0x8000C3A4
 	extabindex  start:0x8000DAD8 end:0x8000DB14
 	.text       start:0x80AF1900 end:0x80AF2E40
 	.data       start:0x80C73278 end:0x80C73B00
 	.bss        start:0x80DA0508 end:0x80DA0530
 
-sdk/ec/ec_listContentSetGroups.cpp:
+ec.a/ec_listContentSetGroups.o:
 	extab       start:0x8000C3A4 end:0x8000C5D8
 	extabindex  start:0x8000DB14 end:0x8000DB44
 	.text       start:0x80AF2E40 end:0x80AF3600
 	.data       start:0x80C73B00 end:0x80C74130
 	.bss        start:0x80DA0530 end:0x80DA0538
 
-sdk/ec/ec_listContentDownloadInfos.cpp:
+ec.a/ec_listContentDownloadInfos.o:
 	extab       start:0x8000C5D8 end:0x8000C624
 	extabindex  start:0x8000DB44 end:0x8000DB68
 	.text       start:0x80AF3600 end:0x80AF3C30
 	.data       start:0x80C74130 end:0x80C746C8
 	.bss        start:0x80DA0538 end:0x80DA0540
 
-sdk/ec/ec_checkECard.cpp:
+ec.a/ec_checkECard.o:
 	extab       start:0x8000C624 end:0x8000C744
 	extabindex  start:0x8000DB68 end:0x8000DB98
 	.text       start:0x80AF3C30 end:0x80AF4160
 	.data       start:0x80C746C8 end:0x80C74C38
 	.bss        start:0x80DA0540 end:0x80DA0548
 
-sdk/ec/ec_listECardItems.cpp:
+ec.a/ec_listECardItems.o:
 	extab       start:0x8000C744 end:0x8000C754
 	extabindex  start:0x8000DB98 end:0x8000DBB0
 	.text       start:0x80AF4160 end:0x80AF4230
 	.data       start:0x80C74C38 end:0x80C74EB0
 	.bss        start:0x80DA0548 end:0x80DA0550
 
-sdk/ec/ec_file_bw.cpp:
+ec.a/ec_file_bw.o:
 	extab       start:0x8000C754 end:0x8000C7DC
 	extabindex  start:0x8000DBB0 end:0x8000DC7C
 	.text       start:0x80AF4230 end:0x80AF5180
 	.data       start:0x80C74EB0 end:0x80C75678
 
-sdk/ec/ec_shoplog_bw.cpp:
+ec.a/ec_shoplog_bw.o:
 	extab       start:0x8000C7DC end:0x8000C814
 	extabindex  start:0x8000DC7C end:0x8000DCD0
 	.text       start:0x80AF5180 end:0x80AF5740
 	.data       start:0x80C75678 end:0x80C758A8
 
-sdk/ec/ec_sysconfig_bw.cpp:
+ec.a/ec_sysconfig_bw.o:
 	extab       start:0x8000C814 end:0x8000C85C
 	extabindex  start:0x8000DCD0 end:0x8000DD3C
 	.text       start:0x80AF5740 end:0x80AF5C40
 	.data       start:0x80C758A8 end:0x80C75C98
 	.bss        start:0x80DA0550 end:0x80DA0558
 
-sdk/ec/ec_chkDownload_bw.cpp:
+ec.a/ec_chkDownload_bw.o:
 	extab       start:0x8000C85C end:0x8000C894
 	extabindex  start:0x8000DD3C end:0x8000DD78
 	.text       start:0x80AF5C40 end:0x80AF6120
 	.data       start:0x80C75C98 end:0x80C75DF0
 
-sdk/ec/ec_http_bw.cpp:
+ec.a/ec_http_bw.o:
 	extab       start:0x8000C894 end:0x8000C9D0
 	extabindex  start:0x8000DD78 end:0x8000DDFC
 	.text       start:0x80AF6120 end:0x80AF81FC
 	.data       start:0x80C75DF0 end:0x80C76888
 	.bss        start:0x80DA0558 end:0x80DA05A0
 
-sdk/RevoEX/net/neterrorcode.c:
+net.a/neterrorcode.o:
 	.text       start:0x80AF81FC end:0x80AF866C
 	.data       start:0x80C76888 end:0x80C768A8
 
-sdk/RevoEX/net/NETVersion.c:
+net.a/NETVersion.o:
 	.text       start:0x80AF866C end:0x80AF8674
 	.data       start:0x80C768A8 end:0x80C768E0
 	.sdata      start:0x80C797C8 end:0x80C797D0
 
-sdk/RevoEX/net/wireless_macaddr.c:
+net.a/wireless_macaddr.o:
 	.text       start:0x80AF8674 end:0x80AF8678
 
-sdk/RevoEX/net/netmemcpy.c:
+net.a/netmemcpy.o:
 	.text       start:0x80AF8678 end:0x80AF8A38
 
-sdk/RevoEX/net/netmemset.c:
+net.a/netmemset.o:
 	.text       start:0x80AF8A38 end:0x80AF8B3C
 
-sdk/RevoEX/nhttp/NHTTP_bgnend.c:
+nhttp.a/NHTTP_bgnend.o:
 	.text       start:0x80AF8B3C end:0x80AF8EAC
 	.data       start:0x80C768E0 end:0x80C76968
 
-sdk/RevoEX/nhttp/NHTTP_control.c:
+nhttp.a/NHTTP_control.o:
 	.text       start:0x80AF8EAC end:0x80AF91DC
 	.data       start:0x80C76968 end:0x80C769C0
 
-sdk/RevoEX/nhttp/NHTTP_list.c:
+nhttp.a/NHTTP_list.o:
 	.text       start:0x80AF91DC end:0x80AF942C
 
-sdk/RevoEX/nhttp/NHTTP_os_RVL.c:
+nhttp.a/NHTTP_os_RVL.o:
 	.text       start:0x80AF942C end:0x80AF9650
 	.data       start:0x80C769C0 end:0x80C76A00
 	.sdata      start:0x80C797D0 end:0x80C797D8
 
-sdk/RevoEX/nhttp/NHTTP_recvbuf.c:
+nhttp.a/NHTTP_recvbuf.o:
 	.text       start:0x80AF9650 end:0x80AF9CEC
 
-sdk/RevoEX/nhttp/NHTTP_request.c:
+nhttp.a/NHTTP_request.o:
 	.text       start:0x80AF9CEC end:0x80AFA728
 	.rodata     start:0x80B45C10 end:0x80B45C28
 	.data       start:0x80C76A00 end:0x80C76A10
 	.sdata      start:0x80C797D8 end:0x80C797E0
 
-sdk/RevoEX/nhttp/NHTTP_response.c:
+nhttp.a/NHTTP_response.o:
 	.text       start:0x80AFA728 end:0x80AFA9F8
 
-sdk/RevoEX/nhttp/NHTTP_socket_RVL.c:
+nhttp.a/NHTTP_socket_RVL.o:
 	.text       start:0x80AFA9F8 end:0x80AFB2F4
 
-sdk/RevoEX/nhttp/NHTTP_stdlib_RVL.c:
+nhttp.a/NHTTP_stdlib_RVL.o:
 	.text       start:0x80AFB2F4 end:0x80AFBC68
 	.rodata     start:0x80B45C28 end:0x80B45C50
 	.data       start:0x80C76A10 end:0x80C76A58
 
-sdk/RevoEX/nhttp/NHTTP_thread.c:
+nhttp.a/NHTTP_thread.o:
 	.text       start:0x80AFBC68 end:0x80AFE8F4
 	.rodata     start:0x80B45C50 end:0x80B45D28
 	.data       start:0x80C76A58 end:0x80C76B28
 	.sdata      start:0x80C797E0 end:0x80C79840
 
-sdk/RevoEX/nhttp/d_nhttp_private.c:
+nhttp.a/d_nhttp_private.o:
 	.text       start:0x80AFE8F4 end:0x80AFEFDC
 
-sdk/RevoEX/nhttp/d_nhttp.c:
+nhttp.a/d_nhttp.o:
 	.text       start:0x80AFEFDC end:0x80AFFF5C
 	.data       start:0x80C76B28 end:0x80C76E20
 	.sdata      start:0x80C79840 end:0x80C79850
 	.sbss       start:0x80C7B7C8 end:0x80C7B7D8
 
-sdk/RevoEX/nhttp/d_nhttp_common.c:
+nhttp.a/d_nhttp_common.o:
 	.text       start:0x80AFFF5C end:0x80B00784
 	.data       start:0x80C76E20 end:0x80C76E60
 	.sbss       start:0x80C7B7D8 end:0x80C7B7E0
 	.bss        start:0x80DA05A0 end:0x80DA1280
 
-sdk/RevoEX/nwc24/NWC24StdAPI.c:
+nwc24.a/NWC24StdAPI.o:
 	.text       start:0x80B00784 end:0x80B0126C
 	.data       start:0x80C76E60 end:0x80C76EE8
 
-sdk/RevoEX/nwc24/NWC24FileAPI.c:
+nwc24.a/NWC24FileAPI.o:
 	.text       start:0x80B0126C end:0x80B0229C
 	.data       start:0x80C76EE8 end:0x80C76F18
 	.sdata      start:0x80C79850 end:0x80C79860
 	.sbss       start:0x80C7B7E0 end:0x80C7B7F0
 
-sdk/RevoEX/nwc24/NWC24Config.c:
+nwc24.a/NWC24Config.o:
 	.text       start:0x80B0229C end:0x80B0293C
 	.data       start:0x80C76F18 end:0x80C76F80
 	.sdata      start:0x80C79860 end:0x80C79870
 	.sbss       start:0x80C7B7F0 end:0x80C7B7F8
 
-sdk/RevoEX/nwc24/NWC24Manage.c:
+nwc24.a/NWC24Manage.o:
 	.text       start:0x80B0293C end:0x80B02CB0
 	.data       start:0x80C76F80 end:0x80C77090
 	.sdata      start:0x80C79870 end:0x80C79878
 	.sbss       start:0x80C7B7F8 end:0x80C7B810
 
-sdk/RevoEX/nwc24/NWC24MBoxCtrl.c:
+nwc24.a/NWC24MBoxCtrl.o:
 	.text       start:0x80B02CB0 end:0x80B03048
 	.data       start:0x80C77090 end:0x80C770D0
 	.sdata      start:0x80C79878 end:0x80C79880
 	.sbss       start:0x80C7B810 end:0x80C7B818
 
-sdk/RevoEX/nwc24/NWC24Mime.c:
+nwc24.a/NWC24Mime.o:
 	.text       start:0x80B03048 end:0x80B03328
 
-sdk/RevoEX/nwc24/NWC24Schedule.c:
+nwc24.a/NWC24Schedule.o:
 	.text       start:0x80B03328 end:0x80B03D3C
 	.data       start:0x80C770D0 end:0x80C77130
 	.sbss       start:0x80C7B818 end:0x80C7B828
 	.bss        start:0x80DA1280 end:0x80DA1400
 
-sdk/RevoEX/nwc24/NWC24FriendList.c:
+nwc24.a/NWC24FriendList.o:
 	.text       start:0x80B03D3C end:0x80B04014
 	.data       start:0x80C77130 end:0x80C77150
 	.sdata      start:0x80C79880 end:0x80C79888
 
-sdk/RevoEX/nwc24/NWC24SecretFList.c:
+nwc24.a/NWC24SecretFList.o:
 	.text       start:0x80B04014 end:0x80B04130
 	.data       start:0x80C77150 end:0x80C77170
 	.sdata      start:0x80C79888 end:0x80C79890
 
-sdk/RevoEX/nwc24/NWC24UserId.c:
+nwc24.a/NWC24UserId.o:
 	.text       start:0x80B04130 end:0x80B0444C
 	.rodata     start:0x80B45D28 end:0x80B45D38
 
-sdk/RevoEX/nwc24/NWC24Time.c:
+nwc24.a/NWC24Time.o:
 	.text       start:0x80B0444C end:0x80B04628
 	.data       start:0x80C77170 end:0x80C77198
 	.sbss       start:0x80C7B828 end:0x80C7B830
 	.bss        start:0x80DA1400 end:0x80DA14E0
 
-sdk/RevoEX/nwc24/NWC24Ipc.c:
+nwc24.a/NWC24Ipc.o:
 	.text       start:0x80B04628 end:0x80B0479C
 	.sbss       start:0x80C7B830 end:0x80C7B838
 
-sdk/RevoEX/nwc24/NWC24Download.c:
+nwc24.a/NWC24Download.o:
 	.text       start:0x80B0479C end:0x80B05010
 	.data       start:0x80C77198 end:0x80C771B8
 	.sdata      start:0x80C79890 end:0x80C79898
 
-sdk/RevoEX/nwc24/NWC24System.c:
+nwc24.a/NWC24System.o:
 	.text       start:0x80B05010 end:0x80B051A0
 	.data       start:0x80C771B8 end:0x80C77200
 	.sdata      start:0x80C79898 end:0x80C798A0
 	.sbss       start:0x80C7B838 end:0x80C7B848
 	.bss        start:0x80DA14E0 end:0x80DA1540
 
-sdk/RevoEX/so/SOCommon.c:
+so.a/SOCommon.o:
 	.text       start:0x80B051A0 end:0x80B06238
 	.data       start:0x80C77200 end:0x80C773E0
 	.sdata      start:0x80C798A0 end:0x80C798A8
 	.sbss       start:0x80C7B848 end:0x80C7B858
 	.bss        start:0x80DA1540 end:0x80DA1560
 
-sdk/RevoEX/so/SOBasic.c:
+so.a/SOBasic.o:
 	.text       start:0x80B06238 end:0x80B074D0
 	.data       start:0x80C773E0 end:0x80C77430
 	.sdata      start:0x80C798A8 end:0x80C798B0
 	.sbss       start:0x80C7B858 end:0x80C7B860
 
-sdk/RevoEX/so/SOInformation.c:
+so.a/SOInformation.o:
 	.text       start:0x80B074D0 end:0x80B079D0
 
-sdk/RevoEX/so/SOOption.c:
+so.a/SOOption.o:
 	.text       start:0x80B079D0 end:0x80B07CB0
 
-sdk/RevoEX/ssl/ssl_api.c:
+ssl.a/ssl_api.o:
 	.text       start:0x80B07CB0 end:0x80B08AE4
 	.data       start:0x80C77430 end:0x80C774E0
 	.sdata      start:0x80C798B0 end:0x80C798B8
 	.sbss       start:0x80C7B860 end:0x80C7B870
 	.bss        start:0x80DA1560 end:0x80DA4580
 
-sdk/RevoEX/ssl/ssl_mutex.c:
+ssl.a/ssl_mutex.o:
 	.text       start:0x80B08AE4 end:0x80B08AF0
 
-sdk/RVL_SDK/vf/pf_clib.c:
+vf.a/pf_clib.o:
 	.text       start:0x80B08AF0 end:0x80B08E20
 
-sdk/RVL_SDK/vf/pf_code.c:
+vf.a/pf_code.o:
 	.text       start:0x80B08E20 end:0x80B08E40
 	.rodata     start:0x80B45D38 end:0x80B45D98
 
-sdk/RVL_SDK/vf/pf_service.c:
+vf.a/pf_service.o:
 	.text       start:0x80B08E40 end:0x80B08F60
 
-sdk/RVL_SDK/vf/pf_str.c:
+vf.a/pf_str.o:
 	.text       start:0x80B08F60 end:0x80B094D0
 
-sdk/RVL_SDK/vf/pf_w_clib.c:
+vf.a/pf_w_clib.o:
 	.text       start:0x80B094D0 end:0x80B09580
 
-sdk/RVL_SDK/vf/pf_driver.c:
+vf.a/pf_driver.o:
 	.text       start:0x80B09580 end:0x80B0A0C0
 
-sdk/RVL_SDK/vf/pdm_bpb.c:
+vf.a/pdm_bpb.o:
 	.text       start:0x80B0A0C0 end:0x80B0AA20
 
-sdk/RVL_SDK/vf/pdm_disk.c:
+vf.a/pdm_disk.o:
 	.text       start:0x80B0AA20 end:0x80B0BFC0
 
-sdk/RVL_SDK/vf/pdm_partition.c:
+vf.a/pdm_partition.o:
 	.text       start:0x80B0BFC0 end:0x80B0D830
 
-sdk/RVL_SDK/vf/pdm_mbr.c:
+vf.a/pdm_mbr.o:
 	.text       start:0x80B0D830 end:0x80B0DE00
 
-sdk/RVL_SDK/vf/pdm_dskmng.c:
+vf.a/pdm_dskmng.o:
 	.text       start:0x80B0DE00 end:0x80B0E040
 	.bss        start:0x80DA4580 end:0x80DA5150
 
-sdk/RVL_SDK/vf/pf_cache.c:
+vf.a/pf_cache.o:
 	.text       start:0x80B0E040 end:0x80B0FC30
 
-sdk/RVL_SDK/vf/pf_cluster.c:
+vf.a/pf_cluster.o:
 	.text       start:0x80B0FC30 end:0x80B10380
 
-sdk/RVL_SDK/vf/pf_dir.c:
+vf.a/pf_dir.o:
 	.text       start:0x80B10380 end:0x80B11640
 	.sdata      start:0x80C798B8 end:0x80C798C8
 
-sdk/RVL_SDK/vf/pf_entry.c:
+vf.a/pf_entry.o:
 	.text       start:0x80B11640 end:0x80B132A0
 	.data       start:0x80C774E0 end:0x80C774F0
 	.sdata2     start:0x80C7C490 end:0x80C7C498
 
-sdk/RVL_SDK/vf/pf_entry_iterator.c:
+vf.a/pf_entry_iterator.o:
 	.text       start:0x80B132A0 end:0x80B153A0
 	.sdata      start:0x80C798C8 end:0x80C798F0
 
-sdk/RVL_SDK/vf/pf_fat.c:
+vf.a/pf_fat.o:
 	.text       start:0x80B153A0 end:0x80B18370
 	.rodata     start:0x80B45D98 end:0x80B45DD8
 
-sdk/RVL_SDK/vf/pf_fat12.c:
+vf.a/pf_fat12.o:
 	.text       start:0x80B18370 end:0x80B18EA0
 
-sdk/RVL_SDK/vf/pf_fat16.c:
+vf.a/pf_fat16.o:
 	.text       start:0x80B18EA0 end:0x80B19420
 
-sdk/RVL_SDK/vf/pf_fat32.c:
+vf.a/pf_fat32.o:
 	.text       start:0x80B19420 end:0x80B19A70
 
-sdk/RVL_SDK/vf/pf_fatfs.c:
+vf.a/pf_fatfs.o:
 	.text       start:0x80B19A70 end:0x80B19A80
 
-sdk/RVL_SDK/vf/pf_file.c:
+vf.a/pf_file.o:
 	.text       start:0x80B19A80 end:0x80B1D450
 
-sdk/RVL_SDK/vf/pf_path.c:
+vf.a/pf_path.o:
 	.text       start:0x80B1D450 end:0x80B1FE40
 	.sdata      start:0x80C798F0 end:0x80C79920
 	.sdata2     start:0x80C7C498 end:0x80C7C4A8
 
-sdk/RVL_SDK/vf/pf_sector.c:
+vf.a/pf_sector.o:
 	.text       start:0x80B1FE40 end:0x80B20700
 
-sdk/RVL_SDK/vf/pf_volume.c:
+vf.a/pf_volume.o:
 	.text       start:0x80B20700 end:0x80B22490
 	.bss        start:0x80DA5150 end:0x80DCCEA0
 
-sdk/RVL_SDK/vf/pf_cp932.c:
+vf.a/pf_cp932.o:
 	.text       start:0x80B22490 end:0x80B22990
 	.rodata     start:0x80B45DD8 end:0x80B4A050
 
-sdk/RVL_SDK/vf/pf_api_util.c:
+vf.a/pf_api_util.o:
 	.text       start:0x80B22990 end:0x80B22AF0
 	.data       start:0x80C774F0 end:0x80C77590
 
-sdk/RVL_SDK/vf/pf_attach.c:
+vf.a/pf_attach.o:
 	.text       start:0x80B22AF0 end:0x80B22B90
 
-sdk/RVL_SDK/vf/pf_chdir.c:
+vf.a/pf_chdir.o:
 	.text       start:0x80B22B90 end:0x80B22BE0
 
-sdk/RVL_SDK/vf/pf_create.c:
+vf.a/pf_create.o:
 	.text       start:0x80B22BE0 end:0x80B22C50
 
-sdk/RVL_SDK/vf/pf_detach.c:
+vf.a/pf_detach.o:
 	.text       start:0x80B22C50 end:0x80B22C80
 
-sdk/RVL_SDK/vf/pf_errnum.c:
+vf.a/pf_errnum.o:
 	.text       start:0x80B22C80 end:0x80B22CB0
 
-sdk/RVL_SDK/vf/pf_fclose.c:
+vf.a/pf_fclose.o:
 	.text       start:0x80B22CB0 end:0x80B22CE0
 
-sdk/RVL_SDK/vf/pf_finfo.c:
+vf.a/pf_finfo.o:
 	.text       start:0x80B22CE0 end:0x80B22D10
 
-sdk/RVL_SDK/vf/pf_fopen.c:
+vf.a/pf_fopen.o:
 	.text       start:0x80B22D10 end:0x80B22DC0
 
-sdk/RVL_SDK/vf/pf_format.c:
+vf.a/pf_format.o:
 	.text       start:0x80B22DC0 end:0x80B22DF0
 
-sdk/RVL_SDK/vf/pf_fread.c:
+vf.a/pf_fread.o:
 	.text       start:0x80B22DF0 end:0x80B22E20
 
-sdk/RVL_SDK/vf/pf_fseek.c:
+vf.a/pf_fseek.o:
 	.text       start:0x80B22E20 end:0x80B22E50
 
-sdk/RVL_SDK/vf/pf_fsfirst.c:
+vf.a/pf_fsfirst.o:
 	.text       start:0x80B22E50 end:0x80B22ED0
 
-sdk/RVL_SDK/vf/pf_fsnext.c:
+vf.a/pf_fsnext.o:
 	.text       start:0x80B22ED0 end:0x80B22F00
 
-sdk/RVL_SDK/vf/pf_fstat.c:
+vf.a/pf_fstat.o:
 	.text       start:0x80B22F00 end:0x80B22F60
 
-sdk/RVL_SDK/vf/pf_fsync.c:
+vf.a/pf_fsync.o:
 	.text       start:0x80B22F60 end:0x80B22F90
 
-sdk/RVL_SDK/vf/pf_fwrite.c:
+vf.a/pf_fwrite.o:
 	.text       start:0x80B22F90 end:0x80B22FC0
 
-sdk/RVL_SDK/vf/pf_getdev.c:
+vf.a/pf_getdev.o:
 	.text       start:0x80B22FC0 end:0x80B22FF0
 
-sdk/RVL_SDK/vf/pf_init_prfile2.c:
+vf.a/pf_init_prfile2.o:
 	.text       start:0x80B22FF0 end:0x80B23030
 
-sdk/RVL_SDK/vf/pf_mkdir.c:
+vf.a/pf_mkdir.o:
 	.text       start:0x80B23030 end:0x80B23080
 
-sdk/RVL_SDK/vf/pf_remove.c:
+vf.a/pf_remove.o:
 	.text       start:0x80B23080 end:0x80B230D0
 
-sdk/RVL_SDK/vf/pf_unmount.c:
+vf.a/pf_unmount.o:
 	.text       start:0x80B230D0 end:0x80B23100
 
-sdk/RVL_SDK/vf/pf_filelock.c:
+vf.a/pf_filelock.o:
 	.text       start:0x80B23100 end:0x80B23120
 
-sdk/RVL_SDK/vf/pf_system.c:
+vf.a/pf_system.o:
 	.text       start:0x80B23120 end:0x80B231B0
 	.sbss       start:0x80C7B870 end:0x80C7B878
 
-sdk/RVL_SDK/vf/d_vf.c:
+vf.a/d_vf.o:
 	.text       start:0x80B231B0 end:0x80B24400
 	.rodata     start:0x80B4A050 end:0x80B4A120
 	.data       start:0x80C77590 end:0x80C77960
@@ -9372,125 +9372,125 @@ sdk/RVL_SDK/vf/d_vf.c:
 	.sbss       start:0x80C7B878 end:0x80C7B880
 	.bss        start:0x80DCCEA0 end:0x80DCCEB8
 
-sdk/RVL_SDK/vf/d_vf_sys.c:
+vf.a/d_vf_sys.o:
 	.text       start:0x80B24400 end:0x80B27400
 	.data       start:0x80C77960 end:0x80C77970
 	.sdata      start:0x80C79930 end:0x80C79938
 	.sbss       start:0x80C7B880 end:0x80C7B898
 	.bss        start:0x80DCCEB8 end:0x80DCCFF0
 
-sdk/RVL_SDK/vf/d_hash.c:
+vf.a/d_hash.o:
 	.text       start:0x80B27400 end:0x80B27AA0
 	.bss        start:0x80DCCFF0 end:0x80DCD230
 
-sdk/RVL_SDK/vf/d_time.c:
+vf.a/d_time.o:
 	.text       start:0x80B27AA0 end:0x80B27E70
 	.rodata     start:0x80B4A120 end:0x80B4A150
 
-sdk/RVL_SDK/vf/d_common.c:
+vf.a/d_common.o:
 	.text       start:0x80B27E70 end:0x80B28B70
 	.bss        start:0x80DCD230 end:0x80DCD438
 
-sdk/RVL_SDK/vf/nand_drv.c:
+vf.a/nand_drv.o:
 	.text       start:0x80B28B70 end:0x80B2B840
 	.rodata     start:0x80B4A150 end:0x80B4A170
 	.sbss       start:0x80C7B898 end:0x80C7B8A0
 	.bss        start:0x80DCD438 end:0x80DCD5E0
 
-sdk/RVL_SDK/vf/sd_drv.c:
+vf.a/sd_drv.o:
 	.text       start:0x80B2B840 end:0x80B2B850
 
-sdk/DWC/dwc_common/dwc_base64.c:
+dwc_common.a/dwc_base64.o:
 	.text       start:0x80B2B850 end:0x80B2BBC0
 	.data       start:0x80C77970 end:0x80C779B8
 	.sdata      start:0x80C79938 end:0x80C79940
 
-sdk/DWC/dwc_common/dwc_error.c:
+dwc_common.a/dwc_error.o:
 	.text       start:0x80B2BBC0 end:0x80B2BCD0
 	.data       start:0x80C779B8 end:0x80C77A30
 	.sbss       start:0x80C7B8A0 end:0x80C7B8A8
 
-sdk/DWC/dwc_common/dwc_init.c:
+dwc_common.a/dwc_init.o:
 	.text       start:0x80B2BCD0 end:0x80B2C020
 	.data       start:0x80C77A30 end:0x80C77CE8
 	.sdata      start:0x80C79940 end:0x80C79968
 	.sbss       start:0x80C7B8A8 end:0x80C7B8B0
 
-sdk/DWC/dwc_common/dwc_memfunc.c:
+dwc_common.a/dwc_memfunc.o:
 	.text       start:0x80B2C020 end:0x80B2C170
 	.data       start:0x80C77CE8 end:0x80C77D40
 	.sbss       start:0x80C7B8B0 end:0x80C7B8B8
 
-sdk/DWC/dwc_common/dwc_report.c:
+dwc_common.a/dwc_report.o:
 	.text       start:0x80B2C170 end:0x80B2C4D0
 	.data       start:0x80C77D40 end:0x80C77EC0
 	.sbss       start:0x80C7B8B8 end:0x80C7B8C0
 
-sdk/DWC/dwc_nonport/dwc_nonport.c:
+dwc_nonport.a/dwc_nonport.o:
 	.text       start:0x80B2C4D0 end:0x80B2CFE0
 	.data       start:0x80C77EC0 end:0x80C77F50
 	.sbss       start:0x80C7B8C0 end:0x80C7B8D0
 
-sdk/DWC/dwcsec_auth/dwc_auth_interface.c:
+dwcsec_auth.a/dwc_auth_interface.o:
 	.text       start:0x80B2CFE0 end:0x80B2F440
 	.data       start:0x80C77F50 end:0x80C78758
 	.sdata      start:0x80C79968 end:0x80C79AA0
 	.sbss       start:0x80C7B8D0 end:0x80C7B8E0
 	.bss        start:0x80DCD5E0 end:0x80DCDA98
 
-sdk/DWC/dwcsec_nas/dwc_naslogin.c:
+dwcsec_nas.a/dwc_naslogin.o:
 	.text       start:0x80B2F440 end:0x80B2F560
 	.sdata      start:0x80C79AA0 end:0x80C79AA8
 	.sbss       start:0x80C7B8E0 end:0x80C7B8E8
 
-sdk/DWC/dwcsec_prof/dwc_prof.c:
+dwcsec_prof.a/dwc_prof.o:
 	.text       start:0x80B2F560 end:0x80B2FC30
 	.data       start:0x80C78758 end:0x80C78808
 	.bss        start:0x80DCDA98 end:0x80DCDAC8
 
-sdk/DWC/dwcsec_svl/dwc_svl.c:
+dwcsec_svl.a/dwc_svl.o:
 	.text       start:0x80B2FC30 end:0x80B2FD80
 	.data       start:0x80C78808 end:0x80C78828
 	.sbss       start:0x80C7B8E8 end:0x80C7B8F0
 
-sdk/RVL_SDK/usbcmn/puh_ker_mem.c:
+usbcmn.a/puh_ker_mem.o:
 	.text       start:0x80B2FD80 end:0x80B2FDF0
 
-sdk/RVL_SDK/usbcmn/puh_ker_msg.c:
+usbcmn.a/puh_ker_msg.o:
 	.text       start:0x80B2FDF0 end:0x80B2FE80
 	.bss        start:0x80DCDAC8 end:0x80DCDAE0
 
-sdk/RVL_SDK/usbcmn/puh_ker_sem.c:
+usbcmn.a/puh_ker_sem.o:
 	.text       start:0x80B2FE80 end:0x80B30180
 	.sbss       start:0x80C7B8F0 end:0x80C7B8F8
 	.bss        start:0x80DCDAE0 end:0x80DCDC20
 
-sdk/RVL_SDK/sdi/sdi_api.c:
+sdi.a/sdi_api.o:
 	.text       start:0x80B30180 end:0x80B31730
 	.data       start:0x80C78828 end:0x80C78878
 	.sdata      start:0x80C79AA8 end:0x80C79AB0
 	.sbss       start:0x80C7B8F8 end:0x80C7B918
 	.bss        start:0x80DCDC20 end:0x80DCDCA0
 
-sdk/RVL_SDK/usbmic/usbmic.c:
+usbmic.a/usbmic.o:
 	.text       start:0x80B31730 end:0x80B32E10
 	.rodata     start:0x80B4A170 end:0x80B4A1A0
 	.data       start:0x80C78878 end:0x80C788D8
 	.sdata      start:0x80C79AB0 end:0x80C79ABC
 	.bss        start:0x80DCDCA0 end:0x80DCDF60
 
-sdk/RVL_SDK/usbmic/mic.c:
+usbmic.a/mic.o:
 	.text       start:0x80B32E10 end:0x80B337A0
 	.rodata     start:0x80B4A1A0 end:0x80B4A1CC
 
-sdk/RVL_SDK/usbmic/ringbuffer.c:
+usbmic.a/ringbuffer.o:
 	.text       start:0x80B337A0 end:0x80B33E20
 
-sdk/RVL_SDK/usbmic/usbrequest.c:
+usbmic.a/usbrequest.o:
 	.text       start:0x80B33E20 end:0x80B34450
 
-sdk/RVL_SDK/usbmic/dpc.c:
+usbmic.a/dpc.o:
 	.text       start:0x80B34450 end:0x80B34610
 
-sdk/RVL_SDK/usbmic/usbhelpers.c:
+usbmic.a/usbhelpers.o:
 	.text       start:0x80B34610 end:0x80B3480C

--- a/tools/splits_fixup.py
+++ b/tools/splits_fixup.py
@@ -1,0 +1,148 @@
+import os
+import re
+from pathlib import *
+
+# Converts split paths from archive/object paths to source paths.
+# Various fixups are applied to organize things to our liking.
+
+# Finds .o/.obj files and splits off the file extension
+obj_regex = re.compile(r"(.*)\.ob?j?")
+
+# Determines if an object is within an archive,
+# and splits the archive name from the rest of the path
+archive_regex = re.compile(r"(.*?)\.a[\\\/](.*)")
+
+# Cleans up RB3 project paths
+# Removes "hproj" and "wii_release" path components
+band_regex = re.compile(r"hproj[\\\/]band3_wii[\\\/](.*)[\\\/]wii_release[\\\/](.*)")
+
+# RVL SDK archives
+# Most of these names are sourced from various other places in doldecomp
+# Others are present in the RB3 debug map
+rvl_names = [
+    "ai", "ar", "aralt", "arc", "arq", "ax", "axfx",
+    "base", "bte",
+    "card", "cnt", "cx",
+    "darch", "db", "dsp", "dvd", "dwc",
+    "eart", "enc", "esp", "euart", "exi",
+    "fs",
+    "gba", "gd", "gf", "gx",
+    "hbm", "hid",
+    "ipc",
+    "kbd", "kpad", "kpr",
+    "mem", "mix", "mtx",
+    "nand",
+    "os",
+    "pad",
+    "rso", "rvl",
+    "sc", "scutil", "sdi", "si", "socket",
+    "thp", "tpl",
+    "usb", "usbcmn", "usbmic",
+    "vf", "vi",
+    "wenc", "wpad", "wpaddrm", "wpadgtr", "wud",
+]
+
+# RevoEX archives
+# https://discord.com/channels/727908905392275526/1050967074090004500/1208698417853890580
+revo_ex_names = [
+    "mp", "mpdl", "mpds",
+    "ncd", "net", "nhttp", "ntr", "nwc24",
+    "so", "ssl",
+    "vf",
+    "wd",
+]
+
+# DWC archives
+# https://discord.com/channels/727908905392275526/1050967074090004500/1208699973156347955
+dwc_names = [
+    "dwc_common",
+    "dwc_nonport",
+    "dwcsec_auth",
+    "dwcsec_nas",
+    "dwcsec_prof",
+    "dwcsec_svl",
+]
+
+# Other SDK libs
+sdk_c_names = [
+    "NdevExi2A",
+    "mobiclip",
+]
+sdk_cpp_names = [
+    "ec",
+]
+
+# Make sure this script still works if the working directory is the `tools` folder
+base_path = os.curdir
+if not os.path.exists(os.path.join(base_path, "src")):
+    base_path = os.pardir
+
+# Load original generated splits file
+splits_path = os.path.join(base_path, "config", "SZBE69_B8", "splits.txt")
+with open(splits_path, "r") as symbols_file:
+    symbols_text = symbols_file.read()
+
+# Search splits
+new_symbols_text: list[str] = []
+previous_match_end = 0
+for obj_match in obj_regex.finditer(symbols_text):
+    obj_path = obj_match.group(1).replace("src/", "").replace("Src/", "")
+    path_range = range(obj_match.start(), obj_match.end())
+
+    # Check if the object is contained in an archive
+    lib_match = archive_regex.match(obj_path)
+    if lib_match is None:
+        # Assume C++ if not, and place in top-level directory
+        obj_path = obj_path + ".cpp"
+    else:
+        lib_name = lib_match.group(1)
+        lib_path = lib_match.group(2)
+
+        # Determine which library this is and how to organize it
+        if lib_name == "lib":
+            # RB3 code, determine folders and put them in top-level directory
+            band_match = band_regex.match(lib_path)
+            obj_path = band_match.group(1) + "/" + band_match.group(2) + ".cpp"
+        elif lib_name == "MSL_C.PPCEABI.bare.H":
+            # Results in sdk/PowerPC_EABI_Support/MSL_C/...
+            obj_path = "sdk/" + lib_path.removeprefix("Products/Eppc/TempBuildMSL/") + ".c"
+        elif lib_name == "MSL_C++.PPCEABI.bare.H":
+            # Results in sdk/PowerPC_EABI_Support/MSL_C++/...
+            obj_path = "sdk/" + lib_path.removeprefix("Products/Eppc/TempBuildMSL/") + ".cpp"
+        elif lib_name == "Runtime.PPCEABI.H":
+            obj_path = f"sdk/PowerPC_EABI_Support/Runtime/{lib_path}.cpp"
+        elif lib_name == "TRK_Hollywood_Revolution":
+            obj_path = f"sdk/PowerPC_EABI_Support/MetroTRK/" + lib_path.removeprefix("Data/wiiProj/metrotrk/metrotrk/") + ".c"
+        elif lib_name in sdk_c_names:
+            obj_path = f"sdk/{lib_name}/{lib_path}.c"
+        elif lib_name in sdk_cpp_names:
+            obj_path = f"sdk/{lib_name}/{lib_path}.cpp"
+        else:
+            # RVL SDK and related libs, check as lowercase
+            lib_name_lower = lib_name.lower()
+            if lib_name_lower in rvl_names:
+                obj_path = f"sdk/RVL_SDK/{lib_name}/{lib_path}.c"
+            elif lib_name_lower in revo_ex_names:
+                obj_path = f"sdk/RevoEX/{lib_name}/{lib_path}.c"
+            elif lib_name_lower in dwc_names:
+                obj_path = f"sdk/DWC/{lib_name}/{lib_path}.c"
+            # For documentation purposes; not necessary for us
+            # elif lib_name_lower == "rfl":
+            #   obj_path = f"sdk/RVLFaceLib/{lib_path}.c"
+
+            # Undetermined source, place into lib/ directory
+            else:
+                obj_path = f"lib/{lib_name}/{lib_path}.c"
+
+    # Modify splits to use the determined path
+    new_symbols_text.append(symbols_text[previous_match_end:obj_match.start()])
+    new_symbols_text.append(obj_path)
+    previous_match_end = obj_match.end()
+
+# Remaining file text
+new_symbols_text.append(symbols_text[previous_match_end:])
+
+# Write new splits file
+with open(splits_path, "w") as symbols_file:
+    for piece in new_symbols_text:
+        symbols_file.write(piece)

--- a/tools/splits_generate_sources.py
+++ b/tools/splits_generate_sources.py
@@ -1,0 +1,32 @@
+import os
+import re
+from pathlib import *
+
+# Finds .c/.cpp files and splits off the file extension
+obj_regex = re.compile(r"(.*\.cp?p?):")
+
+# Make sure this script still works if the working directory is the `tools` folder
+base_path = os.curdir
+if not os.path.exists(os.path.join(base_path, "src")):
+    base_path = os.pardir
+
+# Load splits file
+splits_path = os.path.join(base_path, "config", "SZBE69_B8", "splits.txt")
+with open(splits_path, "r") as symbols_file:
+    symbols_text = symbols_file.read()
+
+# Find source file names
+for obj_match in obj_regex.finditer(symbols_text):
+    obj_path = obj_match.group(1)
+    src_path = os.path.join(base_path, "src_todo", obj_path)
+
+    # Check if this file exists in the real source directory
+    if os.path.exists(os.path.join(base_path, "src", obj_path)):
+        if os.path.exists(src_path):
+            os.remove(src_path)
+        continue
+
+    # Generate file for this split
+    os.makedirs(os.path.dirname(src_path), exist_ok = True)
+    with open(src_path, "w") as symbols_file:
+        symbols_file.write("\n")


### PR DESCRIPTION
The original splits file has been preserved in case future structure changes need to be made, though it shouldn't be too difficult to make those changes manually if needed.

The source file generation script outputs the following structure:

- band3
- lib
  - binkwii
- network
- sdk
  - DWC
  - ec
  - NdevExi2A
  - PowerPC_EABI_Support
    - MetroTRK
    - MSL
      - MSL_C
      - MSL_C++
    - Runtime
  - RevoEX
  - RVL_SDK
- system

These loose objects will go into the top-level directory:

- App.cpp
- BandOffline.cpp
- BudgetScreen.cpp
- ChecksumData_wii.cpp
- keygen_wii.cpp
- Main.cpp