### PR TITLE
Fix and match PlatformMgr

### DIFF
--- a/config/SZBE69_B8/objects.json
+++ b/config/SZBE69_B8/objects.json
@@ -300,7 +300,7 @@
             "system/os/NetStream.cpp": "NonMatching",
             "system/os/NetworkSocket_Wii.cpp": "NonMatching",
             "system/os/OnlineID.cpp": "Matching",
-            "system/os/PlatformMgr.cpp": "NonMatching",
+            "system/os/PlatformMgr.cpp": { "status": "NonMatching", "extra_cflags": ["-ipa file"] },
             "system/os/PlatformMgr_Wii.cpp": "NonMatching",
             "system/os/ProfilePicture.cpp": "NonMatching",
             "system/os/ProfilePicture_Wii.cpp": "Matching",

--- a/config/SZBE69_B8/objects.json
+++ b/config/SZBE69_B8/objects.json
@@ -300,7 +300,7 @@
             "system/os/NetStream.cpp": "NonMatching",
             "system/os/NetworkSocket_Wii.cpp": "NonMatching",
             "system/os/OnlineID.cpp": "Matching",
-            "system/os/PlatformMgr.cpp": { "status": "NonMatching", "extra_cflags": ["-ipa file"] },
+            "system/os/PlatformMgr.cpp": { "status": "Matching", "extra_cflags": ["-ipa file"] },
             "system/os/PlatformMgr_Wii.cpp": "NonMatching",
             "system/os/ProfilePicture.cpp": "NonMatching",
             "system/os/ProfilePicture_Wii.cpp": "Matching",

--- a/src/system/os/PlatformMgr.cpp
+++ b/src/system/os/PlatformMgr.cpp
@@ -34,7 +34,7 @@ PlatformRegion SymbolToPlatformRegion(Symbol s){
 }
 
 void UTF8FilterKeyboardString(char* c, int i, const char* cc){
-    static const char* allowed = SystemConfig(platform_mgr)->FindArray(keyboard_allowed_chars, true)->Str(1);
+    static const char* allowed = SystemConfig(platform_mgr)->FindStr(keyboard_allowed_chars);
     UTF8FilterString(c, i, cc, allowed, '?');
 }
 

--- a/src/system/os/PlatformMgr.h
+++ b/src/system/os/PlatformMgr.h
@@ -28,7 +28,7 @@ enum NotifyLocation {
     i, d, k
 };
 
-class PlatformMgr : public MsgSource, ContentMgr::Callback {
+class PlatformMgr : public MsgSource, public ContentMgr::Callback {
 public:
     PlatformMgr();
     virtual DataNode Handle(DataArray*, bool);
@@ -113,7 +113,7 @@ public:
     bool unk6d;
     int unk70;
     bool mEthernetCableConnected;
-    
+
     char filler[0x432b];
 
     bool unk43a0;

--- a/src/system/os/PlatformMgr.h
+++ b/src/system/os/PlatformMgr.h
@@ -157,7 +157,7 @@ public:
     bool mIsOnlineRestricted;
     bool unkce69;
     bool unkce6a;
-};
+} __attribute__((aligned(32)));
 
 Symbol PlatformRegionToSymbol(PlatformRegion);
 PlatformRegion SymbolToPlatformRegion(Symbol);


### PR DESCRIPTION
0.06% code, 1.94% data!

`-ipa file` seems to be the key to all the inline generation reversals we have. It doesn't work when set globally however, causes a ton of link errors, so this was likely hand-set on specific files.