### PR TITLE
Add `-f` and `-l` suffix versions and `<cmath>` overloads of `math.h` functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@ AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortEnumsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: All
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false

--- a/config/SZBE69_B8/objects.json
+++ b/config/SZBE69_B8/objects.json
@@ -1511,7 +1511,7 @@
             "system/oggvorbis/codebook.c": "NonMatching",
             "system/oggvorbis/envelope.c": "Matching",
             "system/oggvorbis/floor0.c": "NonMatching",
-            "system/oggvorbis/floor1.c": "NonMatching",
+            "system/oggvorbis/floor1.c": "Matching",
             "system/oggvorbis/framing.c": "Matching",
             "system/oggvorbis/info.c": "Matching",
             "system/oggvorbis/lsp.c": "Matching",

--- a/src/band3/bandtrack/GemRepTemplate.cpp
+++ b/src/band3/bandtrack/GemRepTemplate.cpp
@@ -8,8 +8,8 @@
 
 #define kNumGemSlotMats 1
 
-GemRepTemplate::GemRepTemplate(const TrackConfig& tc) : mConfig(SystemConfig("track_graphics", "gem")), 
-    kTailPulseRate(mConfig->FindArray("tail_pulse_rate", true)->Float(1)), 
+GemRepTemplate::GemRepTemplate(const TrackConfig& tc) : mConfig(SystemConfig("track_graphics", "gem")),
+    kTailPulseRate(mConfig->FindArray("tail_pulse_rate", true)->Float(1)),
     kTailPulseSmoothing(mConfig->FindArray("tail_pulse_smoothing", true)->Float(1)),
     kTailOffsetX(mConfig->FindArray("tail_offset_x", true)->Float(1)),
     kTailMinAlpha(mConfig->FindArray("tail_min_alpha", true)->Float(1)),
