### PR TITLE
Rework cflags system and make objects be specified per-version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -103,5 +103,13 @@
   "C/C++ Include Guard.Auto Update Path Blocklist": [
     "include/zlib"
   ],
-  "search.useIgnoreFiles": false
+  "search.useIgnoreFiles": false,
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "config/**/flags.json"
+      ],
+      "url": "./doc/flags_schema.json"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -110,6 +110,12 @@
         "config/**/flags.json"
       ],
       "url": "./doc/flags_schema.json"
+    },
+    {
+      "fileMatch": [
+        "config/**/objects.json"
+      ],
+      "url": "./doc/objects_schema.json"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,8 +33,18 @@
       "command": "ninja",
       "group": {
         "kind": "build",
-        "isDefault": false
-      }
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "ninja diff",
+      "type": "shell",
+      "command": "ninja",
+      "args": [
+        "diff"
+      ],
+      "problemMatcher": []
     },
     {
       "label": "all_source",
@@ -59,10 +69,7 @@
       "problemMatcher": {
         "base": "$gcc"
       },
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      }
+      "group": "build"
     },
     {
       "label": "decompctx (current file)",

--- a/config/SZBE69/flags.json
+++ b/config/SZBE69/flags.json
@@ -67,11 +67,11 @@
             ]
         },
         "system": {
-            "base": "rb3",
+            "base": "band3",
             "flags": []
         },
         "network": {
-            "base": "rb3",
+            "base": "band3",
             "flags": []
         },
         "json_c": {

--- a/config/SZBE69/flags.json
+++ b/config/SZBE69/flags.json
@@ -6,34 +6,39 @@
         "-code_merging safe,aggressive"
     ],
     "cflags": {
-        "runtime": {
-            "base": null,
-            "flags": [
-                "-use_lmw_stmw on",
-                "-str reuse,pool,readonly",
-                "-common off",
-                "-inline auto"
-            ]
-        },
         "base": {
             "base": null,
             "flags": [
                 "-nodefaults",
+                "-nosyspath",
+                "-gccinc",
+
+                "-maxerrors 1",
+
                 "-proc gekko",
                 "-align powerpc",
                 "-enum int",
                 "-fp hardware",
-                "-Cpp_exceptions off",
-                "-O4,s",
+
                 "-pragma \"cats off\"",
-                "-pragma \"warn_notinlined off\"",
-                "-maxerrors 1",
-                "-nosyspath",
-                "-fp_contract on",
-                "-str reuse,pool",
-                "-func_align 4",
-                "-gccinc",
-                "-d NDEBUG"
+                "-pragma \"warn_notinlined off\""
+            ]
+        },
+        "runtime": {
+            "base": "base",
+            "flags": [
+                "-str reuse,pool,readonly",
+                "-use_lmw_stmw on",
+                "-common off",
+
+                "-O4,p",
+                "-inline auto"
+            ]
+        },
+        "rvl_sdk": {
+            "base": "base",
+            "flags": [
+                "-func_align 16"
             ]
         },
         "rb3": {
@@ -41,15 +46,19 @@
             "flags": [
                 "-sdata 2",
                 "-sdata2 2",
+                "-str reuse,pool",
+                "-func_align 4",
+
+                "-fp_contract on",
                 "-pragma \"merge_float_consts on\"",
+
                 "-RTTI on",
-                "-inline off"
-            ]
-        },
-        "sdk": {
-            "base": "base",
-            "flags": [
-                "-func_align 16"
+                "-Cpp_exceptions off",
+
+                "-O4,s",
+                "-inline off",
+
+                "-d NDEBUG"
             ]
         }
     }

