### PR TITLE
More `vector` progress; a `map` fix; `MILO_DEBUG` and `GAME_VERSION` defines

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -36,7 +36,7 @@
                 "limitSymbolsToIncludedHeaders": true
             },
             "defines": [
-                "NDEBUG",
+                "MILO_DEBUG",
                 "__MWERKS__=0x4302"
             ]
         }

--- a/config/SZBE69/flags.json
+++ b/config/SZBE69/flags.json
@@ -23,6 +23,9 @@
                 "-pragma \"cats off\"",
                 "-pragma \"warn_notinlined off\"",
 
+                "-RTTI on",
+                "-Cpp_exceptions off",
+
                 "-d NDEBUG"
             ]
         },
@@ -59,9 +62,6 @@
                 "-fp_contract on",
                 "-pragma \"merge_float_consts on\"",
 
-                "-RTTI on",
-                "-Cpp_exceptions off",
-
                 "-O4,s",
                 "-inline off"
             ]
@@ -82,7 +82,8 @@
                 "-pragma \"merge_float_consts on\"",
 
                 "-lang=c99",
-                "-inline auto"
+                "-O4,s",
+                "-inline noauto"
             ]
         },
         "zlib": {
@@ -90,10 +91,13 @@
             "flags": [
                 "-sdata 2",
                 "-sdata2 2",
+
                 "-pool on",
+                "-str reuse,pool",
                 "-pragma \"merge_float_consts on\"",
 
                 "-lang=c99",
+                "-O4,p",
                 "-inline auto"
             ]
         },
@@ -122,6 +126,7 @@
                 "-pragma \"merge_float_consts on\"",
 
                 "-lang=c99",
+                "-O4,p",
                 "-inline auto"
             ]
         }

--- a/config/SZBE69/objects.json
+++ b/config/SZBE69/objects.json
@@ -4,6 +4,25 @@
         "cflags": "band3",
         "objects": {}
     },