@@ -73,7 +73,7 @@ RndMat* GemRepTemplate::GetMatByTag(const char* c, int slot) {
 }
 
 bool VertLess(const RndMesh::Vert& v1, const RndMesh::Vert& v2) {
-    if ((float)__fabs(v1.pos.y - v2.pos.y) < 0.1f) { // nonsense regswap
+    if ((float)std::fabs(double(v1.pos.y - v2.pos.y)) < 0.1f) { // nonsense regswap
         return v1.pos.x < v2.pos.x;
     }
     return v1.pos.y < v2.pos.y;

--- a/src/band3/game/Shuttle.cpp
+++ b/src/band3/game/Shuttle.cpp
@@ -8,14 +8,14 @@ Shuttle::~Shuttle() {}
 void Shuttle::SetActive(bool b) { mActive = b; }
 
 void Shuttle::Poll() {
-    if (mActive) { 
+    if (mActive) {
         JoypadData* data = JoypadGetPadData(mPadNum);
         if (data) {
             float f2 = pow(data->GetLX(), 5);
             float f1 = 1000.0f;
             f1 *= f2;
             float f0 = unk_0x0 + f1; // this func is a mess
-            if (f0 > unk_0x4) { 
+            if (f0 > unk_0x4) {
                 if (f0 < 0) f2 = f0;
             } else f2 = unk_0x4;
 

--- a/src/sdk/PowerPC_EABI_Support/MSL/MSL_C++/cmath
+++ b/src/sdk/PowerPC_EABI_Support/MSL/MSL_C++/cmath
@@ -6,34 +6,142 @@ namespace std {
     using ::double_t;
     using ::float_t;
 
-    using ::fabs;
-    using ::fmod;
+#define _IMPORT_MATH_NAME(name)                                                          \
+    using ::name;                                                                        \
+    using ::name##f;                                                                     \
+    using ::name##l
 
-    using ::exp;
-    using ::log;
-    using ::log10;
+#define _IMPORT_MATH(name)                                                               \
+    _IMPORT_MATH_NAME(name);                                                             \
+    inline float name(float x) { return name##f(x); }                                    \
+    inline long double name(long double x) { return name##l(x); }
 
-    using ::pow;
-    using ::sqrt;
+#define _IMPORT_MATHC(name, argtype, arg)                                                \
+    _IMPORT_MATH_NAME(name);                                                             \
+    inline float name(argtype arg) { return name##f(arg); }                              \
+    inline long double name(argtype arg) { return name##l(arg); }
 
-    using ::sin;
-    using ::cos;
-    using ::tan;
-    using ::asin;
-    using ::acos;
-    using ::atan;
-    using ::atan2;
+#define _IMPORT_MATHR(name, ret)                                                         \
+    _IMPORT_MATH_NAME(name);                                                             \
+    inline ret name(float x) { return name##f(x); }                                      \
+    inline ret name(long double x) { return name##l(x); }
 
-    using ::sinh;
-    using ::cosh;
-    using ::tanh;
+#define _IMPORT_MATH2(name)                                                              \
+    _IMPORT_MATH_NAME(name);                                                             \
+    inline float name(float x, float y) { return name##f(x, y); }                        \
+    inline long double name(long double x, long double y) { return name##l(x, y); }
 
-    using ::ceil;
-    using ::floor;
+#define _IMPORT_MATH2C(name, arg2type, arg2)                                             \
+    _IMPORT_MATH_NAME(name);                                                             \
+    inline float name(float x, arg2type arg2) { return name##f(x, arg2); }               \
+    inline long double name(long double x, arg2type arg2) { return name##l(x, arg2); }
 
-    using ::frexp;
-    using ::ldexp;
-    using ::modf;
+#define _IMPORT_MATH2P(name, arg2name)                                                   \
+    _IMPORT_MATH_NAME(name);                                                             \
+    inline float name(float x, float *arg2name) { return name##f(x, arg2name); }         \
+    inline long double name(long double x, long double *arg2name) {                      \
+        return name##l(x, arg2name);                                                     \
+    }
+
+#define _IMPORT_MATH3(name)                                                              \
+    _IMPORT_MATH_NAME(name);                                                             \
+    inline float name(float x, float y, float z) { return name(x, y, z); }               \
+    inline long double name##f(long double x, long double y, long double z) {            \
+        return name##l(x, y, z);                                                         \
+    }
+
+#define _IMPORT_MATH3C(name, arg3type, arg3)                                             \
+    _IMPORT_MATH_NAME(name);                                                             \
+    inline float name(float x, float y, arg3type arg3) { return name##f(x, y, arg3); }   \
+    inline long double name(long double x, long double y, arg3type arg3) {               \
+        return name##l(x, y, arg3);                                                      \
+    }
+
+    _IMPORT_MATH(fabs);
+    _IMPORT_MATH2(fmod);
+    _IMPORT_MATH2(remainder);
+    _IMPORT_MATH3C(remquo, int *, quo);
+    _IMPORT_MATH3(fma);
+    _IMPORT_MATH2(fmax);
+    _IMPORT_MATH2(fmin);
+    _IMPORT_MATH2(fdim);
+
+    // _IMPORT_MATHC(nan, const char *, str);
+
+    _IMPORT_MATH(exp);
+    _IMPORT_MATH(exp2);
+    _IMPORT_MATH(expm1);
+    _IMPORT_MATH(log);
+    _IMPORT_MATH(log10);
+    _IMPORT_MATH(log2);
+    _IMPORT_MATH(log1p);
+
+    _IMPORT_MATH2(pow);
+    _IMPORT_MATH(sqrt);
+    _IMPORT_MATH(cbrt);
+    _IMPORT_MATH2(hypot);
+
+    _IMPORT_MATH(sin);
+    _IMPORT_MATH(cos);
+    _IMPORT_MATH(tan);
+    _IMPORT_MATH(asin);
+    _IMPORT_MATH(acos);
+    _IMPORT_MATH(atan);
+    _IMPORT_MATH2(atan2);
+
+    _IMPORT_MATH(sinh);
+    _IMPORT_MATH(cosh);
+    _IMPORT_MATH(tanh);
+    _IMPORT_MATH(asinh);
+    _IMPORT_MATH(acosh);
+    _IMPORT_MATH(atanh);
+
+    _IMPORT_MATH(erf);
+    _IMPORT_MATH(erfc);
+    _IMPORT_MATH(tgamma);
+    _IMPORT_MATH(lgamma);
+
+    _IMPORT_MATH(ceil);
+    _IMPORT_MATH(floor);
+    _IMPORT_MATH(trunc);
+    _IMPORT_MATH(round);
+    _IMPORT_MATHR(lround, long);
+    _IMPORT_MATHR(llround, long long);
+
+    _IMPORT_MATH(nearbyint);
+    _IMPORT_MATH(rint);
+    _IMPORT_MATHR(lrint, long);
+    _IMPORT_MATHR(llrint, long long);
+
+    _IMPORT_MATH2C(frexp, int *, exp);
+    _IMPORT_MATH2C(ldexp, int, exp);
+
+    _IMPORT_MATH2P(modf, iptr);
+
+    _IMPORT_MATH2C(scalbn, int, exp);
+    _IMPORT_MATH2C(scalbln, long, exp);
+    _IMPORT_MATHR(ilogb, int);
+    _IMPORT_MATH(logb);
+
+    _IMPORT_MATH2(nextafter);
+    _IMPORT_MATH2C(nexttoward, long double, to);
+
+    _IMPORT_MATH2(copysign);
+
+#undef _IMPORT_MATH_NAME
+#undef _IMPORT_MATH
+#undef _IMPORT_MATHC
+#undef _IMPORT_MATHR
+#undef _IMPORT_MATH2
+#undef _IMPORT_MATH2C
+#undef _IMPORT_MATH2P
+#undef _IMPORT_MATH3
+#undef _IMPORT_MATH3C
+
+    inline float abs(float x) { return fabsf(x); }
+    inline double abs(double x) { return fabs(x); }
+    inline long double abs(long double x) { return fabsl(x); }
+
 }
 
 #endif

--- a/src/sdk/PowerPC_EABI_Support/MSL/MSL_C++/cstdlib
+++ b/src/sdk/PowerPC_EABI_Support/MSL/MSL_C++/cstdlib
@@ -46,6 +46,12 @@ namespace std {
 
     using ::bsearch;
     using ::qsort;
+
+    inline long abs(long x) { return labs(x); }
+    inline long long abs(long long x) { return llabs(x); }
+
+    inline ldiv_t div(long x, long y) { return ldiv(x, y); }
+    inline lldiv_t div(long long x, long long y) { return lldiv(x, y); }
 }
 
 #endif

--- a/src/sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/arith.h
+++ b/src/sdk/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/arith.h
@@ -5,6 +5,11 @@
 extern "C" {
 #endif
 
+#if !defined(__MWERKS__) || defined(__VS_CODE__)
+#define __abs(x) abs(x)
+#define __labs(x) labs(x)
+#endif
+
 typedef struct {
     int quot;
     int rem;

--- a/src/sdk/PowerPC_EABI_Support/MSL/MSL_C/math.h
+++ b/src/sdk/PowerPC_EABI_Support/MSL/MSL_C/math.h
@@ -62,11 +62,131 @@ int __fpclassifyd(double);
 #define FP_ILOGBNAN
 */
 
-double nan(const char *str);
+#define _DECL_MATH(name)                                                                 \
+    double name(double x);                                                               \
+    inline float name##f(float x) { return name(x); }                                    \
+    inline long double name##l(long double x) { return name(x); }
 
-inline long double fabsl(long double x) {
-    return __fabs((double)x);
-}
+#define _DECL_MATHC(name, argtype, arg)                                                  \
+    double name(argtype arg);                                                            \
+    inline float name##f(argtype arg) { return name(arg); }                              \
+    inline long double name##l(argtype arg) { return name(arg); }
+
+#define _DECL_MATHR(name, ret)                                                           \
+    ret name(double x);                                                                  \
+    inline ret name##f(float x) { return name(x); }                                      \
+    inline ret name##l(long double x) { return name(x); }
+
+#define _DECL_MATH2(name)                                                                \
+    double name(double x, double y);                                                     \
+    inline float name##f(float x, float y) { return name(x, y); }                        \
+    inline long double name##l(long double x, long double y) { return name(x, y); }
+
+#define _DECL_MATH2C(name, arg2type, arg2)                                               \
+    double name(double x, arg2type arg2);                                                \
+    inline float name##f(float x, arg2type arg2) { return name(x, arg2); }               \
+    inline long double name##l(long double x, arg2type arg2) { return name(x, arg2); }
+
+#define _DECL_MATH2P(name, arg2name)                                                     \
+    double name(double x, double *arg2name);                                             \
+    float name##f(float x, float *arg2name);                                             \
+    long double name##l(long double x, long double *arg2name);
+
+#define _DECL_MATH3(name)                                                                \
+    double name(double x, double y, double z);                                           \
+    inline float name##f(float x, float y, float z) { return name(x, y, z); }            \
+    inline long double name##l(long double x, long double y, long double z) {            \
+        return name(x, y, z);                                                            \
+    }
+
+#define _DECL_MATH3C(name, arg3type, arg3)                                               \
+    double name(double x, double y, arg3type arg3);                                      \
+    inline float name##f(float x, float y, arg3type arg3) { return name(x, y, arg3); }   \
+    inline long double name##l(long double x, long double y, arg3type arg3) {            \
+        return name(x, y, arg3);                                                         \
+    }
+
+_DECL_MATH(fabs);
+_DECL_MATH2(fmod);
+_DECL_MATH2(remainder);
+_DECL_MATH3C(remquo, int *, quo);
+_DECL_MATH3(fma);
+_DECL_MATH2(fmax);
+_DECL_MATH2(fmin);
+_DECL_MATH2(fdim);
+
+_DECL_MATHC(nan, const char *, str);
+
+_DECL_MATH(exp);
+_DECL_MATH(exp2);
+_DECL_MATH(expm1);
+_DECL_MATH(log);
+_DECL_MATH(log10);
+_DECL_MATH(log2);
+_DECL_MATH(log1p);
+
+_DECL_MATH2(pow);
+_DECL_MATH(sqrt);
+_DECL_MATH(cbrt);
+_DECL_MATH2(hypot);
+
+_DECL_MATH(sin);
+_DECL_MATH(cos);
+_DECL_MATH(tan);
+_DECL_MATH(asin);
+_DECL_MATH(acos);
+_DECL_MATH(atan);
+_DECL_MATH2(atan2);
+
+_DECL_MATH(sinh);
+_DECL_MATH(cosh);
+_DECL_MATH(tanh);
+_DECL_MATH(asinh);
+_DECL_MATH(acosh);
+_DECL_MATH(atanh);
+
+_DECL_MATH(erf);
+_DECL_MATH(erfc);
+_DECL_MATH(tgamma);
+_DECL_MATH(lgamma);
+
+_DECL_MATH(ceil);
+_DECL_MATH(floor);
+_DECL_MATH(trunc);
+_DECL_MATH(round);
+_DECL_MATHR(lround, long);
+_DECL_MATHR(llround, long long);
+
+_DECL_MATH(nearbyint);
+_DECL_MATH(rint);
+_DECL_MATHR(lrint, long);
+_DECL_MATHR(llrint, long long);
+
+_DECL_MATH2C(frexp, int *, exp);
+_DECL_MATH2C(ldexp, int, exp);
+
+_DECL_MATH2P(modf, iptr);
+
+_DECL_MATH2C(scalbn, int, exp);
+_DECL_MATH2C(scalbln, long, exp);
+_DECL_MATHR(ilogb, int);
+_DECL_MATH(logb);
+
+_DECL_MATH2(nextafter);
+_DECL_MATH2C(nexttoward, long double, to);
+
+_DECL_MATH2(copysign);
+
+#undef _DECL_MATH
+#undef _DECL_MATHC
+#undef _DECL_MATHR
+#undef _DECL_MATH2
+#undef _DECL_MATH2C
+#undef _DECL_MATH2P
+#undef _DECL_MATH3
+#undef _DECL_MATH3C
+
+inline double fabs(double x) { return __fabs(x); }
 
 #ifdef __cplusplus
 }

--- a/src/sdk/RVL_SDK/revolution/math.h
+++ b/src/sdk/RVL_SDK/revolution/math.h
@@ -9,9 +9,6 @@ extern "C" {
 #endif // ifdef __cplusplus
 
 #define FABS(x) (float)__fabs(x)
-#define fabs(x) __fabs(x)
-// #define __frsqrtes opword
-
 #define SQUARE(v) ((v) * (v))
 
 #define TAU     6.2831855f
@@ -23,26 +20,6 @@ extern "C" {
 #ifndef M_PI
 #define M_PI ((float)3.14159274101257324219)
 #endif
-
-inline float cosf(float x){
-    return (float)cos(x);
-}
-
-inline float sinf(float x){
-    return (float)sin(x);
-}
-
-inline float tanf(float x){
-    return (float)tan(x);
-}
-
-inline float acosf(float x){
-    return (float)acos(x);
-}
-
-inline float sqrtf(float x){
-    return (float)sqrt(x);
-}
 
 #ifdef __cplusplus
 };

--- a/src/system/beatmatch/MasterAudio.cpp
+++ b/src/system/beatmatch/MasterAudio.cpp
@@ -409,7 +409,7 @@ void ChannelData::Poll() {
 
 void ChannelData::SetSlipTrackSpeed(float trackSpeed) {
     if (mSlipTrack) {
-        if (mSlipTrack->mMaxSlip * 0.9f < __fabs(mSlipTrack->GetCurrentOffset())) {
+        if (std::fabs(mSlipTrack->GetCurrentOffset()) > mSlipTrack->mMaxSlip * 0.9f) {
             trackSpeed = 1.0f;
         }
         if (mSpeed != trackSpeed || mOverallSpeed != 1.0f) {

--- a/src/system/beatmatch/Playback.cpp
+++ b/src/system/beatmatch/Playback.cpp
@@ -35,7 +35,7 @@ void Playback::Poll(float f){
                 }
             }
 
-            while(floc <= mTime || mTime < f && (fabs_f(floc - mTime) < fabs_f(floc - f))){
+            while(floc <= mTime || mTime < f && (std::fabs(floc - mTime) < std::fabs(floc - f))){
                 DoCommand(arr);
                 mCommandIndex++;
                 if(mCommandIndex >= cmdSize) break;
@@ -81,7 +81,7 @@ void Playback::DoCommand(DataArray* arr){
                 sink->ForceMercurySwitch(arr->Int(3) != 0);
             }
         }
-    }   
+    }
 }
 
 bool Playback::LoadFile(const class String& str){

--- a/src/system/beatmatch/TrackWatcherImpl.cpp
+++ b/src/system/beatmatch/TrackWatcherImpl.cpp
@@ -216,7 +216,7 @@ oh:
 }
 
 bool TrackWatcherImpl::InSlopWindow(float f1, float f2) const {
-    return fabs_f(f2 + mSyncOffset) - f1 <= mSlop;
+    return std::fabs(f2 + mSyncOffset - f1) <= mSlop;
 }
 
 void TrackWatcherImpl::SetGemsPlayedUntil(int thresh){

--- a/src/system/char/CharIKHand.cpp
+++ b/src/system/char/CharIKHand.cpp
@@ -223,8 +223,9 @@ void CharIKHand::IKElbow(RndTransformable* trans1, RndTransformable* trans2){
                 v188 -= v140;
                 Normalize(v188, v188);
                 Scale(v188, v164len, v188);
-                float sine = sin(asined / 2);
-                float cosine = cos(asined / 2);
+                double half = asined / 2.0;
+                float sine = sin(half);
+                float cosine = cos(half);
                 Hmx::Quat q198(v188.x, v188.y, v188.z, 0.0f);
                 Hmx::Quat q1a8(v170.x * sine, v170.y * sine, v170.z* sine, cosine);
                 Hmx::Quat q1b8;
@@ -281,7 +282,7 @@ void CharIKHand::MeasureLengths(){
                 unk64 = len * 2.0f * parentlen;
                 mInv2ab = parentlen * parentlen + (len * len + 0.0f);
                 if(unk64 != 0.0f) unk64 = 1.0f / unk64;
-                mAAPlusBB = len + parentlen;        
+                mAAPlusBB = len + parentlen;
             }
         }
     }
@@ -318,13 +319,13 @@ BEGIN_LOADS(CharIKHand)
     bs >> mStretch;
     if(gRev > 1) bs >> mScalable;
     else mScalable = false;
-    
+
     if(gRev > 3) bs >> mMoveElbow;
     else mMoveElbow = true;
 
     if(gRev > 5) bs >> mElbowSwing;
     else mElbowSwing = 0.0f;
-    
+
     if(gRev > 6) bs >> mAlwaysIKElbow;
     if(gRev > 7){
         bs >> mConstrainWrist;

--- a/src/system/char/CharInterest.cpp
+++ b/src/system/char/CharInterest.cpp
@@ -17,11 +17,11 @@ CharInterest::CharInterest() : mMaxViewAngle(20.0f), mPriority(1.0f), mMinLookTi
 }
 
 CharInterest::~CharInterest(){
-    
+
 }
 
 void CharInterest::SyncMaxViewAngle(){
-    mMaxViewAngleCos = cos_f(mMaxViewAngle * 0.017453292f);
+    mMaxViewAngleCos = std::cos(mMaxViewAngle * 0.017453292f);
 }
 
 // https://decomp.me/scratch/ekyoO retail scratch
@@ -63,13 +63,13 @@ BEGIN_LOADS(CharInterest)
     if (u16(temp - 2) <= 3) {
         ObjPtr<Hmx::Object, ObjectDir> obj(this, NULL);
         bs >> obj;
-    } else if (temp > 5) { bs >> mDartOverride; } 
+    } else if (temp > 5) { bs >> mDartOverride; }
     if (gRev > 2) {
         bs >> mCategoryFlags;
         if (gRev == 3) {
             u8 x;
             bs >> x;
-        } 
+        }
     }
     if (gRev > 4) {
         bs >> mOverrideMinTargetDistance;
@@ -125,20 +125,20 @@ float CharInterest::ComputeScore(const Vector3& v1, const Vector3& v2, const Vec
     Subtract(v7c, v2, v88);
     float lensq = LengthSquared(v88);
     Normalize(v88, v88);
-    
+
     float dot = Dot(v1, v88);
     float f1 = 0.0f;
     if(dot >= mMaxViewAngleCos) f1 = 1.0f;
-    
+
     float dot2 = Dot(v3, v88);
     float f2 = 0.0f;
     if(dot2 >= mMaxViewAngleCos) f2 = 1.0f;
-    
+
     float f7 = -(lensq * f - 1.0f);
     if(IsNaN(f7)){
         f7 = 0.2f;
     }
-    
+
     float f4 = f7 + f1 + f2 + neg99;
     if(f4 >= 0.0f){
         f4 = f4 + RandomFloat(-0.25f, 0.25);

--- a/src/system/char/CharLookAt.cpp
+++ b/src/system/char/CharLookAt.cpp
@@ -194,15 +194,15 @@ void CharLookAt::SyncLimits(){
     ClampEq(mMaxYaw, -80.0f, 80.0f);
     ClampEq(mMinPitch, -80.0f, 80.0f);
     ClampEq(mMaxPitch, -80.0f, 80.0f);
-    float max_yaw = Max(fabs_f(mMinYaw), fabs_f(mMaxYaw));
-    float max_pitch = Max(fabs_f(mMinPitch), fabs_f(mMaxPitch));
+    float max_yaw = Max(std::fabs(mMinYaw), std::fabs(mMaxYaw));
+    float max_pitch = Max(std::fabs(mMinPitch), std::fabs(mMaxPitch));
     float max_overall = Max(max_yaw, max_pitch);
-    mBounds.mMin.y = cos(max_overall * DEG2RAD);
+    mBounds.mMin.y = std::cos(max_overall * DEG2RAD);
     mBounds.mMax.y = 1.0E+29f;
-    mBounds.mMin.z = mBounds.mMin.y * tan(mMinYaw * DEG2RAD);
-    mBounds.mMax.z = mBounds.mMin.y * tan(mMaxYaw * DEG2RAD);
-    mBounds.mMin.x = mBounds.mMin.y * tan(mMinPitch * DEG2RAD);
-    mBounds.mMax.x = mBounds.mMin.y * tan(mMaxPitch * DEG2RAD);
+    mBounds.mMin.z = mBounds.mMin.y * std::tan(mMinYaw * DEG2RAD);
+    mBounds.mMax.z = mBounds.mMin.y * std::tan(mMaxYaw * DEG2RAD);
+    mBounds.mMin.x = mBounds.mMin.y * std::tan(mMinPitch * DEG2RAD);
+    mBounds.mMax.x = mBounds.mMin.y * std::tan(mMaxPitch * DEG2RAD);
 }
 
 void CharLookAt::PollDeps(std::list<Hmx::Object*>& changedBy, std::list<Hmx::Object*>& change){

--- a/src/system/math/Decibels.cpp
+++ b/src/system/math/Decibels.cpp
@@ -5,7 +5,7 @@
 float DbToRatio(float db){
     float ratio;
     if(db <= -96.0f) ratio = 0.0f;
-    else ratio = pow_f(10.0, db / 20.0f);
+    else ratio = std::pow(10.0f, db / 20.0f);
     return ratio;
 }
 
@@ -14,5 +14,5 @@ float RatioToDb(float ratio){
         ratio = 0.0f;
         MILO_LOG("Got a BAD Decibel ratio\n");
     }
-    return (ratio <= 0.0f) ? -96.0f : log10_f(ratio) * 20.0f;
+    return (ratio <= 0.0f) ? -96.0f : std::log10(ratio) * 20.0f;
 }

--- a/src/system/math/Interp.cpp
+++ b/src/system/math/Interp.cpp
@@ -24,7 +24,7 @@ void LinearInterpolator::Reset(float y0, float y1, float x0, float x1) {
     mX1 = x1;
     mY0 = y0;
     mY1 = y1;
-    if (fabs_f(run) < 0.000001f)
+    if (std::fabs(run) < 0.000001f)
         mSlope = 0.0;
     else
         mSlope = (y1 - y0) / run;
@@ -50,7 +50,7 @@ void ExpInterpolator::Reset(float f1, float f2, float f3, float f4, float f5) {
     mX1 = f4;
     mY0 = f1;
     mY1 = f2;
-    if (fabs_f(f0) < 0.000001f)
+    if (std::fabs(f0) < 0.000001f)
         mInvRun = 1.0f;
     else
         mInvRun = 1.0f / f0;
@@ -65,7 +65,7 @@ void ExpInterpolator::Reset(const DataArray *data) {
 
 // fn_802DD32C
 float ExpInterpolator::Eval(float f) {
-    double pow_res = pow((double)(mInvRun * (f - mX0)), (double)mPower);
+    double pow_res = pow(mInvRun * (f - mX0), mPower);
 
     // mInvRun * (f - mX0) is an implicit cast from float to double?
     // mPower is also implicitly casted from float to double
@@ -88,7 +88,7 @@ void InvExpInterpolator::Reset(float f1, float f2, float f3, float f4, float f5)
     mX1 = f4;
     mY0 = f1;
     mY1 = f2;
-    if (fabs_f(f0) < 0.000001f)
+    if (std::fabs(f0) < 0.000001f)
         mInvRun = 1.0f;
     else
         mInvRun = 1.0f / f0;
@@ -107,7 +107,7 @@ float InvExpInterpolator::Eval(float f) {
 
     double a = -(mInvRun * (f - mX0) - 1);
 
-    pow_res = pow(a, (double)mPower);
+    pow_res = std::pow(a, (double)mPower);
     return (1.0f - pow_res) * mRise + mY0;
 }
 
@@ -134,7 +134,7 @@ void ATanInterpolator::Reset(float y0, float y1, float x0, float x1, float sever
 
     if(!(severity > 0.001f)) MILO_FAIL("ATanInterpolator: severity (%f) too small.", severity);
 
-    float ftan = atan(f31);
+    float ftan = std::atan(f31);
 
     float fneg = y1 - y0;
     float fsub = -ftan - ftan;
@@ -151,7 +151,7 @@ void ATanInterpolator::Reset(const DataArray *data) {
 
 // fn_802DD944
 float ATanInterpolator::Eval(float f) {
-    float ret = atan_f(mXMapping.Eval(f));
+    float ret = std::atan(mXMapping.Eval(f));
     ret *= mScale;
     return ret + mOffset;
 }

--- a/src/system/math/MathFuncs.h
+++ b/src/system/math/MathFuncs.h
@@ -3,20 +3,6 @@
 #include <math.h>
 #include <cmath>
 
-extern "C" float asin_f(double);
-extern "C" float acos_f(double);
-extern "C" float atan_f(double);
-extern "C" float fabs_f(double);
-extern "C" float pow_f(double, double);
-extern "C" float sin_f(double);
-extern "C" float cos_f(double);
-extern "C" float tan_f(double);
-extern "C" float log10_f(double);
-extern "C" float sqrt_f(double);
-extern "C" float floor_f(double);
-extern "C" float ceil_f(double);
-extern "C" float fmod_f(double,double);
-
 inline int CountBits(int num) {
     int temp_r0;
     int var_r3;
@@ -107,82 +93,18 @@ inline int Mod(int num, int modbase){
     else return div;
 }
 
-inline float sqrt_f(double d){
-    return sqrt(d);
-}
-
-inline float asin_f(double d){
-    return asin(d);
-}
-
-inline float acos_f(double d){
-    return acos(d);
-}
-
-inline float atan_f(double d){
-    return atan(d);
-}
-
-// inline float my_fabsf(float x){
-//     return fabsf(x);
-// }
-
-// inline float fabsf(float x) {
-//     return (float)fabs((double)x);
-// }
-
-// extern inline double fabs(double x) {
-//     return __fabs(x);
-// }
-
-inline float fabs_f(double d){
-    return __fabs(d);
-}
-
 inline bool IsFloatZero(float f){
-    return fabs_f(f) < 0.0001f;
+    return std::abs(f) < 0.0001f;
 }
 
 inline bool IsFloatOne(float f){
-    return fabs_f(f - 1.0f) < 0.000099999997f;
-}
-
-inline float pow_f(double x, double y){
-    return pow(x, y);
-}
-
-inline double pow_d(double x, double y){
-    return pow(x, y);
-}
-
-inline float sin_f(double d){
-    return sin(d);
-}
-
-inline float cos_f(double d){
-    return cos(d);
-}
-
-inline float tan_f(double d){
-    return tan(d);
-}
-
-inline float log10_f(double d){
-    return log10(d);
-}
-
-inline float floor_f(double d){
-    return floor(d);
-}
-
-inline float ceil_f(double d){
-    return ceil(d);
+    return std::abs(f - 1.0f) < 0.000099999997f;
 }
 
 inline float Modulo(float f1, float f2) {
     if (f2 == 0.0f)
         return 0.0f;
-    float tmp = fmod_f(f1, f2);
+    float tmp = std::fmod(f1, f2);
     if (tmp < 0.0f)
         tmp += f2;
     return tmp;
@@ -192,9 +114,6 @@ inline float ModRange(float f1, float f2, float f3){
     return Modulo(f3 - f1, f2 - f1) + f1;
 }
 
-inline float fmod_f(double x, double y){
-    return fmod(x, y);
-}
 
 inline float Interp(float a, float b, float c){
     float delta = b - a;

--- a/src/system/math/Rand.cpp
+++ b/src/system/math/Rand.cpp
@@ -1,6 +1,6 @@
 #include "math/Rand.h"
+#include "math/MathFuncs.h"
 #include "os/Debug.h"
-#include <math.h>
 #include "os/OSFuncs.h"
 
 Rand gRand(0x29A);
@@ -58,8 +58,8 @@ float Rand::Gaussian() {
                 f5 = f2 * f2 + f3 * f3;
             } while (f5 >= 1.0f);
         } while (0 == f5);
-        f4 = log(f5);
-        f5 = sqrt((-2.0f * f4) / f5);
+        f4 = std::log(f5);
+        f5 = std::sqrt((-2.0f * f4) / f5);
         mSpareGaussianValue = f2 * f5;
         mSpareGaussianAvailable = true;
         return f3 * f5;

--- a/src/system/math/Rot.cpp
+++ b/src/system/math/Rot.cpp
@@ -9,18 +9,18 @@ void deadstripped_assert() {MILO_ASSERT(false, 0);}
 void TransformNoScale::SetRot(const Hmx::Matrix3& m) {
     Hmx::Quat quat;
     quat.Set(m);
-    
+
     float nu_x = 32767.0f * quat.x + 0.5f;
-    q.x = floor(nu_x > quat.x ? nu_x : (nu_x < -32767.0f ? nu_x : quat.x));
+    q.x = std::floor(nu_x > quat.x ? nu_x : (nu_x < -32767.0f ? nu_x : quat.x));
 
     float nu_y = 32767.0f * quat.y + 0.5f;
-    q.y = floor(nu_y > quat.y ? nu_y : (nu_y < -32767.0f ? nu_y : quat.y));
+    q.y = std::floor(nu_y > quat.y ? nu_y : (nu_y < -32767.0f ? nu_y : quat.y));
 
     float nu_z = 32767.0f * quat.z + 0.5f;
-    q.z = floor(nu_z > quat.z ? nu_z : (nu_z < -32767.0f ? nu_z : quat.z));
+    q.z = std::floor(nu_z > quat.z ? nu_z : (nu_z < -32767.0f ? nu_z : quat.z));
 
     float nu_w = 32767.0f * quat.w + 0.5f;
-    q.w = floor(nu_w > quat.w ? nu_w : (nu_w < -32767.0f ? nu_w : quat.w));
+    q.w = std::floor(nu_w > quat.w ? nu_w : (nu_w < -32767.0f ? nu_w : quat.w));
 
 }
 
@@ -39,17 +39,17 @@ BinStream& operator>>(BinStream& bs, TransformNoScale& t) {
 
 float GetXAngle(const Hmx::Matrix3& m) {
     float z = m.y.z;
-    return atan2(z, m.y.y);
+    return std::atan2(z, m.y.y);
 }
 
 float GetYAngle(const Hmx::Matrix3& m) {
     float z = -m.x.z;
-    return atan2(z, m.z.z);
+    return std::atan2(z, m.z.z);
 }
 
 float GetZAngle(const Hmx::Matrix3& m) {
     float x = m.y.x;
-    return -atan2(x, m.y.y);
+    return -std::atan2(x, m.y.y);
 }
 
 TextStream& operator<<(TextStream& ts, const Hmx::Quat& v) {

--- a/src/system/math/Trig.cpp
+++ b/src/system/math/Trig.cpp
@@ -9,13 +9,13 @@ void TrigTableInit() {
     float *temp_r30 = gBigSinTable;
     int i;
     for (i = 0; i < 256; i++, temp_r30 += 2) {
-        *temp_r30 = sin_f(0.024543693f * i);
+        *temp_r30 = std::sin(0.024543693f * i);
         if (i != 0) {
             *(temp_r30-1) = *temp_r30 - *(temp_r30-2);
         }
     }
     int tmp = (i - 1) * 2;
-    *(gBigSinTable + tmp + 1) = sin_f(0.024543693f * i) - *(gBigSinTable + tmp);
+    *(gBigSinTable + tmp + 1) = std::sin(0.024543693f * i) - *(gBigSinTable + tmp);
 }
 
 void TrigTableTerminate() {
@@ -45,33 +45,33 @@ float FastSin(float f) {
 }
 
 DataNode DataSin(DataArray *da) {
-    return DataNode(sin_f(DegreesToRadians(da->Float(1))));
+    return DataNode(std::sin(DegreesToRadians(da->Float(1))));
 }
 
 DataNode DataCos(DataArray *da) {
-    return DataNode(cos_f(DegreesToRadians(da->Float(1))));
+    return DataNode(std::cos(DegreesToRadians(da->Float(1))));
 }
 
 DataNode DataTan(DataArray *da) {
-    return DataNode(tan_f(DegreesToRadians(da->Float(1))));
+    return DataNode(std::tan(DegreesToRadians(da->Float(1))));
 }
 
 DataNode DataASin(DataArray *da) {
     float f = da->Float(1);
     if(IsNaN(f)) return DataNode(0.0f);
-    else return DataNode(RadiansToDegrees(asin_f(f)));
+    else return DataNode(RadiansToDegrees(std::asin(f)));
 }
 
 DataNode DataACos(DataArray *da) {
     float f = da->Float(1);
     if(IsNaN(f)) return DataNode(0.0f);
-    else return DataNode(RadiansToDegrees(acos_f(f)));
+    else return DataNode(RadiansToDegrees(std::acos(f)));
 }
 
 DataNode DataATan(DataArray *da) {
     float f = da->Float(1);
     if(IsNaN(f)) return DataNode(0.0f);
-    else return DataNode(RadiansToDegrees(atan_f(f)));
+    else return DataNode(RadiansToDegrees(std::atan(f)));
 }
 
 void TrigInit() {

--- a/src/system/midi/MidiReader.cpp
+++ b/src/system/midi/MidiReader.cpp
@@ -354,7 +354,7 @@ void MidiReader::ReadMetaEvent(int i, unsigned char uc, BinStream& bs){
             }
             else {
                 double base = 2;
-                int powed = pow_d(base, ts_den);
+                int powed = std::pow(base, ts_den);
                 if(ts_num == 0){
                     MILO_WARN("%s (%s): Time signature %d/%d at %s has invalid numerator (%d)",
                         mStreamName.c_str(), mCurTrackName.c_str(), ts_num, powed, TickFormat(i, *mMeasureMap), ts_num);

--- a/src/system/obj/DataFunc.cpp
+++ b/src/system/obj/DataFunc.cpp
@@ -361,7 +361,7 @@ static DataNode DataMax(DataArray* da){
 
 static DataNode DataAbs(DataArray* da){
     DataNode& n = da->Evaluate(1);
-    float f = fabs_f(n.LiteralFloat(da));
+    float f = std::fabs(n.LiteralFloat(da));
     if(n.Type() == kDataInt)
         return DataNode((int)f);
     else return DataNode(f);
@@ -488,7 +488,7 @@ static DataNode DataDivideEq(DataArray* da){
 }
 
 static DataNode DataSqrt(DataArray* da){
-    return DataNode(sqrt(da->Float(1)));
+    return DataNode(std::sqrt(da->Float(1)));
 }
 
 DefDataFunc(Mod, {
@@ -516,7 +516,7 @@ static DataNode DataDist(DataArray *da) {
     z = da->Float(3) - da->Float(6);
     y = da->Float(2) - da->Float(5);
     x = da->Float(1) - da->Float(4);
-    return DataNode(sqrt(x*x+y*y+z*z));
+    return DataNode(std::sqrt(x*x+y*y+z*z));
 }
 
 static DataNode DataSymbol(DataArray* da){
@@ -545,11 +545,11 @@ static DataNode DataRound(DataArray* da){
 }
 
 static DataNode DataFloor(DataArray* da){
-    return DataNode(floor_f(da->Float(1)));
+    return DataNode(std::floor(da->Float(1)));
 }
 
 static DataNode DataCeil(DataArray* da){
-    return DataNode(ceil_f(da->Float(1)));
+    return DataNode(std::ceil(da->Float(1)));
 }
 
 static DataNode DataDelete(DataArray* da){

--- a/src/system/oggvorbis/codec_internal.h
+++ b/src/system/oggvorbis/codec_internal.h
@@ -23,13 +23,13 @@
 
 #define BLOCKTYPE_IMPULSE    0
 #define BLOCKTYPE_PADDING    1
-#define BLOCKTYPE_TRANSITION 0 
+#define BLOCKTYPE_TRANSITION 0
 #define BLOCKTYPE_LONG       1
 
 #define PACKETBLOBS 15
 
 typedef struct vorbis_block_internal{
-  float  **pcmdelay;  /* this is a pointer into local storage */ 
+  float  **pcmdelay;  /* this is a pointer into local storage */
   float  ampmax;
   int    blocktype;
 
@@ -57,7 +57,7 @@ typedef void vorbis_info_mapping;
 
 typedef struct private_state {
   /* local lookup storage */
-  envelope_lookup        *ve; /* envelope lookup */    
+  envelope_lookup        *ve; /* envelope lookup */
   int                     window[2];
   vorbis_look_transform **transform[2];    /* block, type */
   drft_lookup             fft_look[2];
@@ -84,7 +84,7 @@ typedef struct private_state {
 /* codec_setup_info contains all the setup information specific to the
    specific compression/decompression mode in progress (eg,
    psychoacoustic settings, channel setup, options, codebook
-   etc).  
+   etc).
 *********************************************************************/
 
 #include "highlevel.h"
@@ -124,11 +124,16 @@ typedef struct codec_setup_info {
   highlevel_encode_setup hi; /* used only by vorbisenc.c.  It's a
                                 highly redundant structure, but
                                 improves clarity of program flow. */
-  int         halfrate_flag; /* painless downsample for decode */  
+  int         halfrate_flag; /* painless downsample for decode */
 } codec_setup_info;
 
 extern vorbis_look_psy_global *_vp_global_look(vorbis_info *vi);
 extern void _vp_global_free(vorbis_look_psy_global *look);
+
+#ifdef __MWERKS__
+/* decomp hack: needs to be a macro and not a define */
+#define abs(x) __abs(x)
+#endif
 
 #endif
 

--- a/src/system/oggvorbis/floor1.c
+++ b/src/system/oggvorbis/floor1.c
@@ -268,10 +268,6 @@ static vorbis_look_floor *floor1_look(vorbis_dsp_state *vd,
   return(look);
 }
 
-inline int abs(int i){
-  return __abs(i);
-}
-
 static int render_point(int x0,int x1,int y0,int y1,int x){
   y0&=0x7fff; /* mask off flag */
   y1&=0x7fff;

--- a/src/system/oggvorbis/mdct.c
+++ b/src/system/oggvorbis/mdct.c
@@ -46,11 +46,6 @@
 #include "os.h"
 #include "misc.h"
 
-inline double fabs(double x)
-{
-   return __fabs(x) ;
-}
-
 /* build lookups for trig functions; also pre-figure scaling and
    some window function algebra. */
 

--- a/src/system/oggvorbis/psy.c
+++ b/src/system/oggvorbis/psy.c
@@ -32,15 +32,6 @@
 #define NEGINF -9999.f
 static double stereo_threshholds[]={0.0, .5, 1.0, 1.5, 2.5, 4.5, 8.5, 16.5, 9e10};
 
-inline int abs(int i){
-  return __abs(i);
-}
-
-inline double fabs(double x)
-{
-   return __fabs(x) ;
-}
-
 vorbis_look_psy_global *_vp_global_look(vorbis_info *vi){
   codec_setup_info *ci=vi->codec_setup;
   vorbis_info_psy_global *gi=&ci->psy_g_param;

--- a/src/system/oggvorbis/res0.c
+++ b/src/system/oggvorbis/res0.c
@@ -62,11 +62,6 @@ typedef struct {
 
 } vorbis_look_residue0;
 
-inline double fabs(double x)
-{
-   return __fabs(x) ;
-}
-
 void res0_free_info(vorbis_info_residue *i){
   vorbis_info_residue0 *info=(vorbis_info_residue0 *)i;
   if(info){

--- a/src/system/oggvorbis/sharedbook.c
+++ b/src/system/oggvorbis/sharedbook.c
@@ -25,11 +25,6 @@
 #include "codebook.h"
 #include "scales.h"
 
-inline double fabs(double x)
-{
-   return __fabs(x) ;
-}
-
 /**** pack/unpack helpers ******************************************/
 int _ilog(unsigned int v){
   int ret=0;

--- a/src/system/os/Timer.cpp
+++ b/src/system/os/Timer.cpp
@@ -116,7 +116,7 @@ void TimerStats::PrintPctile(float pctile) {
         }
     }
 
-    int a = floor(pctile * 100);
+    int a = std::floor(pctile * 100);
     if (target > MAX_TOP_VALS) {
         TheDebug << MakeString("   %dth pctile:   <%.2f THIS IS AN OVERESTIMATE.  For accurate percentile, increase MAX_TOP_VALS in Timer.h\n",
             a, top

--- a/src/system/rndobj/Anim.cpp
+++ b/src/system/rndobj/Anim.cpp
@@ -39,7 +39,7 @@ bool RndAnimatable::ConvertFrames(float& f){
 }
 
 RndAnimatable::RndAnimatable() : mFrame(0.0f), mRate(k30_fps) {
-    
+
 }
 
 void RndAnimatable::Save(BinStream&){
@@ -94,9 +94,9 @@ BEGIN_LOADS(RndAnimatable)
             RndAnimFilter* filtObj = Dir()->New<RndAnimFilter>(filt);
             filtObj->SetProperty("anim", DataNode(this));
             filtObj->SetProperty("scale", DataNode(theScale));
-            filtObj->SetProperty("offset", DataNode(theOffset));            
+            filtObj->SetProperty("offset", DataNode(theOffset));
             filtObj->SetProperty("min", DataNode(theMin));
-            filtObj->SetProperty("max", DataNode(theMax));            
+            filtObj->SetProperty("max", DataNode(theMax));
             filtObj->SetProperty("loop", DataNode(theLoop));
         }
         ObjPtrList<RndAnimatable, class ObjectDir> animList(this, kObjListNoNull);
@@ -154,11 +154,11 @@ Task* RndAnimatable::Animate(float blend, bool wait, float delay, Rate rate, flo
     float taskStart = start;
     if(type == dest) start = mFrame;
     if(period){
-        fpu = __fabs(end - taskStart);
+        fpu = std::fabs(end - taskStart);
         fpu = fpu / period;
     }
     else fpu = scale * gRateFpu[rate];
-    
+
     AnimTask* task = new AnimTask(this, start, end, fpu, type == loop, blend);
     if(wait){
         AnimTask* blendTask = task->BlendTask();
@@ -173,7 +173,7 @@ Task* RndAnimatable::Animate(float blend, bool wait, float delay, Rate rate, flo
 Task* RndAnimatable::Animate(float start, float end, TaskUnits units, float period, float blend){
     float fpu;
     if(period){
-        fpu = __fabs(end - start);
+        fpu = std::fabs(end - start);
         fpu = fpu / period;
     }
     else {
@@ -242,7 +242,7 @@ DataNode RndAnimatable::OnAnimate(DataArray* arr){
     if(periodArr){
         p = periodArr->Float(1);
         MILO_ASSERT(p, 0x1A9);
-        p = float(__fabs((animTaskEnd - animTaskStart))) / p;
+        p = std::fabs(animTaskEnd - animTaskStart) / p;
     }
 
     AnimTask* theTask = new AnimTask(this, animTaskStart, animTaskEnd, p, animTaskLoop, local_blend);

--- a/src/system/rndobj/AnimFilter.cpp
+++ b/src/system/rndobj/AnimFilter.cpp
@@ -37,7 +37,7 @@ BEGIN_COPYS(RndAnimFilter)
 END_COPYS
 
 RndAnimFilter::RndAnimFilter() : mAnim(this, 0), mPeriod(0.0f), mStart(0.0f), mEnd(0.0f), mScale(1.0f), mOffset(0.0f), mSnap(0.0f), mJitter(0.0f), mJitterFrame(0.0f), mType(kRange) {
-    
+
 }
 
 SAVE_OBJ(RndAnimFilter, 0x4A)
@@ -83,7 +83,7 @@ float RndAnimFilter::StartFrame(){
     else {
         float denom = Scale();
         if(denom == 0.0f) denom = 1.0f;
-        
+
         return (mStart - FrameOffset()) / denom;
     }
 }
@@ -93,7 +93,7 @@ float RndAnimFilter::EndFrame(){
     else {
         float denom = Scale();
         if(denom == 0.0f) denom = 1.0f;
-        
+
         float ret = (mEnd - FrameOffset()) / denom;
         if(mType == kShuttle){
             ret *= 2.0f;
@@ -128,7 +128,7 @@ DataNode RndAnimFilter::OnSafeAnims(DataArray* da){
 
 BEGIN_PROPSYNCS(RndAnimFilter)
     SYNC_PROP_SET(anim, mAnim, SetAnim(_val.Obj<RndAnimatable>(0)))
-    SYNC_PROP_SET(scale, mScale, mScale = __fabs(_val.Float(0)))
+    SYNC_PROP_SET(scale, mScale, mScale = std::fabs(_val.Float(0)))
     SYNC_PROP(offset, mOffset)
     SYNC_PROP(period, mPeriod)
     SYNC_PROP(start, mStart)

--- a/src/system/rndobj/PropKeys.cpp
+++ b/src/system/rndobj/PropKeys.cpp
@@ -32,7 +32,7 @@ BinStream& operator<<(BinStream& bs, const ObjectStage& stage){
 
 PropKeys::PropKeys(Hmx::Object* o1, Hmx::Object* o2) : mTarget(o1, o2), mProp(0), mTrans(0), mInterpHandler(),
     mLastKeyFrameIndex(-2), mKeysType(kFloat), mInterpolation(kLinear), mPropExceptionID(kNoException), unk18lastbit(0) {
-    
+
 }
 
 PropKeys::~PropKeys(){
@@ -60,7 +60,7 @@ int PropKeys::SetKey(float frame){
     float f = 0.0f;
     for(int i = 0; i < NumKeys(); i++){
         if(FrameFromIndex(i, f)){
-            float fabsFloat = __fabs(frame - f);
+            float fabsFloat = std::fabs(frame - f);
             if(fabsFloat < 0.000099999997f)
                 return i;
         }

--- a/src/system/rndobj/Utl.cpp
+++ b/src/system/rndobj/Utl.cpp
@@ -357,8 +357,8 @@ void RndUtlTerminate(){
 
 // fn_806598A0
 float ConvertFov(float a, float b) {
-    float x = tan(0.5f * a);
-    return atan(b * x) * 2;
+    float x = std::tan(0.5f * a);
+    return std::atan(b * x) * 2;
 }
 
 // fn_806598F4

--- a/src/system/speex/libspeex/lsp.c
+++ b/src/system/speex/libspeex/lsp.c
@@ -96,15 +96,6 @@ Heavily modified by Jean-Marc Valin (c) 2002-2006 (fixed-point,
 #define NULL 0
 #endif
 
-inline int abs(int i){
-  return __abs(i);
-}
-
-inline double fabs(double x)
-{
-   return __fabs(x) ;
-}
-
 #ifdef FIXED_POINT
 
 #define FREQ_SCALE 16384

--- a/src/system/speex/libspeex/vbr.c
+++ b/src/system/speex/libspeex/vbr.c
@@ -73,11 +73,6 @@ const float vbr_uhb_thresh[2][11]={
    { 3.9f,  2.5f,  0.0f,  0.0f,  0.0f,  0.0f,  0.0f,  0.0f,  0.0f,  0.0f, -1.0f}  /*  2 kbps */
 };
 
-inline double fabs(double x)
-{
-   return __fabs(x) ;
-}
-
 void vbr_init(VBRState *vbr)
 {
    int i;

--- a/src/system/stlport/cmath
+++ b/src/system/stlport/cmath
@@ -99,8 +99,48 @@ inline long double log10l(long double v) { return __log10l(v); }
 //using ::abs;
 //_STLP_END_NAMESPACE
 
-#ifndef _STLP_CMATH_H_HEADER
-#  include <stl/_cmath.h>
+// decomp hack: use native cmath directly
+#ifdef _STLP_CMATH_ONLY_VENDOR
+_STLP_BEGIN_NAMESPACE
+
+#define _STLP_USE_MATH(name)       \
+  using _STLP_VENDOR_STD::name;    \
+  using _STLP_VENDOR_STD::name##f; \
+  using _STLP_VENDOR_STD::name##l;
+
+using _STLP_VENDOR_STD::abs;
+
+_STLP_USE_MATH(acos);
+_STLP_USE_MATH(asin);
+_STLP_USE_MATH(atan);
+_STLP_USE_MATH(atan2);
+_STLP_USE_MATH(ceil);
+_STLP_USE_MATH(cos);
+_STLP_USE_MATH(cosh);
+_STLP_USE_MATH(exp);
+_STLP_USE_MATH(fabs);
+_STLP_USE_MATH(floor);
+_STLP_USE_MATH(fmod);
+_STLP_USE_MATH(frexp);
+_STLP_USE_MATH(hypot);
+_STLP_USE_MATH(ldexp);
+_STLP_USE_MATH(log);
+_STLP_USE_MATH(log10);
+_STLP_USE_MATH(modf);
+_STLP_USE_MATH(pow);
+_STLP_USE_MATH(sin);
+_STLP_USE_MATH(sinh);
+_STLP_USE_MATH(sqrt);
+_STLP_USE_MATH(tan);
+_STLP_USE_MATH(tanh);
+
+#undef _STLP_USE_MATH
+
+_STLP_END_NAMESPACE
+#else
+#  ifndef _STLP_CMATH_H_HEADER
+#    include <stl/_cmath.h>
+#  endif
 #endif
 
 #if (_STLP_OUTERMOST_HEADER_ID ==  0x110 )

--- a/src/system/stlport/config/stl_mwbroadway.h
+++ b/src/system/stlport/config/stl_mwbroadway.h
@@ -13,9 +13,7 @@
 
 #define _STLP_BIG_ENDIAN
 
-// No -l or -f suffix versions of math.h functions
-#define _STLP_NO_VENDOR_MATH_L 1
-#define _STLP_NO_VENDOR_MATH_F 1
+#define _STLP_CMATH_ONLY_VENDOR
 
 #undef _STLP_NO_UNCAUGHT_EXCEPT_SUPPORT
 #undef _STLP_NO_UNEXPECTED_EXCEPT_SUPPORT

--- a/src/system/ui/LabelNumberTicker.cpp
+++ b/src/system/ui/LabelNumberTicker.cpp
@@ -82,7 +82,7 @@ void LabelNumberTicker::Poll(){
         float animsum = animdelay + animtime;
         if(split >= animdelay){
             float quotient = (split - animdelay) / animtime;
-            quotient *= pow_f(quotient, mAcceleration);
+            quotient *= std::pow(quotient, mAcceleration);
             int somenum = unk12c + (int)(quotient * (mDesiredValue - unk12c));
             if(mTickTrigger && mTickEvery != 0){
                 if((somenum / mTickEvery) > (unk130 / mTickEvery)){

--- a/src/system/ui/UIFontImporter.cpp
+++ b/src/system/ui/UIFontImporter.cpp
@@ -9,11 +9,11 @@ int gREV = 9;
 
 // idk what to name this, it's mainly used when assigning to mFontPctSize
 inline float fabs720(int i){
-    return fabs_f(i / 720.0f);
+    return std::fabs(i / 720.0f);
 }
 
 inline float fabs480(int i){
-    return fabs_f(i / 480.0f);
+    return std::fabs(i / 480.0f);
 }
 
 inline int round480(float f){
@@ -26,7 +26,7 @@ inline int round720(float f){
 
 UIFontImporter::UIFontImporter() : mUpperCaseAthroughZ(1), mLowerCaseAthroughZ(1), mNumbers0through9(1), mPunctuation(1), mUpperEuro(1), mLowerEuro(1),
     mPlus(""), mMinus(""), mFontName("Arial"), mFontPctSize(fabs720(-0xc)), mItalics(0), mFontQuality(kFontQuality_AntiAliased), mFontWeight(400),
-    mPitchAndFamily(0x22), mFontCharset(0), mFontSupersample(kFontSuperSample_None), mLeft(0), mRight(0), mTop(0), mBottom(0), mFillWithSafeWhite(0), 
+    mPitchAndFamily(0x22), mFontCharset(0), mFontSupersample(kFontSuperSample_None), mLeft(0), mRight(0), mTop(0), mBottom(0), mFillWithSafeWhite(0),
     mFontToImportFrom(this, 0), mBitmapSavePath("ui/image/"), mBitMapSaveName("temp.BMP"), mGennedFonts(this, kObjListNoNull), mReferenceKerning(this, 0),
     mMatVariations(this, kObjListNoNull), mDefaultMat(this, 0), mHandmadeFont(this, 0), mCheckNG(0), mSyncResource(), mLastGenWasNG(1) {
     DataArray* cfg = SystemConfig(objects, StaticClassName())->FindArray(default_bitmap_path, false);
@@ -35,7 +35,7 @@ UIFontImporter::UIFontImporter() : mUpperCaseAthroughZ(1), mLowerCaseAthroughZ(1
 }
 
 UIFontImporter::~UIFontImporter(){
-    
+
 }
 
 BEGIN_COPYS(UIFontImporter)
@@ -312,7 +312,7 @@ void UIFontImporter::ImportSettingsFromFont(RndFont* font){
     }
     if(has_import_font){
         SetProperty("font_name", DataNode(font->Property("font_name", true)->Str(0)));
-        SetProperty("font_size", DataNode(fabs720(-font->Property("font_size", true)->Int(0)))); 
+        SetProperty("font_size", DataNode(fabs720(-font->Property("font_size", true)->Int(0))));
         SetProperty("bold", DataNode(font->Property("bold", true)->Int(0)));
         SetProperty("italics", DataNode(font->Property("italics", true)->Int(0)));
         SetProperty("left", DataNode(font->Property("left", true)->Int(0)));
@@ -473,9 +473,9 @@ BEGIN_PROPSYNCS(UIFontImporter)
         mLastGenWasNG ? round720(mFontPctSize) : round480(mFontPctSize),
         mFontPctSize = mLastGenWasNG ? fabs720(-_val.Int(0)) : fabs480(-_val.Int(0)))
     SYNC_PROP_SET(font_pixel_size,
-        abs(mLastGenWasNG ? round720(mFontPctSize) : round480(mFontPctSize)),
+        std::abs(mLastGenWasNG ? round720(mFontPctSize) : round480(mFontPctSize)),
         mFontPctSize = mLastGenWasNG ? fabs720(-_val.Int(0)) : fabs480(-_val.Int(0)))
-    SYNC_PROP_SET(bold, abs(mFontWeight), mFontWeight = _val.Int(0) ? 800 : 400; GenerateBitmapFilename())
+    SYNC_PROP_SET(bold, std::abs(mFontWeight), mFontWeight = _val.Int(0) ? 800 : 400; GenerateBitmapFilename())
     SYNC_PROP_MODIFY(italics, mItalics, GenerateBitmapFilename())
     SYNC_PROP(font_quality, (int&)mFontQuality)
     SYNC_PROP(pitch_and_family, mPitchAndFamily)

--- a/src/system/ui/UILabel.cpp
+++ b/src/system/ui/UILabel.cpp
@@ -321,7 +321,7 @@ void UILabel::Update() {
 }
 
 void UILabel::LabelUpdate(bool b, bool c) {
-    
+
 }
 
 RndFont* UILabel::AltFont(){
@@ -462,7 +462,7 @@ float GetTextSizeFromPctHeight(float f){
         Vector2 vec2_2(0.0f, f);
         Vector3 vec3_2;
         TheUI->unk34->ScreenToWorld(vec2_2, transnum, vec3_2);
-        return __fabs(vec3_1.z - vec3_2.z);
+        return std::fabs(vec3_1.z - vec3_2.z);
     }
     else return f;
 }
@@ -475,7 +475,7 @@ float GetPctHeightFromTextSize(float f){
         Vector3 vec3_2(0.0f, 0.0f, -f);
         Vector2 vec2_2;
         TheUI->unk34->WorldToScreen(vec3_2, vec2_2);
-        return __fabs(vec2_1.y - vec2_2.y);
+        return std::fabs(vec2_1.y - vec2_2.y);
     }
     else return f;
 }

--- a/src/system/utl/MBT.cpp
+++ b/src/system/utl/MBT.cpp
@@ -29,9 +29,9 @@ const char* TickFormat(int tick, const MeasureMap& map){
     else return "negative tick";
 }
 
-// this feels fake, double check retail and see if fmod_f or something to that effect got called
 const char* FormatTimeMSH(float f){
-    double f2 = fmod((double)f, 60000.0);
-    double f3 = fmod((double)f, 1000.0);
+    // this feels fake, double check retail and see if fmod_f or something to that effect got called
+    double f2 = std::fmod((double)f, 60000.0);
+    double f3 = std::fmod((double)f, 1000.0);
     return MakeString("%d:%02d.%02d", (int)(f / 60000.0f), (int)(f2 / 1000.0), (int)(f3 / 10.0));
 }

--- a/src/system/utl/MultiTempoTempoMap.cpp
+++ b/src/system/utl/MultiTempoTempoMap.cpp
@@ -31,7 +31,7 @@ float MultiTempoTempoMap::GetTempoBPM(int tick) const {
 // float ConvertTimeBase(float value, float srcStart, float srcEnd, float destStart, float destEnd,) {
 //     float loopTickLength = srcEnd - srcStart;
 //     float loopTick = value - srcEnd;
-//     float loopPercent = floor(loopTick / loopTickLength);
+//     float loopPercent = std::floor(loopTick / loopTickLength);
 
 //     float loopTimeLength = destEnd - destStart;
 //     float loopTime = loopTimeLength * loopPercent + destEnd;
@@ -52,7 +52,7 @@ float MultiTempoTempoMap::TickToTime(float tick) const {
     } else {
         float loopTickLength = mEndLoopTick - startTick;
         float loopTick = tick - mEndLoopTick;
-        float loopPercent = floor(loopTick / loopTickLength);
+        float loopPercent = std::floor(loopTick / loopTickLength);
 
         float loopTimeLength = mEndLoopTime - mStartLoopTime;
         float loopTime = loopTimeLength * loopPercent + mEndLoopTime;
@@ -75,7 +75,7 @@ float MultiTempoTempoMap::TimeToTick(float time) const {
     } else {
         // float loopTimeLength = endTime - mStartLoopTime;
         // float loopTime = time - endTime;
-        // float loopPercent = floor_f(loopTime / loopTimeLength);
+        // float loopPercent = std::floor(loopTime / loopTimeLength);
 
         // float a = time + -(loopTimeLength * loopPercent - loopTime);
 
@@ -89,7 +89,7 @@ float MultiTempoTempoMap::TimeToTick(float time) const {
 
         float loopTimeLength = endTime - startTime;
         float loopTime = time - endTime;
-        float loopPercent = floor(loopTime / loopTimeLength);
+        float loopPercent = std::floor(loopTime / loopTimeLength);
 
         float loopTickLength = endTick - startTick;
         float loopTick = loopTickLength * loopPercent + endTick;
@@ -170,7 +170,7 @@ float MultiTempoTempoMap::GetTimeInLoop(float time){
     float timeFromStart = time - startTime;
     MILO_ASSERT(timeFromStart >= 0.0f, 0xE3);
 
-    float a = floor_f(timeFromStart / loopLength);
+    float a = std::floor(timeFromStart / loopLength);
     return startTime + -(loopLength * a - timeFromStart);
 }
 


### PR DESCRIPTION
~~Draft because, for some reason, locally this has a lower match % than the current upstream branch lol~~

Some varied fixes along the way; also adjusted the clang-format config to allow any small function to go on a single line, not just those in a class body.