--- a/config/SZBE69/flags.json
+++ b/config/SZBE69/flags.json
@@ -6,39 +6,51 @@
         "-code_merging safe,aggressive"
     ],
     "cflags": {
-        "runtime": [
-            "-use_lmw_stmw on",
-            "-str reuse,pool,readonly",
-            "-common off",
-            "-inline auto"
-        ],
-        "base": [
-            "-nodefaults",
-            "-proc gekko",
-            "-align powerpc",
-            "-enum int",
-            "-fp hardware",
-            "-Cpp_exceptions off",
-            "-O4,s",
-            "-pragma \"cats off\"",
-            "-pragma \"warn_notinlined off\"",
-            "-maxerrors 1",
-            "-nosyspath",
-            "-fp_contract on",
-            "-str reuse,pool",
-            "-func_align 4",
-            "-gccinc",
-            "-d NDEBUG"
-        ],
-        "rb3": [
-            "-sdata 2",
-            "-sdata2 2",
-            "-pragma \"merge_float_consts on\"",
-            "-RTTI on",
-            "-inline off"
-        ],
-        "sdk": [
-            "-func_align 16"
-        ]
+        "runtime": {
+            "base": null,
+            "flags": [
+                "-use_lmw_stmw on",
+                "-str reuse,pool,readonly",
+                "-common off",
+                "-inline auto"
+            ]
+        },
+        "base": {
+            "base": null,
+            "flags": [
+                "-nodefaults",
+                "-proc gekko",
+                "-align powerpc",
+                "-enum int",
+                "-fp hardware",
+                "-Cpp_exceptions off",
+                "-O4,s",
+                "-pragma \"cats off\"",
+                "-pragma \"warn_notinlined off\"",
+                "-maxerrors 1",
+                "-nosyspath",
+                "-fp_contract on",
+                "-str reuse,pool",
+                "-func_align 4",
+                "-gccinc",
+                "-d NDEBUG"
+            ]
+        },
+        "rb3": {
+            "base": "base",
+            "flags": [
+                "-sdata 2",
+                "-sdata2 2",
+                "-pragma \"merge_float_consts on\"",
+                "-RTTI on",
+                "-inline off"
+            ]
+        },
+        "sdk": {
+            "base": "base",
+            "flags": [
+                "-func_align 16"
+            ]
+        }
     }
 }

--- a/config/SZBE69/flags.json
+++ b/config/SZBE69/flags.json
@@ -21,16 +21,23 @@
                 "-fp hardware",
 
                 "-pragma \"cats off\"",
-                "-pragma \"warn_notinlined off\""
+                "-pragma \"warn_notinlined off\"",
+
+                "-d NDEBUG"
             ]
         },
         "runtime": {
             "base": "base",
             "flags": [
+                "-sdata 2",
+                "-sdata2 2",
                 "-str reuse,pool,readonly",
+                "-pragma \"merge_float_consts on\"",
+
                 "-use_lmw_stmw on",
                 "-common off",
 
+                "-lang=c99",
                 "-O4,p",
                 "-inline auto"
             ]
@@ -41,7 +48,7 @@
                 "-func_align 16"
             ]
         },
-        "rb3": {
+        "band3": {
             "base": "base",
             "flags": [
                 "-sdata 2",
@@ -56,9 +63,66 @@
                 "-Cpp_exceptions off",
 
                 "-O4,s",
-                "-inline off",
+                "-inline off"
+            ]
+        },
+        "system": {
+            "base": "rb3",
+            "flags": []
+        },
+        "network": {
+            "base": "rb3",
+            "flags": []
+        },
+        "json_c": {
+            "base": "base",
+            "flags": [
+                "-sdata 2",
+                "-sdata2 2",
+                "-pragma \"merge_float_consts on\"",
 
-                "-d NDEBUG"
+                "-lang=c99",
+                "-inline auto"
+            ]
+        },
+        "zlib": {
+            "base": "base",
+            "flags": [
+                "-sdata 2",
+                "-sdata2 2",
+                "-pool on",
+                "-pragma \"merge_float_consts on\"",
+
+                "-lang=c99",
+                "-inline auto"
+            ]
+        },
+        "libtomcrypt": {
+            "base": "zlib",
+            "flags": []
+        },
+        "speex": {
+            "base": "zlib",
+            "flags": []
+        },
+        "libogg": {
+            "base": "zlib",
+            "flags": []
+        },
+        "vorbis": {
+            "base": "zlib",
+            "flags": []
+        },
+        "bt": {
+            "base": "base",
+            "flags": [
+                "-sdata 2",
+                "-sdata2 2",
+                "-str reuse,pool",
+                "-pragma \"merge_float_consts on\"",
+
+                "-lang=c99",
+                "-inline auto"
             ]
         }
     }

--- a/config/SZBE69/objects.json
+++ b/config/SZBE69/objects.json
@@ -1,0 +1,12 @@
+{
+    "band3": {
+        "mw_version": "Wii/1.3",
+        "cflags": "band3",
+        "objects": {}
+    },
+    "system": {
+        "mw_version": "Wii/1.3",
+        "cflags": "system",
+        "objects": {}
+    }
+}

