### PR TITLE
DataArray.cpp now equivalent

### DIFF
--- a/config/SZBE69_B8/objects.json
+++ b/config/SZBE69_B8/objects.json
@@ -1075,7 +1075,7 @@
             "system/movie/Splash.cpp": "NonMatching",
             "system/movie/TexMovie.cpp": "Matching",
 
-            "system/obj/DataArray.cpp": "NonMatching",
+            "system/obj/DataArray.cpp": "Equivalent",
             "system/obj/DataFile.cpp": "NonMatching",
             "system/obj/DataFunc.cpp": "NonMatching",
             "system/obj/DataNode.cpp": "NonMatching",

--- a/src/decomp.h
+++ b/src/decomp.h
@@ -11,7 +11,7 @@
 #define CONCAT(x, y) __CONCAT(x, y)
 
 // Compile without matching hacks.
-#if defined(NON_MATCHING) || !defined(__MWERKS__) || defined(DECOMP_IDE_FLAG)
+#if defined(NON_MATCHING) || !defined(__MWERKS__)
 #define DECOMP_FORCEACTIVE(module, ...)
 #define DECOMP_FORCELITERAL(module, ...)
 #define DECOMP_FORCEFUNC(module, decl, ...)

--- a/src/system/obj/Data.h
+++ b/src/system/obj/Data.h
@@ -57,6 +57,8 @@ public:
     DataNodeValue mValue;
     DataType mType;
 
