### PR TITLE
Fix warnings again, a small bit of tidy

### DIFF
--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -20,6 +20,8 @@
                 "-fp hardware",
 
                 "-pragma \"cats off\"",
+
+                "-pragma \"warning off (10184)\"",
                 "-pragma \"warn_notinlined off\"",
 
                 "-RTTI on",

--- a/config/SZBE69_B8/flags.json
+++ b/config/SZBE69_B8/flags.json
@@ -23,6 +23,8 @@
 
                 "-pragma \"warning off (10184)\"",
                 "-pragma \"warn_notinlined off\"",
+                "-pragma \"warn_filenamecaps on\"",
+                "-pragma \"warn_filenamecaps_system on\"",
 
                 "-RTTI on",
                 "-Cpp_exceptions off",

--- a/src/network/Platform/MemoryManager.h
+++ b/src/network/Platform/MemoryManager.h
@@ -37,7 +37,7 @@ namespace Quazal {
 
         static void *Allocate(unsigned long size, _InstructionType inst) {
             MemoryManager* memMgr = MemoryManager::GetDefaultMemoryManager();
-            Allocate(memMgr, size, "Unknown", 0, inst);
+            return Allocate(memMgr, size, "Unknown", 0, inst);
         }
 
         int GetHeaderSize();

--- a/src/network/Platform/Result.cpp
+++ b/src/network/Platform/Result.cpp
@@ -25,12 +25,14 @@ namespace Quazal {
         m_iReturnCode = i;
         m_cszFilename = __FILE__;
         m_iLineNumber = 0x59;
+        return *this;
     }
 
     qResult& qResult::operator=(const qResult& q){
         m_iReturnCode = q.m_iReturnCode;
         m_cszFilename = q.m_cszFilename;
         m_iLineNumber = q.m_iLineNumber;
+        return *this;
     }
 
     void qResult::Trace(unsigned int) const {}

--- a/src/network/Platform/RootObject.cpp
+++ b/src/network/Platform/RootObject.cpp
@@ -4,22 +4,22 @@
 namespace Quazal {
 
     void* RootObject::operator new(unsigned long ul){
-        MemoryManager::Allocate(ul, MemoryManager::_InstType3);
+        return MemoryManager::Allocate(ul, MemoryManager::_InstType3);
     }
 
     void* RootObject::operator new(unsigned long ul, const char *cc, unsigned int ui) {
-        MemoryManager::Allocate(
+        return MemoryManager::Allocate(
             MemoryManager::GetDefaultMemoryManager(),
             ul, cc, ui,
             MemoryManager::_InstType3);
     }
 
     void* RootObject::operator new[](unsigned long ul) {
-        MemoryManager::Allocate(ul, MemoryManager::_InstType4);
+        return MemoryManager::Allocate(ul, MemoryManager::_InstType4);
     }
 
     void* RootObject::operator new[](unsigned long ul, const char *cc, unsigned int ui) {
-        MemoryManager::Allocate(
+        return MemoryManager::Allocate(
             MemoryManager::GetDefaultMemoryManager(),
             ul, cc, ui,
             MemoryManager::_InstType4);

--- a/src/system/math/Sqrt_Wii.c
+++ b/src/system/math/Sqrt_Wii.c
@@ -1,15 +1,17 @@
 #include "decomp.h"
-double sqrt(register double f1) {
-    register float f0 = f1;
-    register float f2 = 0.5f, f3 = 3.0f, f4;
+double sqrt(register double value) {
+    register float fValue = value; // f0
+    register float f_1, half = 0.5f, three = 3.0f, f_4;
+
     ASM_BLOCK (
-        frsqrte f1, f0 // f1 = 1/sqrt(f0)
-        fmuls f4, f1, f1 // f4 = f1 * f1
-        fmuls f1, f1, f2 // f1 *= f2
-        fnmsubs f4, f4, f0, f3 // f4 = -((f4 * f0) - f3)
-        fmuls f1, f4, f1 // f1 *= f4
-        fsel f1, f1, f1, f0 // f1 = f0 > 0 ? f1 : f1
-        fmuls f1, f0, f1 // f1 *= f0
+        frsqrte  f_1, fValue              // f_1 = 1/sqrt(fValue)
+        fmuls    f_4, f_1, f_1            // f_4 = f_1 * f_1
+        fmuls    f_1, f_1, half           // f_1 *= half
+        fnmsubs  f_4, f_4, fValue, three  // f_4 = -((f_4 * fValue) - three)
+        fmuls    f_1, f_4, f_1            // f_1 *= f_4
+        fsel     f_1, f_1, f_1, fValue    // f_1 = fValue > 0 ? f_1 : f_1
+        fmuls    value, fValue, f_1       // f_1 *= fValue
     )
-    return f1;
+
+    return value;
 }

--- a/src/system/midi/MidiReader.cpp
+++ b/src/system/midi/MidiReader.cpp
@@ -249,15 +249,17 @@ void MidiReader::ReadMidiEvent(int tick, unsigned char status, unsigned char dat
 void MidiReader::ReadSystemEvent(int i, unsigned char uc, BinStream& bs){
     switch(uc){
         case 0xF0:
-        case 0xF7:
+        case 0xF7: {
             MidiVarLenNumber num(bs);
             bs.Seek(num.mValue, BinStream::kSeekCur);
             break;
-        case 0xFF:
+        }
+        case 0xFF: {
             unsigned char read;
             bs >> read;
             ReadMetaEvent(i, read, bs);
             break;
+        }
         default:
             MILO_WARN("%s (%s): Cannot parse system event %i", mStreamName.c_str(), mCurTrackName.c_str(), uc);
             break;
@@ -274,7 +276,7 @@ void MidiReader::ReadMetaEvent(int i, unsigned char uc, BinStream& bs){
         case 0x1:
         case 0x2:
         case 0x3:
-        case 0x5:
+        case 0x5: {
             char buf[0x100];
             if(numVal >= 0x100){
                 bs.Read(buf, 8);
@@ -305,7 +307,8 @@ void MidiReader::ReadMetaEvent(int i, unsigned char uc, BinStream& bs){
                 mRcvr.OnText(i, buf, uc);
             }
             break;
-        case 0x51:
+        }
+        case 0x51: {
             unsigned char c,b,a;
             bs >> c >> b >> a;
             int product = a + c * 0x10000 + b * 0x100;
@@ -325,7 +328,8 @@ void MidiReader::ReadMetaEvent(int i, unsigned char uc, BinStream& bs){
                     mStreamName.c_str(), mCurTrackName.c_str(), TickFormat(i, *mMeasureMap), 6e+07f / (float)product);
             }
             break;
-        case 0x2F:
+        }
+        case 0x2F: {
             ProcessMidiList();
             if(mCurTrackIndex == mNumTracks){
                 mState = kEnd;
@@ -340,7 +344,8 @@ void MidiReader::ReadMetaEvent(int i, unsigned char uc, BinStream& bs){
                 mRcvr.OnEndOfTrack();
             }
             break;
-        case 0x58:
+        }
+        case 0x58: {
             unsigned char ts_num, ts_den;
             bs >> ts_num >> ts_den;
             if(ts_den > 6){
@@ -366,6 +371,7 @@ void MidiReader::ReadMetaEvent(int i, unsigned char uc, BinStream& bs){
                 bs.Seek(2, BinStream::kSeekCur);
             }
             break;
+        }
         case 4:
         case 6:
         case 7:

--- a/src/system/obj/Object.h
+++ b/src/system/obj/Object.h
@@ -48,7 +48,7 @@ public:
     void ReplaceObject(DataNode&, Hmx::Object*, Hmx::Object*, Hmx::Object*);
     void Replace(Hmx::Object*, Hmx::Object*, Hmx::Object*);
     int Size() const;
-    TypeProps& Copy(const TypeProps&, Hmx::Object*);
+    void Copy(const TypeProps&, Hmx::Object*);
     Symbol Key(int) const;
     DataNode& Value(int) const;
 };

--- a/src/system/obj/PropSync_p.h
+++ b/src/system/obj/PropSync_p.h
@@ -25,7 +25,6 @@ template<class T1, class T2> class ObjPtr;
 template<class T1, class T2> class ObjOwnerPtr;
 template<class T1, class T2> class ObjPtrList;
 template<class T> class ObjDirPtr;
-template<class T1, class T2 = u16> class ObjVector;
 
 bool PropSync(class String&, DataNode&, DataArray*, int, PropOp);
 bool PropSync(FilePath&, DataNode&, DataArray*, int, PropOp);
@@ -124,26 +123,30 @@ template <class T> bool PropSync(ObjPtrList<T, class ObjectDir>& ptr, DataNode& 
         for(int cnt = prop->Int(i++); cnt > 0; cnt--) ++it;
         MILO_ASSERT(i == prop->Size(), 0x150);
         switch(op){
-            case kPropGet:
+            case kPropGet: {
                 T* item = *it;
                 return PropSync(item, node, prop, i, op);
-            case kPropSet:
+            }
+            case kPropSet: {
                 T* objToSet = 0;
                 if(PropSync(objToSet, node, prop, i, op)){
                     ptr.Set(it, objToSet);
                     return true;
                 }
                 break;
-            case kPropRemove:
+            }
+            case kPropRemove: {
                 ptr.erase(it);
                 return true;
-            case kPropInsert:
+            }
+            case kPropInsert: {
                 T* objToInsert = 0;
                 if(PropSync(objToInsert, node, prop, i, op)){
                     ptr.insert(it, objToInsert);
                     return true;
                 }
                 break;
+            }
         }
         return false;
     }

--- a/src/system/obj/TypeProps.cpp
+++ b/src/system/obj/TypeProps.cpp
@@ -183,7 +183,7 @@ void TypeProps::Save(BinStream& d, Hmx::Object* ref){
         return;
     }
     d << potentialArr;
-    
+
 }
 
 void TypeProps::Load(BinStream& d, bool old_proxy, Hmx::Object* ref){
@@ -217,7 +217,6 @@ void TypeProps::Load(BinStream& d, bool old_proxy, Hmx::Object* ref){
 
     if(def){
         if(mMap && TheLoadMgr.EditMode()){
-            
             for(int i = 0; mMap && i < mMap->Size(); i += 2){
                 DataArray* found = def->FindArray(mMap->Sym(i), false);
                 if(!found || (CONST_ARRAY(found)->Node(1).Type() != kDataCommand) && !found->Node(1).CompatibleType(CONST_ARRAY(mMap)->Node(i + 1).Type())) {
@@ -309,7 +308,7 @@ void TypeProps::AddRefObjects(Hmx::Object* ref){
     }
 }
 
-TypeProps& TypeProps::Copy(const TypeProps& prop, Hmx::Object* ref){
+void TypeProps::Copy(const TypeProps& prop, Hmx::Object* ref){
     ClearAll(ref);
     if(prop.mMap != 0){
         mMap = prop.mMap->Clone(true, false, 0);

--- a/src/system/os/CritSec.h
+++ b/src/system/os/CritSec.h
@@ -1,6 +1,6 @@
 #ifndef OS_CRITSEC_H
 #define OS_CRITSEC_H
-#include <revolution/os.h>
+#include <revolution/OS.h>
 #include "utl/PoolAlloc.h"
 
 class CriticalSection {

--- a/src/system/os/DateTime.cpp
+++ b/src/system/os/DateTime.cpp
@@ -6,7 +6,7 @@
 #include "utl/Symbols.h"
 #include "utl/Locale.h"
 #include "utl/LocaleOrdinal.h"
-#include <revolution/os.h>
+#include <revolution/OS.h>
 
 #include "decomp.h"
 

--- a/src/system/os/Debug.cpp
+++ b/src/system/os/Debug.cpp
@@ -13,7 +13,7 @@
 #include "os/System.h"
 #include "os/Timer.h"
 
-#include <revolution/os.h>
+#include <revolution/OS.h>
 #include <cstdlib>
 #include <vector>
 

--- a/src/system/os/HDCache.h
+++ b/src/system/os/HDCache.h
@@ -5,7 +5,7 @@
 #include "utl/FileStream.h"
 #include "utl/MemStream.h"
 #include <vector>
-#include <revolution/os.h>
+#include <revolution/OS.h>
 
 class HDCache {
 public:

--- a/src/system/os/OSFuncs.h
+++ b/src/system/os/OSFuncs.h
@@ -1,6 +1,6 @@
 #ifndef OS_OSFUNCS_H
 #define OS_OSFUNCS_H
-#include <revolution/os.h>
+#include <revolution/OS.h>
 
 extern OSThread* gMainThreadID;
 

--- a/src/system/os/ProfilePicture.cpp
+++ b/src/system/os/ProfilePicture.cpp
@@ -4,15 +4,17 @@
 void ProfilePicture::Update(){
 
     switch(mState){
-        case kComplete:
+        case kComplete: {
             OnlineID id;
             ThePlatformMgr.GetOnlineID(mPadNum, &id);
             if(id == mUserID) return;
             mUserID = id;
-        case kIdle:
+        }
+        case kIdle: {
             mState = kFetchingUserData;
             FetchUserData();
             break;
+        }
         default: break;
     }
 }

--- a/src/system/os/SynchronizationEvent.h
+++ b/src/system/os/SynchronizationEvent.h
@@ -1,6 +1,6 @@
 #ifndef OS_SYNCHRONIZATIONEVENT_H
 #define OS_SYNCHRONIZATIONEVENT_H
-#include <revolution/os.h>
+#include <revolution/OS.h>
 
 class SynchronizationEvent {
 public:

--- a/src/system/os/System_Wii.cpp
+++ b/src/system/os/System_Wii.cpp
@@ -50,12 +50,12 @@ void CaptureStackTrace(int depth, unsigned int* trace) {
 
 bool PlatformDebugBreak() {
     if (OSGetConsoleType() & OS_CONSOLE_MASK_EMU) {
-        register int r0, r3;
-        ASM_BLOCK(mfmsr r3) // ??????
-        r0 = r3 | 0x400;
+        register int breakState, ogState;
+        ASM_BLOCK(mfmsr ogState) // Move from Machine State Register
+        breakState = ogState | 0x400;
         ASM_BLOCK(
-            mtmsr r0
-            mtmsr r3
+            mtmsr breakState
+            mtmsr ogState
         )
         return true;
     }

--- a/src/system/os/ThreadCall.h
+++ b/src/system/os/ThreadCall.h
@@ -1,5 +1,5 @@
-#ifndef OS_THREADCALLWII_H
-#define OS_THREADCALLWII_H
+#ifndef OS_THREADCALL_H
+#define OS_THREADCALL_H
 
 class ThreadCallback;
 
@@ -10,4 +10,4 @@ void ThreadCall(int(*)(void), void (*)(int));
 void ThreadCall(ThreadCallback*);
 void ThreadCallPoll();
 
-#endif // OS_THREADCALLWII_H
+#endif // OS_THREADCALL_H

--- a/src/system/rndobj/MultiMesh.h
+++ b/src/system/rndobj/MultiMesh.h
@@ -73,7 +73,10 @@ public:
     }
 };
 
-inline BinStream& operator>>(BinStream& bs, RndMultiMesh::Instance& i) { i.Load(bs); }
+inline BinStream& operator>>(BinStream& bs, RndMultiMesh::Instance& i) {
+    i.Load(bs);
+    return bs;
+}
 
 TextStream& operator<<(TextStream& ts, const RndMultiMesh::Instance& i);
 

--- a/src/system/synth/SynthSample.cpp
+++ b/src/system/synth/SynthSample.cpp
@@ -45,13 +45,13 @@ void SynthSample::Sync(SynthSample::SyncType ty){
         mSampleData.Reset();
         if(!mFile.empty()){
             FileLoader* fl = dynamic_cast<FileLoader*>(TheLoadMgr.ForceGetLoader(mFile));
-            void* buf;
+            const char* buf;
             int size;
-            if(fl) buf = (void*)fl->GetBuffer(&size);
+            if(fl) buf = fl->GetBuffer(&size);
             else buf = 0;
             delete fl;
             if(buf){
-                BufStream bufs(buf, size, true);
+                BufStream bufs((void*)buf, size, true);
                 if(TheLoadMgr.GetPlatform() == kPlatformPC){
                     mSampleData.LoadWAV(bufs, mFile);
                 }
@@ -80,12 +80,12 @@ void SynthSample::PreLoad(BinStream& bs){
     if(!bs.Cached() || gRev < 5){
         if (gRev > 3) {
             mFileLoader = dynamic_cast<FileLoader*>(TheLoadMgr.AddLoader(mFile, kLoadFront));
-        }    
+        }
     }
     else if (gAltRev != 0) {
         CacheResourceResult res;
         mFileLoader = new FileLoader(mFile, CacheWav(mFile.c_str(), res), kLoadFront, 0, false, true, &bs);
-    }    
+    }
     else mSampleData.Load(bs, mFile);
     PushRev(packRevs(gAltRev, gRev), this);
 }

--- a/src/system/utl/Cache.cpp
+++ b/src/system/utl/Cache.cpp
@@ -1,7 +1,7 @@
 #include "utl/Cache.h"
 #include "os/Debug.h"
 #include "os/Timer.h"
-#include "os/ThreadCall_Wii.h"
+#include "os/ThreadCall.h"
 
 int CacheID::GetDeviceID() const {
     MILO_FAIL("CacheID::GetDeviceID() not supported on this platform.\n");
@@ -9,11 +9,11 @@ int CacheID::GetDeviceID() const {
 }
 
 Cache::Cache() : mOpCur(kOpNone), mLastResult(kCache_NoError) {
-    
+
 }
 
 Cache::~Cache(){
-    
+
 }
 
 bool Cache::IsDone(){

--- a/src/system/utl/Cache_Wii.cpp
+++ b/src/system/utl/Cache_Wii.cpp
@@ -1,6 +1,6 @@
 #include "Cache_Wii.h"
 #include "VF.h"
-#include "system/os/ThreadCall_Wii.h"
+#include "system/os/ThreadCall.h"
 
 
 CacheIDWii::CacheIDWii() {
@@ -60,7 +60,7 @@ CacheWii::CacheWii(const CacheIDWii& param_1) {
             const char* error = VFGetApiErrorString();
             OSReport("VFCreateDir vfErr %s Line %d\n", error, 0x5d);
         }
-        dirResult = VFChangeDir(m0x64); 
+        dirResult = VFChangeDir(m0x64);
         if (dirResult != 0) {
             const char* error = VFGetApiErrorString();
             OSReport("VFChangeDir vfErr %s Line %d\n", error, 0x67);

--- a/src/system/world/CameraShot.h
+++ b/src/system/world/CameraShot.h
@@ -48,6 +48,7 @@ public:
 
 inline BinStream& operator>>(BinStream& bs, CamShotFrame& csf){
     csf.Load(bs);
+    return bs;
 }
 
 class CamShotCrowd {
@@ -72,7 +73,7 @@ public:
     virtual void Copy(const Hmx::Object*, Hmx::Object::CopyType);
     virtual void Load(BinStream&);
     virtual ~CamShot();
-    
+
     virtual void StartAnim();
     virtual void EndAnim();
     virtual void SetFrame(float, float);


### PR DESCRIPTION
- Fix a bunch of warnings
- Disable missing-return warning since some spots need a missing return
  - Also just causes noise in the output when building, there's a few functions currently which aren't implemented yet
- Enable warning for mismatching capitalization of include filenames