### PR TITLE
Remove some more VS Code settings.json entries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
   "[python]":{
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
-  "editor.tabSize": 4,
   "files.associations": {
     "algorithm": "cpp",
     "bitset": "cpp",
@@ -71,8 +70,6 @@
     "valarray": "cpp",
     "vector": "cpp",
   },
-  "files.insertFinalNewline": true,
-  "files.trimFinalNewlines": true,
   "C/C++ Include Guard.Macro Type": "Filepath",
   "C/C++ Include Guard.Prefix": "",
   "C/C++ Include Guard.Suffix": "",
@@ -102,7 +99,6 @@
   "C/C++ Include Guard.Auto Update Path Blocklist": [
     "include/zlib"
   ],
-  "search.useIgnoreFiles": false,
   "json.schemas": [
     {
       "fileMatch": [


### PR DESCRIPTION
These settings don't need to be explicitly forced for the workspace; .editorconfig and formatting will take care of tab size and trailing newlines, and forcing ignore file usage in search off isn't necessary as there's a toggle right in the search menu for it.