+    "network": {
+        "mw_version": "Wii/1.3",
+        "cflags": "network",
+        "objects": {
+            "network/net/JsonUtils.cpp": "NonMatching"
+        }
+    },
+    "network/net/json_c": {
+        "mw_version": "Wii/1.3",
+        "cflags": "json_c",
+        "objects": {
+            "network/net/json-c/arraylist.c": "Matching",
+            "network/net/json-c/debug.c": "NonMatching",
+            "network/net/json-c/json_object.c": "NonMatching",
+            "network/net/json-c/json_tokener.c": "NonMatching",
+            "network/net/json-c/linkhash.c": "Matching",
+            "network/net/json-c/printbuf.c": "Matching"
+        }
+    },
     "system": {
         "mw_version": "Wii/1.3",
         "cflags": "system",

--- a/config/SZBE69/splits.txt
+++ b/config/SZBE69/splits.txt
@@ -81,12 +81,12 @@ libs/quazal/unknown/800A/unk_800A515C.cpp:
 	.text       start:0x800A515C end:0x800A5368
 	.data       start:0x8082A5C0 end:0x8082A678
 
-rb3/jsonobjects.cpp:
-	.text       start:0x800A6360 end:0x800A673C
-	.data       start:0x8082A960 end:0x8082AA40
+network/net/JsonUtils.cpp:
+	.text       start:0x800A6360 end:0x800A71BC
+	.data       start:0x8082A928 end:0x8082AA40
 
 rb3/unknown/800/unk_800A673C.cpp:
-	.text       start:0x800A673C end:0x800AAD98
+	.text       start:0x800A71BC end:0x800AAD98
 
 rb3/unknown/800/unk_800AAE1C.cpp:
 	.text       start:0x800AAE1C end:0x800AB8C4
@@ -104,23 +104,23 @@ rb3/unknown/800/unk_800B4630.cpp:
 rb3/unknown/800/unk_800BF1A8.cpp:
 	.text       start:0x800BF1A8 end:0x800C239C
 
-libs/json-c/arraylist.c:
+network/net/json-c/arraylist.c:
 	.text       start:0x800C68E0 end:0x800C6B4C
 
-libs/json-c/json_object.c:
+network/net/json-c/json_object.c:
 	.text       start:0x800C6B4C end:0x800C7714
 	.data       start:0x8082E1D0 end:0x8082E248
 
-libs/json-c/json_tokener.c:
+network/net/json-c/json_tokener.c:
 	.text       start:0x800C7714 end:0x800C92AC
 	.data       start:0x8082E248 end:0x8082E5B0
 
-libs/json-c/linkhash.c:
+network/net/json-c/linkhash.c:
 	.text       start:0x800C92AC end:0x800C999C
 	.rodata     start:0x807F00C0 end:0x807F00C8
 	.data       start:0x8082E5B0 end:0x8082E5D0
 
-libs/json-c/printbuf.c:
+network/net/json-c/printbuf.c:
 	.text       start:0x800C999C end:0x800C9D04
 	.sbss       start:0x808E3E98 end:0x808E3EA0
 

--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -23,7 +23,9 @@
                 "-pragma \"warn_notinlined off\"",
 
                 "-RTTI on",
-                "-Cpp_exceptions off"
+                "-Cpp_exceptions off",
+
+                "-d MILO_DEBUG"
             ]
         },
         "runtime": {

--- a/configure.py
+++ b/configure.py
@@ -28,6 +28,7 @@ from tools.project import (
 from cflags_common import cflags_includes
 
 # Game versions
+# Be sure to update macros.h if this list changes!
 DEFAULT_VERSION = 1
 VERSIONS = [
     "SZBE69",    # 0
@@ -178,9 +179,11 @@ def are_flags_inherited(name: str) -> bool:
 def set_flags_inherited(name: str):
     cflags[name]["inherited"] = True
 
-# Debug flags
+# Additional base flags
+base_flags = get_flags("base")
+base_flags.append(f"-d GAME_VERSION={version_num}")
 if config.debug:
-    get_flags("base").append("-sym dwarf-2,full")
+    base_flags.append("-sym dwarf-2,full")
 
 # Apply cflag inheritance
 def apply_base_flags(key: str):

--- a/decompctx.py
+++ b/decompctx.py
@@ -46,8 +46,14 @@ passthrough_defines: list[str] = [
     "__STDC__",
     "__STDC_VERSION__",
 
+    # Game version defines
+    "GAME_VERSION",
+    "VERSION_SZBE69"
+    "VERSION_SZBE69_BE"
+
     # Debug defines
     "NDEBUG",
+    "MILO_DEBUG",
 
     # __option
     "__option",

--- a/src/macros.h
+++ b/src/macros.h
@@ -1,6 +1,12 @@
 #ifndef MACROS_H
 #define MACROS_H
 
+// Possibilities for the GAME_VERSION define
+// Be sure to update if the list in configure.py changes!
+#define VERSION_SZBE69 0
+#define VERSION_SZBE69_BE 1
+
+// Useful macros
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 

--- a/src/network/net/JsonUtils.cpp
+++ b/src/network/net/JsonUtils.cpp
@@ -33,9 +33,7 @@ void JsonArray::AddMember(JsonObject *obj) {
     json_object_array_add(mObject, obj->GetObject());
 }
 
-// TODO: This is getting eliminated due to the inline,
-// but it needs to be inline for JsonConverter::GetElement()
-inline int JsonArray::GetSize() const {
+int JsonArray::GetSize() const {
     return json_object_array_length(mObject);
 }
 

--- a/src/network/net/JsonUtils.cpp
+++ b/src/network/net/JsonUtils.cpp
@@ -79,7 +79,7 @@ JsonConverter::~JsonConverter() {
     if (objects.size() != 0) {
         int count = objects.size() - 1;
         while (count >= 0) {
-            JsonObject *o = objects.at(count);
+            JsonObject *o = objects[count];
             delete o;
             count--;
         }

--- a/src/network/net/JsonUtils.h
+++ b/src/network/net/JsonUtils.h
@@ -27,6 +27,10 @@ public:
 
     void AddMember(JsonObject *);
     int GetSize() const;
+
+    // Necessary to match JsonConverter::GetElement while
+    // still generating `GetSize() const` in the compiled object
+    int GetSize() { return json_object_array_length(mObject); }
 };
 
 class JsonString : public JsonObject {

--- a/src/network/net/JsonUtils.h
+++ b/src/network/net/JsonUtils.h
@@ -67,6 +67,8 @@ public:
 
     JsonObject *LoadFromString(const String &str);
     JsonObject *GetElement(JsonArray *array, int index);
+
+private:
     void PushObject(JsonObject *obj);
 };
 

--- a/src/system/obj/Object.h
+++ b/src/system/obj/Object.h
@@ -160,7 +160,7 @@ namespace Hmx {
         static Object* NewObject();
 
         static void RegisterFactory(Symbol, ObjectFunc*);
-        bool RegisteredFactory(Symbol);
+        static bool RegisteredFactory(Symbol);
         Object& operator=(const Object&);
         void RemoveFromDir();
 

--- a/src/system/os/Debug.h
+++ b/src/system/os/Debug.h
@@ -51,10 +51,19 @@ public:
 extern Debug TheDebug;
 extern const char* kAssertStr;
 
-#define MILO_ASSERT(cond, line) ((cond) || (TheDebug.Fail(MakeString(kAssertStr, __FILE__, line, #cond)), 0))
-#define MILO_ASSERT_FMT(cond, ...) ((cond) || (TheDebug.Fail(MakeString(__VA_ARGS__)), 0))
-#define MILO_FAIL(...) TheDebug.Fail(MakeString(__VA_ARGS__))
-#define MILO_WARN(...) TheDebug.Notify(MakeString(__VA_ARGS__))
+#ifdef MILO_DEBUG
+#  define MILO_ASSERT(cond, line) ((cond) || (TheDebug.Fail(MakeString(kAssertStr, __FILE__, line, #cond)), 0))
+#  define MILO_ASSERT_FMT(cond, ...) ((cond) || (TheDebug.Fail(MakeString(__VA_ARGS__)), 0))
+#  define MILO_FAIL(...) TheDebug.Fail(MakeString(__VA_ARGS__))
+#  define MILO_WARN(...) TheDebug.Notify(MakeString(__VA_ARGS__))
+#else
+   // The actual conditions for asserts appear to still be evaluated in retail,
+   // various random calls are left over from asserts that exist in debug
+#  define MILO_ASSERT(cond, line) (void)(cond)
+#  define MILO_ASSERT_FMT(cond, ...) (void)(cond)
+#  define MILO_FAIL(...) ((void)0)
+#  define MILO_WARN(...) ((void)0)
+#endif
 
 class DebugNotifier {
 public:

--- a/src/system/stlport/stl/_alloc.h
+++ b/src/system/stlport/stl/_alloc.h
@@ -414,13 +414,13 @@ public:
   template <class _Tp1>
   StlNodeAlloc(const StlNodeAlloc<_Tp1>&) _STLP_NOTHROW {}
 
-  value_type *allocate(const size_type count) {
+  value_type *allocate(const size_type count, const void* ptr = nullptr) const {
     return reinterpret_cast<value_type *>(
       _MemOrPoolAllocSTL(count * sizeof(value_type), FastPool)
     );
   }
 
-  void deallocate(value_type *ptr, const size_type count) {
+  void deallocate(value_type *ptr, const size_type count) const {
     _MemOrPoolFreeSTL(count * sizeof(value_type), FastPool, ptr);
   }
 };
@@ -506,18 +506,21 @@ public:
     _STLP_STD::swap(_M_data, __x._M_data);
   }
 
-  _Tp* allocate(size_type __n, size_type& __allocated_n) {
-    typedef typename _IsSTLportClass<_MaybeReboundAlloc>::_Ret _STLportAlloc;
-    return allocate(__n, __allocated_n, _STLportAlloc());
-  }
-  _Tp* allocate(size_type __n)
-  { return _Base::allocate(__n); }
+// These overloads cause problems with the signature that StlNodeAlloc::allocate has,
+// and also mismatch in retail with the assumption that there is no inlining happening with these
+// Leaving these as commented-out in case they're needed in the future
+//   _Tp* allocate(size_type __n, size_type& __allocated_n) {
+//     typedef typename _IsSTLportClass<_MaybeReboundAlloc>::_Ret _STLportAlloc;
+//     return allocate(__n, __allocated_n, _STLportAlloc());
+//   }
+//   _Tp* allocate(size_type __n)
+//   { return _Base::allocate(__n); }
 
-private:
-  _Tp* allocate(size_type __n, size_type& __allocated_n, const __true_type& /*STLport allocator*/)
-  { return _Base::allocate(__n, __allocated_n); }
-  _Tp* allocate(size_type __n, size_type& __allocated_n, const __false_type& /*STLport allocator*/)
-  { __allocated_n = __n; return allocate(__n); }
+// private:
+//   _Tp* allocate(size_type __n, size_type& __allocated_n, const __true_type& /*STLport allocator*/)
+//   { return _Base::allocate(__n, __allocated_n); }
+//   _Tp* allocate(size_type __n, size_type& __allocated_n, const __false_type& /*STLport allocator*/)
+//   { __allocated_n = __n; return allocate(__n); }
 };
 
 }

--- a/src/system/stlport/stl/_deque.h
+++ b/src/system/stlport/stl/_deque.h
@@ -334,7 +334,7 @@ public:
   static size_t buffer_size() { return (size_t)_Deque_iterator_base<_Tp>::__buffer_size; }
 
   _Deque_base(const allocator_type& __a, size_t __num_elements)
-    : _M_start(), _M_finish(), _M_map(__a, 0),
+    : _M_start(), _M_finish(), _M_map(_STLP_CONVERT_ALLOCATOR(__a, allocator_type, _Tp*), 0),
       _M_map_size(__a, (size_t)0)
   { _M_initialize_map(__num_elements); }
 

--- a/src/system/stlport/stl/_list.h
+++ b/src/system/stlport/stl/_list.h
@@ -170,7 +170,7 @@ public:
   allocator_type get_allocator() const
   { return (const _Node_allocator_type&)_M_node; }
 
-  _List_base(const allocator_type& __a) : _M_node(__a, _Node_base())
+  _List_base(const allocator_type& __a) : _M_node(_STLP_CONVERT_ALLOCATOR(__a, allocator_type, _Node), _Node_base())
   { _M_empty_initialize(); }
   _List_base(__move_source<_Self> src) :
     _M_node(__move_source<_AllocProxy>(src.get()._M_node)) {

--- a/src/system/stlport/stl/_map.h
+++ b/src/system/stlport/stl/_map.h
@@ -139,7 +139,7 @@ public:
     iterator __i = lower_bound(__k);
     // __i->first is greater than or equivalent to __k.
     if (__i == end() || key_comp()(__k, (*__i).first))
-      __i = insert(__i, value_type(__k, _Tp()));
+      __i = _M_t.insert_unique(__i, value_type(__k, _Tp()));
     return (*__i).second;
   }
   void swap(_Self& __x) { _M_t.swap(__x._M_t); }

--- a/src/system/stlport/stl/_slist.h
+++ b/src/system/stlport/stl/_slist.h
@@ -146,7 +146,7 @@ public:
   typedef typename _Alloc_traits<_Tp,_Alloc>::allocator_type allocator_type;
 
   _Slist_base(const allocator_type& __a) :
-    _M_head(__a, _Slist_node_base() ) {
+    _M_head(_STLP_CONVERT_ALLOCATOR(__a, allocator_type, _Node), _Slist_node_base() ) {
     _M_head._M_data._M_next = 0;
   }
   _Slist_base(__move_source<_Self> src) :

--- a/src/system/stlport/stl/_string.c
+++ b/src/system/stlport/stl/_string.c
@@ -78,7 +78,7 @@ void basic_string<_CharT,_Traits,_Alloc>::reserve(size_type __res_arg) {
   if (__n <= capacity() + 1)
     return;
 
-  pointer __new_start = this->_M_end_of_storage.allocate(__n, __n);
+  pointer __new_start = this->_M_end_of_storage.allocate(__n);
   pointer __new_finish = __new_start;
 
   _STLP_TRY {
@@ -127,7 +127,7 @@ basic_string<_CharT, _Traits, _Alloc>::_M_append(const _CharT* __first, const _C
       this->_M_throw_length_error();
     if (__old_size + __n > capacity()) {
       size_type __len = __old_size + (max)(__old_size, (size_t) __n) + 1;
-      pointer __new_start = this->_M_end_of_storage.allocate(__len, __len);
+      pointer __new_start = this->_M_end_of_storage.allocate(__len);
       pointer __new_finish = __new_start;
       _STLP_TRY {
         __new_finish = _STLP_PRIV::__ucopy(this->_M_Start(), this->_M_Finish(), __new_start);
@@ -208,7 +208,7 @@ _CharT* basic_string<_CharT,_Traits,_Alloc> ::_M_insert_aux(_CharT* __p,
   else {
     const size_type __old_len = size();
     size_type __len = __old_len + (max)(__old_len, static_cast<size_type>(1)) + 1;
-    pointer __new_start = this->_M_end_of_storage.allocate(__len, __len);
+    pointer __new_start = this->_M_end_of_storage.allocate(__len);
     pointer __new_finish = __new_start;
     _STLP_TRY {
       __new_pos = _STLP_PRIV::__ucopy(this->_M_Start(), __p, __new_start);
@@ -270,7 +270,7 @@ void basic_string<_CharT,_Traits,_Alloc>::insert(iterator __pos,
     else {
       const size_type __old_size = size();
       size_type __len = __old_size + (max)(__old_size, __n) + 1;
-      pointer __new_start = this->_M_end_of_storage.allocate(__len, __len);
+      pointer __new_start = this->_M_end_of_storage.allocate(__len);
       pointer __new_finish = __new_start;
       _STLP_TRY {
         __new_finish = _STLP_PRIV::__ucopy(this->_M_Start(), __pos, __new_start);
@@ -353,7 +353,7 @@ void basic_string<_CharT,_Traits,_Alloc>::_M_insert(iterator __pos,
     else {
       const size_type __old_size = size();
       size_type __len = __old_size + (max)(__old_size, static_cast<const size_type>(__n)) + 1;
-      pointer __new_start = this->_M_end_of_storage.allocate(__len, __len);
+      pointer __new_start = this->_M_end_of_storage.allocate(__len);
       pointer __new_finish = __new_start;
       _STLP_TRY {
         __new_finish = _STLP_PRIV::__ucopy(this->_M_Start(), __pos, __new_start);
@@ -609,12 +609,12 @@ void _String_base<_Tp, _Alloc>::_M_allocate_block(size_t __n) {
   if ((__n <= (max_size() + 1)) && (__n > 0)) {
 #if defined (_STLP_USE_SHORT_STRING_OPTIM)
     if (__n > _DEFAULT_SIZE) {
-      this->_M_buffers._M_dynamic_buf = _M_end_of_storage.allocate(__n, __n);
+      this->_M_buffers._M_dynamic_buf = _M_end_of_storage.allocate(__n);
       this->_M_finish = this->_M_buffers._M_dynamic_buf;
       this->_M_end_of_storage._M_data = this->_M_finish + __n;
     }
 #else
-    this->_M_start  = _M_end_of_storage.allocate(__n, __n);
+    this->_M_start  = _M_end_of_storage.allocate(__n);
     this->_M_finish = this->_M_start;
     this->_M_end_of_storage._M_data = this->_M_finish + __n;
 #endif /*_STLP_USE_SHORT_STRING_OPTIM  */

--- a/src/system/stlport/stl/_string.h
+++ b/src/system/stlport/stl/_string.h
@@ -436,7 +436,7 @@ private: // Helper functions for append.
         this->_M_throw_length_error();
       if (__old_size + __n > this->capacity()) {
         size_type __len = __old_size + (max)(__old_size, static_cast<size_type>(__n)) + 1;
-        pointer __new_start = this->_M_end_of_storage.allocate(__len, __len);
+        pointer __new_start = this->_M_end_of_storage.allocate(__len);
         pointer __new_finish = __new_start;
         _STLP_TRY {
           __new_finish = uninitialized_copy(this->_M_Start(), this->_M_Finish(), __new_start);
@@ -668,7 +668,7 @@ protected:  // Helper functions for insert.
                           difference_type __n) {
     const size_type __old_size = this->size();
     size_type __len = __old_size + (max)(__old_size, static_cast<size_type>(__n)) + 1;
-    pointer __new_start = this->_M_end_of_storage.allocate(__len, __len);
+    pointer __new_start = this->_M_end_of_storage.allocate(__len);
     pointer __new_finish = __new_start;
     _STLP_TRY {
       __new_finish = uninitialized_copy(this->_M_Start(), __pos, __new_start);

--- a/src/system/stlport/stl/_tree.h
+++ b/src/system/stlport/stl/_tree.h
@@ -228,7 +228,7 @@ public:
 
 protected:
   _Rb_tree_base(const allocator_type& __a) :
-    _M_header(__a, _Node_base() ) {
+    _M_header(_STLP_CONVERT_ALLOCATOR(__a, allocator_type, _Node), _Node_base() ) {
     _M_empty_initialize();
   }
   _Rb_tree_base(__move_source<_Self> src) :

--- a/src/system/stlport/stl/_vector.c
+++ b/src/system/stlport/stl/_vector.c
@@ -105,7 +105,7 @@ void vector<_Tp, _Size, _Alloc>::_M_insert_overflow(pointer __pos, const _Tp& __
   size_type __len = __old_size + (max)(__old_size, __fill_len);
 
   pointer __new_start = this->_M_ptr.allocate(__len, __len);
-  pointer __new_finish = static_cast<pointer>(_STLP_PRIV::__copy_trivial(begin(), __pos, __new_start));
+  pointer __new_finish = static_cast<pointer>(_STLP_PRIV::__copy_trivial(this->_M_ptr._M_data, __pos, __new_start));
   // handle insertion
   __new_finish = _STLP_PRIV::__fill_n(__new_finish, __fill_len, __x);
   if (!__atend)

--- a/src/system/stlport/stl/_vector.c
+++ b/src/system/stlport/stl/_vector.c
@@ -67,7 +67,7 @@ void vector<_Tp, _Size, _Alloc>::reserve(size_type __n) {
       __tmp = _M_allocate_and_copy(__n, begin(), end());
       _M_clear();
     } else {
-      __tmp = this->_M_ptr.allocate(__n, __n);
+      __tmp = this->_M_ptr.allocate(__n);
     }
     _M_set(__tmp, __tmp + __old_size, __tmp + __n);
   }
@@ -79,7 +79,7 @@ void vector<_Tp, _Size, _Alloc>::_M_insert_overflow_aux(pointer __pos, const _Tp
   const size_type __old_size = size();
   size_type __len = __old_size + (max)(__old_size, __fill_len);
 
-  pointer __new_start = this->_M_ptr.allocate(__len, __len);
+  pointer __new_start = this->_M_ptr.allocate(__len);
   pointer __new_finish = __new_start;
   _STLP_TRY {
     __new_finish = _STLP_PRIV::__uninitialized_move(begin(), __pos, __new_start, _TrivialUCopy(), _Movable());
@@ -104,7 +104,7 @@ void vector<_Tp, _Size, _Alloc>::_M_insert_overflow(pointer __pos, const _Tp& __
   const size_type __old_size = size();
   size_type __len = __old_size + (max)(__old_size, __fill_len);
 
-  pointer __new_start = this->_M_ptr.allocate(__len, __len);
+  pointer __new_start = this->_M_ptr.allocate(__len);
   pointer __new_finish = static_cast<pointer>(_STLP_PRIV::__copy_trivial(this->_M_ptr._M_data, __pos, __new_start));
   // handle insertion
   __new_finish = _STLP_PRIV::__fill_n(__new_finish, __fill_len, __x);

--- a/src/system/stlport/stl/_vector.c
+++ b/src/system/stlport/stl/_vector.c
@@ -109,7 +109,7 @@ void vector<_Tp, _Size, _Alloc>::_M_insert_overflow(pointer __pos, const _Tp& __
   // handle insertion
   __new_finish = _STLP_PRIV::__fill_n(__new_finish, __fill_len, __x);
   if (!__atend)
-    __new_finish = static_cast<pointer>(_STLP_PRIV::__copy_trivial(__pos, end(), __new_finish)); // copy remainder
+    __new_finish = static_cast<pointer>(_STLP_PRIV::__copy_trivial(__pos, _M_finish(), __new_finish)); // copy remainder
   _M_clear();
   _M_set(__new_start, __new_finish, __new_start + __len);
 }
@@ -129,7 +129,7 @@ void vector<_Tp, _Size, _Alloc>::_M_fill_insert_aux(iterator __pos, size_type __
     _STLP_STD::_Destroy_Moved(__src);
   }
   _STLP_PRIV::__uninitialized_fill_n(__pos, __n, __x);
-  this->_M_size += __n;
+  _M_inc_finish_idx(__n);
 }
 
 template <class _Tp, class _Size, class _Alloc>
@@ -145,14 +145,14 @@ void vector<_Tp, _Size, _Alloc>::_M_fill_insert_aux (iterator __pos, size_type _
   pointer __old_finish = end();
   if (__elems_after > __n) {
     _STLP_PRIV::__ucopy_ptrs(end() - __n, end(), end(), _TrivialUCopy());
-    this->_M_size += __n;
+    _M_inc_finish_idx(__n);
     _STLP_PRIV::__copy_backward_ptrs(__pos, __old_finish - __n, __old_finish, _TrivialCopy());
     _STLP_STD::fill(__pos, __pos + __n, __x);
   } else {
     auto end = _STLP_PRIV::__uninitialized_fill_n(end(), __n - __elems_after, __x);
-    this->_M_size = end - begin();
+    _M_set_finish_idx(end - begin());
     _STLP_PRIV::__ucopy_ptrs(__pos, __old_finish, end(), _TrivialUCopy());
-    this->_M_size += __elems_after;
+    _M_inc_finish_idx(__elems_after);
     _STLP_STD::fill(__pos, __old_finish, __x);
   }
 }
@@ -161,7 +161,7 @@ template <class _Tp, class _Size, class _Alloc>
 void vector<_Tp, _Size, _Alloc>::_M_fill_insert(iterator __pos,
                                          size_type __n, const _Tp& __x) {
   if (__n != 0) {
-    if (size_type(this->_M_capacity - this->_M_size) >= __n) {
+    if (size_type(this->_M_data_size - this->_M_finish_idx) >= __n) {
       _M_fill_insert_aux(__pos, __n, __x, _Movable());
     } else
       _M_insert_overflow(__pos, __x, _TrivialCopy(), __n);
@@ -178,7 +178,7 @@ vector<_Tp, _Size, _Alloc>& vector<_Tp, _Size, _Alloc>::operator = (const vector
                                                   const_cast<const_pointer>(__x.end()) + 0);
       _M_clear();
       this->_M_ptr._M_data = __tmp;
-      this->_M_capacity = __len;
+      _M_set_data_size(__len);
     } else if (size() >= __xlen) {
       pointer __i = _STLP_PRIV::__copy_ptrs(const_cast<const_pointer>(__x.begin()) + 0,
                                            const_cast<const_pointer>(__x.end()) + 0, begin(), _TrivialCopy());
@@ -189,20 +189,20 @@ vector<_Tp, _Size, _Alloc>& vector<_Tp, _Size, _Alloc>::operator = (const vector
       _STLP_PRIV::__ucopy_ptrs(const_cast<const_pointer>(__x.begin()) + size(),
                               const_cast<const_pointer>(__x.end()) + 0, end(), _TrivialUCopy());
     }
-    this->_M_size = __xlen;
+    _M_set_finish_idx(__xlen);
   }
   return *this;
 }
 
 template <class _Tp, class _Size, class _Alloc>
-void vector<_Tp, _Size, _Alloc>::_M_fill_assign(size_t __n, const _Tp& __val) {
+void vector<_Tp, _Size, _Alloc>::_M_fill_assign(size_type __n, const _Tp& __val) {
   if (__n > capacity()) {
     vector<_Tp, _Size, _Alloc> __tmp(__n, __val, get_allocator());
     __tmp.swap(*this);
   } else if (__n > size()) {
     fill(begin(), end(), __val);
     auto end = _STLP_PRIV::__uninitialized_fill_n(end(), __n - size(), __val);
-    this->_M_size = end - begin();
+    _M_set_finish_idx(end - begin());
   } else
     erase(_STLP_PRIV::__fill_n(begin(), __n, __val), end());
 }

--- a/src/system/stlport/stl/_vector.h
+++ b/src/system/stlport/stl/_vector.h
@@ -46,7 +46,7 @@
 #  include <stl/_uninitialized.h>
 #endif
 
-#if 1 //def _STLP_DEBUG // TODO: Tie to whatever define excludes MILO debug code
+#ifdef MILO_DEBUG
 // From system/os/Debug.cpp
 // Declared here since it's not relevant anywhere else
 void std_vec_range_assert(size_t value, size_t max, const char *func);

--- a/src/system/stlport/stl/_vector.h
+++ b/src/system/stlport/stl/_vector.h
@@ -85,7 +85,7 @@ public:
 
   _Vector_base(size_t __n, const _Alloc& __a)
     : _M_ptr(__a, 0), _M_finish_idx(0), _M_data_size(__n) {
-    _M_ptr._M_data = _M_ptr.allocate(__n, __n);
+    _M_ptr._M_data = _M_ptr.allocate(__n);
   }
 
   _Vector_base(__move_source<_Self> src)
@@ -269,9 +269,8 @@ private:
   template <class _Integer>
   void _M_initialize_aux(_Integer __n, _Integer __val,
                          const __true_type& /*_IsIntegral*/) {
-    size_type __real_n;
-    this->_M_ptr._M_data = this->_M_ptr.allocate(__n, __real_n);
-    _M_set_data_size(__real_n);
+    this->_M_ptr._M_data = this->_M_ptr.allocate(__n);
+    _M_set_data_size(__n);
     _M_set_finish_idx(__n);
     auto end = __uninitialized_fill_n(this->_M_data, __n, __val);
     _M_set_finish_idx(end - this->_M_ptr._M_data);
@@ -398,7 +397,7 @@ private:
                                size_type __n) {
     const size_type __old_size = size();
     size_type __len = __old_size + (max)(__old_size, __n);
-    pointer __new_start = this->_M_ptr.allocate(__len, __len);
+    pointer __new_start = this->_M_ptr.allocate(__len);
     pointer __new_finish = __new_start;
     _STLP_TRY {
       __new_finish = _STLP_PRIV::__uninitialized_move(begin(), __pos, __new_start, _TrivialUCopy(), _Movable());
@@ -598,7 +597,7 @@ private:
   pointer _M_allocate_and_copy(size_type& __n,
                                _ForwardIterator __first, _ForwardIterator __last)
   {
-    pointer __result = this->_M_ptr.allocate(__n, __n);
+    pointer __result = this->_M_ptr.allocate(__n);
     _STLP_TRY {
       uninitialized_copy(__first, __last, __result);
       return __result;
@@ -619,7 +618,7 @@ private:
   void _M_range_initialize(_ForwardIterator __first, _ForwardIterator __last,
                            const forward_iterator_tag &) {
     size_type __n = distance(__first, __last);
-    this->_M_ptr._M_data = this->_M_ptr.allocate(__n, __n);
+    this->_M_ptr._M_data = this->_M_ptr.allocate(__n);
     _M_set_data_size(__n);
     auto end = uninitialized_copy(__first, __last, this->_M_ptr._M_data);
     _M_set_finish_idx(end - this->_M_ptr._M_data);

--- a/src/system/stlport/stl/_vector.h
+++ b/src/system/stlport/stl/_vector.h
@@ -98,6 +98,10 @@ public:
   ~_Vector_base() {
     if (_M_ptr._M_data != pointer())
       _M_ptr.deallocate(_M_ptr._M_data, _M_data_size);
+
+    _M_ptr._M_data = 0;
+    _M_finish_idx = 0;
+    _M_data_size = 0;
   }
 
 protected:
@@ -576,12 +580,12 @@ public:
 private:
   void _M_clear() {
     _STLP_STD::_Destroy_Range(rbegin(), rend());
-    this->_M_ptr.deallocate(begin(), this->_M_data_size);
+    this->_M_ptr.deallocate(this->_M_ptr._M_data, this->_M_data_size);
   }
 
   void _M_clear_after_move() {
     _STLP_STD::_Destroy_Moved_Range(rbegin(), rend());
-    this->_M_ptr.deallocate(begin(), this->_M_data_size);
+    this->_M_ptr.deallocate(this->_M_ptr._M_data, this->_M_data_size);
   }
 
   void _M_set(pointer __s, pointer __f, pointer __e) {

--- a/src/system/stlport/stl/pointers/_vector.h
+++ b/src/system/stlport/stl/pointers/_vector.h
@@ -95,7 +95,7 @@ public:
   const_reference at(size_type __n) const { return cast_traits::to_value_type_cref(_M_impl.at(__n)); }
 
   explicit vector(const allocator_type& __a = allocator_type())
-    : _M_impl(__a) {}
+    : _M_impl(_STLP_CONVERT_ALLOCATOR(__a, allocator_type, _StorageType)) {}
 
   explicit vector(size_type __n, const value_type& __val = value_type(),
          const allocator_type& __a = allocator_type())
@@ -223,7 +223,7 @@ public:
   const_reference at(size_type __n) const { return reinterpret_cast<const_reference>(_M_impl.at(__n)); }
 
   explicit vector(const allocator_type& __a = allocator_type())
-    : _M_impl(__a) {}
+    : _M_impl(_STLP_CONVERT_ALLOCATOR(__a, allocator_type, _StorageType)) {}
 
   explicit vector(size_type __n, const value_type& __val = value_type(),
          const allocator_type& __a = allocator_type())

--- a/src/system/stlport/stl/pointers/_vector.h
+++ b/src/system/stlport/stl/pointers/_vector.h
@@ -129,10 +129,7 @@ public:
 #else
   void push_back(const value_type& __x)
 #endif
-  {
-    const _StorageType __s = cast_traits::to_storage_type_cref(__x);
-    _M_impl.push_back(__s);
-  }
+  { _M_impl.push_back(cast_traits::to_storage_type_cref(__x)); }
 
 #if !defined(_STLP_NO_ANACHRONISMS)
   iterator insert(iterator __pos, const value_type& __x = value_type())
@@ -162,6 +159,132 @@ public:
 
   void resize(size_type __new_size, const value_type& __x = value_type())
   { _M_impl.resize(__new_size, cast_traits::to_storage_type_cref(__x)); }
+
+  void clear() { _M_impl.clear(); }
+
+private:
+  _Base _M_impl;
+};
+
+// Pointer wrapper
+// Necessary due to differences specific to vectors containing pointers.
+// The original implementation above is left unmodified to prevent making new issues.
+template <class _Tp, class _Size, class _Alloc>
+class vector<_Tp*, _Size, _Alloc>
+{
+  typedef void* _StorageType;
+  typedef typename _Alloc_traits<_StorageType, _Alloc>::allocator_type _StorageTypeAlloc;
+  typedef _STLP_PRIV::VECTOR_IMPL<_StorageType, _Size, _StorageTypeAlloc> _Base;
+  typedef vector<_Tp, _Size, _Alloc> _Self;
+
+public:
+  typedef _Tp value_type;
+  typedef value_type* pointer;
+  typedef const value_type* const_pointer;
+  typedef value_type* iterator;
+  typedef const value_type* const_iterator;
+  typedef value_type& reference;
+  typedef const value_type& const_reference;
+  typedef size_t size_type;
+  typedef ptrdiff_t difference_type;
+  typedef random_access_iterator_tag _Iterator_category;
+
+  _STLP_DECLARE_RANDOM_ACCESS_REVERSE_ITERATORS;
+  typedef typename _Alloc_traits<pointer, _Alloc>::allocator_type allocator_type;
+
+  allocator_type get_allocator() const
+  { return _M_impl.get_allocator(); }
+
+  iterator begin()             { return reinterpret_cast<iterator>(_M_impl.begin()); }
+  const_iterator begin() const { return reinterpret_cast<const_iterator>(_M_impl.begin()); }
+  iterator end()               { return reinterpret_cast<iterator>(_M_impl.end()); }
+  const_iterator end() const   { return reinterpret_cast<const_iterator>(_M_impl.end()); }
+
+  reverse_iterator rbegin()              { return reverse_iterator(end()); }
+  const_reverse_iterator rbegin() const  { return const_reverse_iterator(end()); }
+  reverse_iterator rend()                { return reverse_iterator(begin()); }
+  const_reverse_iterator rend() const    { return const_reverse_iterator(begin()); }
+
+  size_type size() const        { return _M_impl.size(); }
+  size_type max_size() const    { return _M_impl.max_size(); }
+
+  size_type capacity() const    { return _M_impl.capacity(); }
+  bool empty() const            { return _M_impl.empty(); }
+
+  pointer& operator[](size_type __n) { return reinterpret_cast<pointer&>(_M_impl[__n]); }
+  const_pointer& operator[](size_type __n) const { return reinterpret_cast<const_pointer&>(_M_impl[__n]); }
+
+  reference front()             { return reinterpret_cast<reference>(_M_impl.front()); }
+  const_reference front() const { return reinterpret_cast<const_reference>(_M_impl.front()); }
+  reference back()              { return reinterpret_cast<reference>(_M_impl.back()); }
+  const_reference back() const  { return reinterpret_cast<const_reference>(_M_impl.back()); }
+
+  reference at(size_type __n) { return reinterpret_cast<reference>(_M_impl.at(__n)); }
+  const_reference at(size_type __n) const { return reinterpret_cast<const_reference>(_M_impl.at(__n)); }
+
+  explicit vector(const allocator_type& __a = allocator_type())
+    : _M_impl(__a) {}
+
+  explicit vector(size_type __n, const value_type& __val = value_type(),
+         const allocator_type& __a = allocator_type())
+    : _M_impl(__n, reinterpret_cast<_StorageType const&>(__val),
+      __a) {}
+
+  vector(const _Self& __x)
+    : _M_impl(__x._M_impl) {}
+
+  explicit vector(__move_source<_Self> src)
+    : _M_impl(__move_source<_Base>(src.get()._M_impl)) {}
+
+  template <class _InputIterator>
+  vector(_InputIterator __first, _InputIterator __last,
+         const allocator_type& __a = allocator_type() )
+  : _M_impl(__first, __last,
+            __a) {}
+
+  _Self& operator=(const _Self& __x) { _M_impl = __x._M_impl; return *this; }
+
+  void reserve(size_type __n) {_M_impl.reserve(__n);}
+  void assign(size_type __n, const value_type& __val)
+  { _M_impl.assign(__n, reinterpret_cast<_StorageType const&>(__val)); }
+
+  template <class _InputIterator>
+  void assign(_InputIterator __first, _InputIterator __last)
+  { _M_impl.assign(__first, __last); }
+
+  void push_back(pointer __x) {
+    value_type& __y = *__x; // Necessary to match correctly
+    _M_impl.push_back(reinterpret_cast<_StorageType*>(&__y));
+  }
+
+#if !defined(_STLP_NO_ANACHRONISMS)
+  iterator insert(iterator __pos, const value_type& __x = value_type())
+#else
+  iterator insert(iterator __pos, const value_type& __x)
+#endif
+  { return reinterpret_cast<iterator>(_M_impl.insert(reinterpret_cast<_StorageType*>(__pos),
+                                                         reinterpret_cast<_StorageType const&>(__x))); }
+
+  void swap(_Self& __x) { _M_impl.swap(__x._M_impl); }
+
+  template <class _InputIterator>
+  void insert(iterator __pos, _InputIterator __first, _InputIterator __last)
+  { _M_impl.insert(reinterpret_cast<_StorageType*>(__pos), __first, __last); }
+
+  void insert (iterator __pos, size_type __n, const value_type& __x) {
+    _M_impl.insert(reinterpret_cast<_StorageType*>(__pos), __n, reinterpret_cast<_StorageType const&>(__x));
+  }
+
+  void pop_back() {_M_impl.pop_back();}
+  iterator erase(iterator __pos)
+  {return reinterpret_cast<iterator>(_M_impl.erase(reinterpret_cast<_StorageType*>(__pos)));}
+  iterator erase(iterator __first, iterator __last) {
+    return reinterpret_cast<iterator>(_M_impl.erase(reinterpret_cast<_StorageType*>(__first),
+                                                        reinterpret_cast<_StorageType*>(__last)));
+  }
+
+  void resize(size_type __new_size, const value_type& __x = value_type())
+  { _M_impl.resize(__new_size, reinterpret_cast<_StorageType const&>(__x)); }
 
   void clear() { _M_impl.clear(); }
 

--- a/src/system/stlport/stl/pointers/_vector.h
+++ b/src/system/stlport/stl/pointers/_vector.h
@@ -129,7 +129,10 @@ public:
 #else
   void push_back(const value_type& __x)
 #endif
-  { _M_impl.push_back(cast_traits::to_storage_type_cref(__x)); }
+  {
+    const _StorageType __s = cast_traits::to_storage_type_cref(__x);
+    _M_impl.push_back(__s);
+  }
 
 #if !defined(_STLP_NO_ANACHRONISMS)
   iterator insert(iterator __pos, const value_type& __x = value_type())

--- a/src/system/utl/Str.cpp
+++ b/src/system/utl/Str.cpp
@@ -2,7 +2,9 @@
 #include "os/Debug.h"
 #include "utl/MemMgr.h"
 #include "system/milo_types.h"
+
 #include <ctype.h>
+#include <string.h>
 
 char gEmpty = 0;
 const char* fname = "Str.cpp";
@@ -238,7 +240,28 @@ bool String::contains(const char *str) const {
     return (index != -1);
 }
 
-// split goes here
+int String::split(const char *token, std::vector<String>& subStrings) const {
+    MILO_ASSERT(subStrings.empty(), 345);
+
+    int lastIndex = 0;
+    int splitIndex = find_first_of(token, 0);
+
+    while (splitIndex != -1U) {
+        if (splitIndex > lastIndex) {
+            String split = substr(lastIndex, splitIndex - lastIndex);
+            subStrings.push_back(split);
+        }
+        lastIndex = splitIndex + 1;
+        splitIndex = find_first_of(token, lastIndex);
+    }
+
+    if (lastIndex < length()) {
+        String split = substr(lastIndex, length() - lastIndex);
+        subStrings.push_back(split);
+    }
+
+    return subStrings.size();
+}
 
 String String::substr(unsigned int pos) const {
     MILO_ASSERT(pos <= mCap, 0x183);

--- a/src/system/utl/Str.h
+++ b/src/system/utl/Str.h
@@ -3,6 +3,7 @@
 #include "utl/TextStream.h"
 #include "utl/Symbol.h"
 #include <string.h>
+#include <vector>
 
 class String : public TextStream {
 public:
@@ -58,8 +59,8 @@ public:
     unsigned int rfind(const char*) const;
 
     bool contains(const char*) const;
-    
-    // split (const char*, vector<String>)
+
+    int split(const char *token, std::vector<String>& subStrings) const;
 
     String substr(unsigned int) const;
     String substr(unsigned int, unsigned int) const;


### PR DESCRIPTION
PR'ing so that this stuff doesn't rot away on my local repo for any longer lol

Vector is still not fully matching, got an annoying regswap in `_M_insert_overflow`. `JsonUtils` would be matching otherwise

![](https://github.com/DarkRTA/rb3/assets/29052821/96ce4646-3577-4572-9a23-2f89e558f68e)
![](https://github.com/DarkRTA/rb3/assets/29052821/14d09348-f3a7-41fc-a82b-2a04d142284c)

---

I added a `MILO_DEBUG` define for the debug macros, so that we can switch back to retail where needed. I also added a `GAME_VERSION` define for any instances where code deviates between builds. It was necessary to fix a vector difference in retail, and will most certainly be necessary in the future.