+    friend class DataArray;
+
     DataNode(){
         mValue.integer = 0;
         mType = kDataInt;

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -342,8 +342,9 @@ bool DataArray::FindData(Symbol s, const char *&ret, bool b) const {
     if (arr != 0) {
         ret = arr->Str(1);
         return true;
-    } else
+    } else {
         return false;
+    }
 }
 
 bool DataArray::FindData(Symbol s, Symbol &ret, bool b) const {
@@ -351,8 +352,9 @@ bool DataArray::FindData(Symbol s, Symbol &ret, bool b) const {
     if (arr != nullptr) {
         ret = (arr->Sym(1));
         return true;
-    } else
+    } else {
         return false;
+    }
 }
 
 bool DataArray::FindData(Symbol s, String &ret, bool b) const {
@@ -361,8 +363,9 @@ bool DataArray::FindData(Symbol s, String &ret, bool b) const {
     if (found) {
         ret = c;
         return true;
-    } else
+    } else {
         return false;
+    }
 }
 
 bool DataArray::FindData(Symbol s, int &ret, bool b) const {
@@ -370,8 +373,9 @@ bool DataArray::FindData(Symbol s, int &ret, bool b) const {
     if (arr != nullptr) {
         ret = arr->Int(1);
         return true;
-    } else
+    } else {
         return false;
+    }
 }
 
 bool DataArray::FindData(Symbol s, float &ret, bool b) const {
@@ -379,8 +383,9 @@ bool DataArray::FindData(Symbol s, float &ret, bool b) const {
     if (arr != nullptr) {
         ret = arr->Float(1);
         return true;
-    } else
+    } else {
         return false;
+    }
 }
 
 bool DataArray::FindData(Symbol s, bool &ret, bool b) const {
@@ -388,8 +393,39 @@ bool DataArray::FindData(Symbol s, bool &ret, bool b) const {
     if (arr != nullptr) {
         ret = arr->Int(1);
         return true;
-    } else
+    } else {
         return false;
+    }
+}
+
+bool DataArray::FindData(Symbol s, Plane &ret, bool b) const {
+    DataArray *arr = FindArray(s, b);
+    if (arr != nullptr) {
+        ret.a = arr->Float(1);
+        ret.b = arr->Float(2);
+        ret.c = arr->Float(3);
+        ret.d = arr->Float(4);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool DataArray::FindData(Symbol s, Hmx::Color &ret, bool b) const {
+    DataArray *arr = FindArray(s, b);
+    if (arr != nullptr) {
+        ret.red = arr->Float(1);
+        ret.green = arr->Float(2);
+        ret.blue = arr->Float(3);
+        if (arr->Size() > 4) {
+            ret.alpha = arr->Float(4);
+        } else {
+            ret.alpha = 1;
+        }
+        return true;
+    } else {
+        return false;
+    }
 }
 
 DataArray* DataArray::Clone(bool b1, bool b2, int i){

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -327,8 +327,14 @@ DataArray *DataArray::FindArray(Symbol s1, Symbol s2, Symbol s3) const {
     return FindArray(s1, true)->FindArray(s2, true)->FindArray(s3, true);
 }
 
+// FindArray(Symbol, Symbol) isn't being inlined below, so this will have to do
+inline DataArray *FindArray_Fake(const DataArray* const ths, Symbol s1, Symbol s2) {
+    return ths->FindArray(s1, true)->FindArray(s2, true);
+}
+
 DataArray *DataArray::FindArray(Symbol s, const char *c) const {
-    return FindArray(s, Symbol(c));
+    // return FindArray(this, s, Symbol(c));
+    return FindArray_Fake(this, s, Symbol(c));
 }
 
 bool DataArray::FindData(Symbol s, const char *&ret, bool b) const {

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -1,5 +1,4 @@
 #include "obj/Data.h"
-#include "types.h"
 #include <stdlib.h>
 #include <string.h>
 #include <list>
@@ -52,6 +51,11 @@ public:
 
 private:
 };
+
+// required to match `__FUNCTION__` strings
+DECOMP_FORCEBLOCK(DataArray, (std::vector<Vector3>& v),
+    v.erase(v.begin(), v.end());
+)
 
 bool strncat_tofit(char* c, int& ri, const char* cc, int i){
     int len = strlen(cc);
@@ -843,3 +847,7 @@ BinStream &operator<<(BinStream &bs, const DataArray *da) {
         bs << false;
     return bs;
 }
+
+DECOMP_FORCEBLOCK(DataArray, (std::vector<Vector3>& v),
+    v.insert(v.end(), Vector3());
+)

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -761,6 +761,7 @@ void DataArray::LoadGlob(BinStream &bs, bool b) {
         mSize = -(v + 1);
         mNodes = (DataNode*)NodesAlloc(-mSize);
         bs.Read(mNodes, v);
+        ((unsigned char*)mNodes)[v] = 0;
     } else {
         bs >> mSize;
         mNodes = (DataNode*)NodesAlloc(-mSize);

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -154,6 +154,10 @@ bool DataArray::PrintUnused(TextStream& ts, DataType ty, bool b) const {
     return ret;
 }
 
+DECOMP_FORCEACTIVE(DataArray,
+    "gLinearNodesMemSize == 0"
+)
+
 void* NodesLinearAlloc(int i){
     MILO_ASSERT(gLinearNodesMemSize > 0, 264);
     gNumLinearAllocs++;
@@ -309,6 +313,11 @@ DataArray* DataArray::FindArray(Symbol tag, bool fail) const {
     if(found == 0 && fail) MILO_FAIL("Couldn't find '%s' in array (file %s, line %d)", tag.mStr, mFile.mStr, mLine);
     return found;
 }
+
+DECOMP_FORCEACTIVE(DataArray,
+    "a->Size()==3",
+    "AddrIsInLinearMem!\n"
+)
 
 DataArray *DataArray::FindArray(Symbol s1, Symbol s2) const {
     return FindArray(s1, true)->FindArray(s2, true);

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -146,12 +146,12 @@ void DataArray::Print(TextStream &ts, DataType type, bool b) const {
             i->Print(ts, b);
             i++;
         }
-        ts << " ";
+        ts << "\n";
         gIndent += 3;
         while (i < end) {
             ts.Space(gIndent);
             i->Print(ts, b);
-            ts << " ";
+            ts << "\n";
             i++;
         }
         gIndent -= 3;
@@ -161,7 +161,7 @@ void DataArray::Print(TextStream &ts, DataType type, bool b) const {
         ts << open;
         for (i = mNodes; i < end; i++) {
             if (i != mNodes) {
-                ts << "\n";
+                ts << " ";
             }
             i->Print(ts, b);
         }

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -488,9 +488,12 @@ int DataArray::NodeCmp(const void* a, const void* b){
         case kDataSymbol:
             return stricmp(anode->Str(), bnode->Str());
         case kDataArray:
-            return NodeCmp(&(anode->Array()->Node(0)), &(bnode->Array()->Node(0)));
-        case kDataObject:
-            return stricmp(anode->GetObj() ? anode->GetObj()->Name() : "", bnode->GetObj() ? bnode->GetObj()->Name() : "");
+            return NodeCmp(&anode->Array()->Node(0), &bnode->Array()->Node(0));
+        case kDataObject: {
+            const char* a = anode->GetObj() ? anode->GetObj()->Name() : "";
+            const char* b = bnode->GetObj() ? bnode->GetObj()->Name() : "";
+            return stricmp(a, b);
+        }
         default:
             MILO_WARN("could not sort array, bad type");
             return 0;

--- a/src/system/obj/DataArray.cpp
+++ b/src/system/obj/DataArray.cpp
@@ -91,56 +91,58 @@ DataNode& DataArray::Node(int i) {
 }
 
 void DataArray::Print(TextStream &ts, DataType type, bool b) const {
-    DataNode *lol;
-    DataNode *dn = mNodes;
-    DataNode *dn_end = &mNodes[mSize];
+    DataNode *i = mNodes;
+    DataNode *end = &mNodes[mSize];
     MILO_ASSERT(type & kDataArray, 0xA6);
-    char begin = '\0';
-    char end = '\0';
+    char open = '\0';
+    char close = '\0';
     if (type == kDataArray) {
-        begin = '(';
-        end = ')';
+        open = '(';
+        close = ')';
     } else if (type == kDataCommand) {
-        begin = '{';
-        end = '}';
+        open = '{';
+        close = '}';
     } else if (type == kDataProperty) {
-        begin = '[';
-        end = ']';
+        open = '[';
+        close = ']';
+    } else {
+        MILO_FAIL("Unrecognized array type %d", type);
     }
-    else MILO_FAIL("Unrecognized array type %d", type);
 
-    while (dn < dn_end) {
-        if (dn->Type() & 0x10)
+    i = mNodes;
+    while (i < end) {
+        if (i->Type() & kDataArray)
             break;
-        dn++;
+        i++;
     }
 
-    if ((dn != dn_end) && !b) {
-        ts << begin;
-        lol = mNodes;
-        if (lol->Type() == kDataSymbol) {
-            lol->Print(ts, b);
-            lol++;
+    if ((i != end) && !b) {
+        ts << open;
+        i = mNodes;
+        if (i->Type() == kDataSymbol) {
+            i->Print(ts, b);
+            i++;
         }
         ts << " ";
         gIndent += 3;
-        while (lol < dn_end) {
+        while (i < end) {
             ts.Space(gIndent);
-            lol->Print(ts, b);
+            i->Print(ts, b);
             ts << " ";
-            lol++;
+            i++;
         }
         gIndent -= 3;
         ts.Space(gIndent);
-        ts << end;
+        ts << close;
     } else {
-        ts << begin;
-        for (lol = mNodes; lol < dn_end; lol++) {
-            if (lol != mNodes)
+        ts << open;
+        for (i = mNodes; i < end; i++) {
+            if (i != mNodes) {
                 ts << "\n";
-            lol->Print(ts, b);
+            }
+            i->Print(ts, b);
         }
-        ts << end;
+        ts << close;
     }
 }
 

--- a/src/system/obj/DataFunc.cpp
+++ b/src/system/obj/DataFunc.cpp
@@ -24,9 +24,6 @@
 std::map<Symbol, DataFunc*> gDataFuncs;
 DataThisPtr gDataThisPtr;
 
-extern Hmx::Object *gDataThis;
-extern class ObjectDir* gDataDir;
-
 // Force ~MergeFilter() to generate here
 DECOMP_FORCEDTOR(DataFunc, MergeFilter);
 

--- a/src/system/obj/DataFunc.h
+++ b/src/system/obj/DataFunc.h
@@ -44,6 +44,9 @@ public:
 #define DEF_DATA_FUNC(name) \
     static DataNode name(DataArray* array)
 
+extern std::map<Symbol, DataFunc*> gDataFuncs;
+extern DataThisPtr gDataThisPtr;
+
 void DataRegisterFunc(Symbol s, DataFunc* func);
 Symbol DataFuncName(DataFunc*);
 bool FileListCallBack(char*);

--- a/src/system/os/Timer.h
+++ b/src/system/os/Timer.h
@@ -142,24 +142,26 @@ public:
     float mTopValues[MAX_TOP_VALS]; // 0x24
 };
 
-typedef void (*StupidAutoTimerFunc)(float, void*);
+typedef void (*AutoTimerCallback)(float elapsed, void* context);
 
 class AutoTimer {
 public:
 
-    AutoTimer(Timer* t, float f, StupidAutoTimerFunc s, void* v) {
+    AutoTimer(Timer* t, float limit, AutoTimerCallback callback, void* context) {
         mTimer = t;
         if (!t) return;
-        unk_0x4 = f; unk_0x8 = s; unk_0xC = v;
+        mTimeLimit = limit;
+        mCallback = callback;
+        mContext = context;
         mTimer->Start();
     }
 
     ~AutoTimer() { if (mTimer) mTimer->Stop(); }
 
-    Timer* mTimer; // 0x0
-    float unk_0x4;
-    StupidAutoTimerFunc unk_0x8; // ???
-    void* unk_0xC;
+    Timer* mTimer;
+    float mTimeLimit;
+    AutoTimerCallback mCallback;
+    void* mContext;
 
     static int sCritFrameCount;
     static std::vector<std::pair<Timer, TimerStats> > sTimers;
@@ -168,12 +170,15 @@ public:
 };
 
 #ifdef VERSION_SZBE69_B8
-#define START_AUTO_TIMER(name) \
+#define START_AUTO_TIMER_CALLBACK(name, func, context) \
     static Timer* _t = AutoTimer::GetTimer(name); \
-    AutoTimer t(_t, 50.0f, NULL, NULL)
+    AutoTimer _at(_t, 50.0f, func, context)
 #else
-#define START_AUTO_TIMER(name) (void)0
+#define START_AUTO_TIMER_CALLBACK(name) (void)0
 #endif
+
+#define START_AUTO_TIMER(name) \
+    START_AUTO_TIMER_CALLBACK(name, NULL, NULL)
 
 #define TIMER_ACTION(name, action) { \
     START_AUTO_TIMER(name); \


### PR DESCRIPTION
Some issues still remain, but the functions they affect otherwise appear to be equivalent.

- `DataArray::Execute`: regswaps, `AutoTimer` constructor, `gDataFuncs.find`.
- `DataArray::Load`: regswaps, stackswaps.