--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -5,47 +5,49 @@
         "-listclosure"
     ],
     "cflags": {
-        "runtime": [
-            "-use_lmw_stmw on",
-            "-str reuse,pool,readonly",
-            "-common off",
-            "-inline auto"
-        ],
-        "base": [
-            "-nodefaults",
-            "-proc gekko",
-            "-align powerpc",
-            "-enum int",
-            "-fp hardware",
-            "-Cpp_exceptions off",
-            "-O4,p",
-            "-pragma \"cats off\"",
-            "-pragma \"warn_notinlined off\"",
-            "-maxerrors 1",
-            "-nosyspath",
-            "-fp_contract on",
-            "-str reuse,pool",
-            "-gccinc"
-        ],
-        "rb3": [
-            "-sdata 2",
-            "-sdata2 2",
-            "-pragma \"merge_float_consts on\"",
-            "-RTTI on",
-            "-inline noauto"
-        ],
-        "sdk": [
-            "-func_align 16"
-        ],
-        "c": [
-            "-lang=c99",
-            "-sdata 2",
-            "-sdata2 2",
-            "-pragma \"merge_float_consts on\"",
-            "-inline auto"
-        ],
-        "zlib": [
-            "-pool on"
-        ]
+        "runtime": {
+            "base": null,
+            "flags": [
+                "-use_lmw_stmw on",
+                "-str reuse,pool,readonly",
+                "-common off",
+                "-inline auto"
+            ]
+        },
+        "base": {
+            "base": null,
+            "flags": [
+                "-nodefaults",
+                "-proc gekko",
+                "-align powerpc",
+                "-enum int",
+                "-fp hardware",
+                "-Cpp_exceptions off",
+                "-O4,p",
+                "-pragma \"cats off\"",
+                "-pragma \"warn_notinlined off\"",
+                "-maxerrors 1",
+                "-nosyspath",
+                "-fp_contract on",
+                "-str reuse,pool",
+                "-gccinc"
+            ]
+        },
+        "rb3": {
+            "base": "base",
+            "flags": [
+                "-sdata 2",
+                "-sdata2 2",
+                "-pragma \"merge_float_consts on\"",
+                "-RTTI on",
+                "-inline noauto"
+            ]
+        },
+        "sdk": {
+            "base": "base",
+            "flags": [
+                "-func_align 16"
+            ]
+        }
     }
 }

--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -5,32 +5,39 @@
         "-listclosure"
     ],
     "cflags": {
-        "runtime": {
-            "base": null,
-            "flags": [
-                "-use_lmw_stmw on",
-                "-str reuse,pool,readonly",
-                "-common off",
-                "-inline auto"
-            ]
-        },
         "base": {
             "base": null,
             "flags": [
                 "-nodefaults",
+                "-nosyspath",
+                "-gccinc",
+
+                "-maxerrors 1",
+
                 "-proc gekko",
                 "-align powerpc",
                 "-enum int",
                 "-fp hardware",
-                "-Cpp_exceptions off",
-                "-O4,p",
+
                 "-pragma \"cats off\"",
-                "-pragma \"warn_notinlined off\"",
-                "-maxerrors 1",
-                "-nosyspath",
-                "-fp_contract on",
-                "-str reuse,pool",
-                "-gccinc"
+                "-pragma \"warn_notinlined off\""
+            ]
+        },
+        "runtime": {
+            "base": "base",
+            "flags": [
+                "-str reuse,pool,readonly",
+                "-use_lmw_stmw on",
+                "-common off",
+
+                "-O4,p",
+                "-inline auto"
+            ]
+        },
+        "rvl_sdk": {
+            "base": "base",
+            "flags": [
+                "-func_align 16"
             ]
         },
         "rb3": {
@@ -38,15 +45,17 @@
             "flags": [
                 "-sdata 2",
                 "-sdata2 2",
+                "-str reuse,pool",
+                "-func_align 4",
+
+                "-fp_contract on",
                 "-pragma \"merge_float_consts on\"",
+
                 "-RTTI on",
+                "-Cpp_exceptions off",
+
+                "-O4,p",
                 "-inline noauto"
-            ]
-        },
-        "sdk": {
-            "base": "base",
-            "flags": [
-                "-func_align 16"
             ]
         }
     }

