### PR TITLE
Mark assert macros as whitespace-sensitive in clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -174,3 +174,8 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
   - ASM_BLOCK
+  - assert
+  - Assert
+  - MILO_ASSERT
+  - _STLP_ASSERT
+  - _STLP_VERBOSE_ASSERT


### PR DESCRIPTION
Otherwise one of IntPacker's asserts will get screwed up when formatting.