--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -64,11 +64,11 @@
             ]
         },
         "system": {
-            "base": "rb3",
+            "base": "band3",
             "flags": []
         },
         "network": {
-            "base": "rb3",
+            "base": "band3",
             "flags": []
         },
         "json_c": {

--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -20,7 +20,10 @@
                 "-fp hardware",
 
                 "-pragma \"cats off\"",
-                "-pragma \"warn_notinlined off\""
+                "-pragma \"warn_notinlined off\"",
+
+                "-RTTI on",
+                "-Cpp_exceptions off"
             ]
         },
         "runtime": {
@@ -56,9 +59,6 @@
                 "-fp_contract on",
                 "-pragma \"merge_float_consts on\"",
 
-                "-RTTI on",
-                "-Cpp_exceptions off",
-
                 "-O4,p",
                 "-inline noauto"
             ]
@@ -79,6 +79,7 @@
                 "-pragma \"merge_float_consts on\"",
 
                 "-lang=c99",
+                "-O4,p",
                 "-inline auto"
             ]
         },
@@ -87,10 +88,13 @@
             "flags": [
                 "-sdata 2",
                 "-sdata2 2",
+
                 "-pool on",
+                "-str reuse,pool",
                 "-pragma \"merge_float_consts on\"",
 
                 "-lang=c99",
+                "-O4,p",
                 "-inline auto"
             ]
         },
@@ -119,6 +123,7 @@
                 "-pragma \"merge_float_consts on\"",
 
                 "-lang=c99",
+                "-O4,p",
                 "-inline auto"
             ]
         }

--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -26,10 +26,15 @@
         "runtime": {
             "base": "base",
             "flags": [
+                "-sdata 2",
+                "-sdata2 2",
                 "-str reuse,pool,readonly",
+                "-pragma \"merge_float_consts on\"",
+
                 "-use_lmw_stmw on",
                 "-common off",
 
+                "-lang=c99",
                 "-O4,p",
                 "-inline auto"
             ]
@@ -40,7 +45,7 @@
                 "-func_align 16"
             ]
         },
-        "rb3": {
+        "band3": {
             "base": "base",
             "flags": [
                 "-sdata 2",
@@ -56,6 +61,65 @@
 
                 "-O4,p",
                 "-inline noauto"
+            ]
+        },
+        "system": {
+            "base": "rb3",
+            "flags": []
+        },
+        "network": {
+            "base": "rb3",
+            "flags": []
+        },
+        "json_c": {
+            "base": "base",
+            "flags": [
+                "-sdata 2",
+                "-sdata2 2",
+                "-pragma \"merge_float_consts on\"",
+
+                "-lang=c99",
+                "-inline auto"
+            ]
+        },
+        "zlib": {
+            "base": "base",
+            "flags": [
+                "-sdata 2",
+                "-sdata2 2",
+                "-pool on",
+                "-pragma \"merge_float_consts on\"",
+
+                "-lang=c99",
+                "-inline auto"
+            ]
+        },
+        "libtomcrypt": {
+            "base": "zlib",
+            "flags": []
+        },
+        "speex": {
+            "base": "zlib",
+            "flags": []
+        },
+        "libogg": {
+            "base": "zlib",
+            "flags": []
+        },
+        "vorbis": {
+            "base": "zlib",
+            "flags": []
+        },
+        "bt": {
+            "base": "base",
+            "flags": [
+                "-sdata 2",
+                "-sdata2 2",
+                "-str reuse,pool",
+                "-pragma \"merge_float_consts on\"",
+
+                "-lang=c99",
+                "-inline auto"
             ]
         }
     }

--- a/config/SZBE69_B8/objects.json
+++ b/config/SZBE69_B8/objects.json
@@ -1,0 +1,60 @@
+{
+    "band3": {
+        "mw_version": "Wii/1.3",
+        "cflags": "band3",
+        "objects": {}
+    },
+    "system": {
+        "mw_version": "Wii/1.3",
+        "cflags": "system",
+        "objects": {
+            "system/math/Color.cpp": "NonMatching",
+            "system/math/CustomArray.cpp": "Matching",
+            "system/math/Interp.cpp": { "status": "NonMatching", "extra_cflags": [ "-O4,s" ] },
+            "system/math/Primes.cpp": "Matching",
+            "system/math/Rand2.cpp": "Matching",
+            "system/math/Sort.cpp": "NonMatching",
+            "system/math/Trig.cpp": "NonMatching",
+            "system/math/Vec.cpp": "Matching",
+
+            "system/meta/Achievements.cpp": "NonMatching",
+            "system/meta/MemcardAction.cpp": "Matching",
+
+            "system/midi/MidiVarLen.cpp": "NonMatching",
+
+            "system/obj/DataFlex.c": "NonMatching",
+            "system/obj/DataNode.cpp": "NonMatching",
+            "system/obj/Object.cpp": { "status": "NonMatching", "extra_cflags": [ "-inline level=1" ] },
+            "system/obj/TypeProps.cpp":  { "status": "NonMatching", "extra_cflags": [ "-inline level=1" ] },
+
+            "system/ui/UIResource.cpp": "NonMatching",
+
+            "system/utl/BinStream.cpp": "NonMatching",
+            "system/utl/ChunkIDs.cpp": "Matching",
+            "system/utl/EncryptXTEA.cpp": "NonMatching",
+            "system/utl/IntPacker.cpp": "Matching",
+            "system/utl/Symbols.cpp": "Matching",
+            "system/utl/Symbols2.cpp": "Matching",
+            "system/utl/Symbols3.cpp": "Matching",
+            "system/utl/Symbols4.cpp": "Matching",
+            "system/utl/SysTest.cpp": "NonMatching",
+            "system/utl/TempoMap.cpp": "Matching",
+            "system/utl/TextFileStream.cpp": "Matching",
+            "system/utl/TextStream.cpp": "Matching"
+        }
+    },
+    "zlib": {
+        "mw_version": "Wii/1.3",
+        "cflags": "zlib",
+        "objects": {
+            "system/zlib/adler32.c": "Matching",
+            "system/zlib/crc32.c": "Matching",
+            "system/zlib/deflate.c": "NonMatching",
+            "system/zlib/trees.c": "NonMatching",
+            "system/zlib/zutil.c": "NonMatching",
+            "system/zlib/inflate.c": "Matching",
+            "system/zlib/inftrees.c": "Matching",
+            "system/zlib/inffast.c": "Matching"
+        }
+    }
+}

--- a/configure.py
+++ b/configure.py
@@ -203,7 +203,7 @@ Matching = True
 Equivalent = config.non_matching
 NonMatching = False
 
-config.warn_missing_config = True
+config.warn_missing_config = False
 config.warn_missing_source = False
 
 def get_object_completed(status: str) -> bool:

--- a/configure.py
+++ b/configure.py
@@ -176,7 +176,6 @@ def set_flags_inherited(name):
 # Debug flags
 if config.debug:
     get_flags("base").append("-sym dwarf-2,full")
-    get_flags("runtime").append("-sym dwarf-2,full")
 
 # Apply cflag inheritance
 def apply_base_flags(key: str):

--- a/configure.py
+++ b/configure.py
@@ -209,7 +209,7 @@ config.libs = [
     {
         "lib": "band3",
         "mw_version": "Wii/1.3",
-        "cflags": get_flags("rb3"),
+        "cflags": get_flags("band3"),
         "host": False,
         "objects": [
 
@@ -218,7 +218,7 @@ config.libs = [
     {
         "lib": "system",
         "mw_version": "Wii/1.3",
-        "cflags": get_flags("rb3"),
+        "cflags": get_flags("system"),
         "host": False,
         "objects": [
             Object(NonMatching, "system/math/Color.cpp"),

--- a/configure.py
+++ b/configure.py
@@ -144,11 +144,17 @@ config.wibo_tag = "0.6.11"
 
 # Project
 config_dir = Path("config") / config.version
+flags_path = config_dir / "flags.json"
+objects_path = config_dir / "objects.json"
 config.config_path = config_dir / "config.yml"
 config.check_sha_path = config_dir / "build.sha1"
+config.reconfig_deps = [
+    flags_path,
+    objects_path,
+]
 
 # Build flags
-flags = json.load(open(config_dir / "flags.json", "r", encoding="utf-8"))
+flags = json.load(open(flags_path, "r", encoding="utf-8"))
 
 config.asflags = [
     "-mgekko",
@@ -219,7 +225,7 @@ def get_object_completed(status: str) -> bool:
     assert False, f"Invalid object status {status}"
 
 libs: list[dict] = []
-objects: dict[str, dict] = json.load(open(config_dir / "objects.json", "r", encoding="utf-8"))
+objects: dict[str, dict] = json.load(open(objects_path, "r", encoding="utf-8"))
 for (lib, lib_config) in objects.items():
     lib_mw_version: str = lib_config["mw_version"]
 

--- a/doc/flags_schema.json
+++ b/doc/flags_schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DTK Build Flags Config",
+  "description": "Version-specific settings for building a DTK project.",
+  "type": "object",
+  "properties": {
+    "ldflags": {
+      "description": "The linker flags to use for this version.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "cflags": {
+      "description": "The compile flags to use for this version.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "base": {
+            "description": "Another set of cflags which should be copied into this set, or null to just add include paths.\nThis inheritance is evaluated in a lowest-to-highest depth order, with includes coming first.",
+            "type": ["string", "null"],
+            "if": {
+              "type": "string"
+            },
+            "then": {
+              "contains": true
+            }
+          },
+          "flags": {
+            "description": "The cflags for this set.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/doc/objects_schema.json
+++ b/doc/objects_schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DTK Object File Config",
+  "description": "Object files to build in a DTK project.",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "mw_version": { "$ref": "#/$defs/mw_version" },
+      "cflags": { "$ref": "#/$defs/cflags" },
+      "objects": {
+        "description": "The objects to be built.",
+        "type": "object",
+        "additionalProperties": {
+          "oneOf": [
+            { "$ref": "#/$defs/status" },
+            {
+              "type": "object",
+              "properties": {
+                "status": { "$ref": "#/$defs/status" },
+                "mw_version": { "$ref": "#/$defs/mw_version" },
+                "asflags": { "$ref": "#/$defs/asflags" },
+                "cflags": { "$ref": "#/$defs/cflags" },
+                "extra_asflags": { "$ref": "#/$defs/extra_asflags" },
+                "extra_cflags": { "$ref": "#/$defs/extra_cflags" },
+                "comment": { "$ref": "#/$defs/comment" }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "additionalProperties": false
+  },
+  "$defs": {
+    "asflags": {
+      "description": "Flags to pass to the assembler.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "cflags": {
+      "description": "Flags to pass to the compiler.",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ]
+    },
+    "extra_asflags": {
+      "description": "Additional flags to pass to the assembler.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "extra_cflags": {
+      "description": "Additional flags to pass to the compiler.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "mw_version": {
+      "description": "The version of MWCC to use.",
+      "type": "string"
+    },
+    "comment": {
+      "description": "Any comments about the object.",
+      "$comment": "This property exists to work around Python's JSON parser not supporting comments.",
+      "type": "string"
+    },
+    "status": {
+      "description": "The match status of the object.",
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "This object is fully matching.",
+          "const": "Matching"
+        },
+        {
+          "description": "This object is not matching.",
+          "const": "NonMatching"
+        },
+        {
+          "description": "This object is not matching, but is functionally equivalent.",
+          "const": "Equivalent"
+        },
+        {
+          "description": "This object is matching, but does not link correctly.",
+          "const": "LinkIssues"
+        }
+      ]
+    }
+  }
+}

--- a/tools/project.py
+++ b/tools/project.py
@@ -59,6 +59,7 @@ class ProjectConfig:
         self.ldflags = None  # Linker flags
         self.libs = None  # List of libraries
         self.linker_version = None  # mwld version
+        self.reconfig_deps = []  # Additional re-configuration dependency files
         self.version = None  # Version name
         self.warn_missing_config = False  # Warn on missing unit configuration
         self.warn_missing_source = False  # Warn on missing source file
@@ -941,6 +942,7 @@ def generate_build_ninja(config, build_config):
                 configure_script,
                 python_lib,
                 Path(python_lib_dir) / "ninja_syntax.py",
+                *config.reconfig_deps
             ]
         ),
     )


### PR DESCRIPTION
- The cflag system now allows inheriting from another set of cflags. Inheritance is evaluated bottom-up, starting with includes first.
- I reorganized cflags to more easily allow lib-specific optimization flags as needed, and added in a bunch of flag sets for libraries in the project.
- Objects are now specified per-version, since not all objects are compiled the same way on all versions.
- Both the flag and object versioning files now have schemas, for documentation and editor validation support.
- I disabled the `Missing configuration for <...>` logging since all it does for us now is just spam the console when reconfiguring.
- I added another VS Code task for `ninja diff`, and made the `ninja` task the default build task, since that makes more sense than just building the current file.