### PR TITLE
Tidy up bounds checking asserts into macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -177,6 +177,8 @@ WhitespaceSensitiveMacros:
   - assert
   - Assert
   - MILO_ASSERT
+  - MILO_ASSERT_RANGE
+  - MILO_ASSERT_RANGE_EQ
   - _STLP_ASSERT
   - _STLP_VERBOSE_ASSERT
   - DECOMP_FORCEBLOCK

--- a/src/band3/bandtrack/GemRepTemplate.cpp
+++ b/src/band3/bandtrack/GemRepTemplate.cpp
@@ -6,7 +6,10 @@
 #include "rndobj/Mat.h"
 #include <algorithm>
 
-#define kNumGemSlotMats 1
+// needs to be an enum for value names to show in asserts
+enum {
+    kNumGemSlotMats = 1
+};
 
 GemRepTemplate::GemRepTemplate(const TrackConfig& tc) : mConfig(SystemConfig("track_graphics", "gem")),
     kTailPulseRate(mConfig->FindArray("tail_pulse_rate", true)->Float(1)),
@@ -100,13 +103,13 @@ float GemRepTemplate::GetTailSectionLength(GemRepTemplate::TailType type) const 
 }
 
 RndMat* GemRepTemplate::GetSlotMat(int matIndex, int slotIndex) const {
-    MILO_ASSERT(( 0) <= (matIndex) && (matIndex) < ( kNumGemSlotMats), 244);
-    MILO_ASSERT(( 0) <= (slotIndex) && (slotIndex) < ( mTrackCfg.GetMaxSlots()), 245);
+    MILO_ASSERT_RANGE(matIndex, 0, kNumGemSlotMats, 244);
+    MILO_ASSERT_RANGE(slotIndex, 0, mTrackCfg.GetMaxSlots(), 245);
     return mSlots[matIndex + slotIndex];
 }
 
 void GemRepTemplate::SetSlotMat(int matIndex, int slotIndex, RndMat* mat) {
-    MILO_ASSERT(( 0) <= (matIndex) && (matIndex) < ( kNumGemSlotMats), 251);
-    MILO_ASSERT(( 0) <= (slotIndex) && (slotIndex) < ( mTrackCfg.GetMaxSlots()), 252);
+    MILO_ASSERT_RANGE(matIndex, 0, kNumGemSlotMats, 251);
+    MILO_ASSERT_RANGE(slotIndex, 0, mTrackCfg.GetMaxSlots(), 252);
     mSlots[matIndex + slotIndex] = mat;
 }

--- a/src/band3/game/BandUser.cpp
+++ b/src/band3/game/BandUser.cpp
@@ -52,7 +52,7 @@ Symbol BandUser::GetDifficultySym() const {
 
 void BandUser::SetDifficulty(Difficulty d){
     MILO_ASSERT(IsLocal(), 0x74);
-    MILO_ASSERT(( 0) <= (d) && (d) < ( kNumDifficulties), 0x75);
+    MILO_ASSERT_RANGE(d, 0, kNumDifficulties, 0x75);
     Difficulty old = mDifficulty;
     unk_0xC = true;
     mDifficulty = d;
@@ -275,7 +275,7 @@ void LocalBandUser::SetOvershellFocus(const char* cc){
 ControllerType LocalBandUser::DebugGetControllerTypeOverride() const { return mControllerTypeOverride; }
 
 void LocalBandUser::DebugSetControllerTypeOverride(ControllerType ct){
-    MILO_ASSERT(( 0) <= (ct) && (ct) <= ( kNumControllerTypes), 0x3B2);
+    MILO_ASSERT_RANGE_EQ(ct, 0, kNumControllerTypes, 0x3B2);
     mControllerTypeOverride = ct;
 }
 

--- a/src/band3/game/Scoring.cpp
+++ b/src/band3/game/Scoring.cpp
@@ -13,9 +13,9 @@ OverdriveConfig::OverdriveConfig(DataArray* cfg){
     readyLevel = cfg->FindFloat("ready_level");
     multiplier = cfg->FindInt("multiplier");
     crowdBoost = cfg->FindFloat("crowd_boost");
-    MILO_ASSERT(( 0) <= (rechargeRate) && (rechargeRate) <= ( 1), 0x22);
-    MILO_ASSERT(( 0) <= (starPhrase) && (starPhrase) <= ( 1), 0x23);
-    MILO_ASSERT(( 0) <= (readyLevel) && (readyLevel) <= ( 1), 0x24);
+    MILO_ASSERT_RANGE_EQ(rechargeRate, 0, 1, 0x22);
+    MILO_ASSERT_RANGE_EQ(starPhrase, 0, 1, 0x23);
+    MILO_ASSERT_RANGE_EQ(readyLevel, 0, 1, 0x24);
 }
 
 Scoring::Scoring() : unk8c(SystemConfig("scoring")), unk90(unk8c->FindArray("overdrive", true)), unkc0(0) {
@@ -99,7 +99,7 @@ Symbol Scoring::GetStarRating(int numStars) const {
     if(numStars == 0) return gNullStr;
     else {
         DataArray* ratings = unk8c->FindArray("star_ratings", "symbols")->Array(1);
-        MILO_ASSERT(( 1) <= (numStars) && (numStars) <= ( ratings->Size()), 0x1BE);
+        MILO_ASSERT_RANGE_EQ(numStars, 1,  ratings->Size(), 0x1BE);
         return ratings->Sym(numStars - 1);
     }
 }

--- a/src/band3/game/Stats.h
+++ b/src/band3/game/Stats.h
@@ -55,7 +55,7 @@ public:
 
     Stats();
     Stats(const Stats& s);
-    
+
 
     // Stats::Stats(const Stats& s) : mHitCount(s.mHitCount), mMissCount(s.mMissCount), m0x08(s.m0x08), m0x0c(s.m0x0c), mPersistentStreak(s.mPersistentStreak), mLongestPersistentStreak(s.mLongestPersistentStreak),
     //     mNotesHitFraction(s.mNotesHitFraction), mFailedDeploy(s.mFailedDeploy), mDeployCount(s.mDeployCount), mFillHitCount(s.mFillHitCount), m0x28(s.m0x28), m0x2c(s.m0x2c), m0x30(s.m0x30), m0x34(s.m0x34),
@@ -64,7 +64,7 @@ public:
     //     mTripleHarmonyPhraseCount(s.mTripleHarmonyPhraseCount), m0x5c(s.m0x5c), m0x60(s.m0x60), m0x64(s.m0x64), m0x68(s.m0x68), m0x6c(s.m0x6c), m0x70(s.m0x70), mSingerStats(s.mSingerStats), mAccessPerformanceAwards(s.mAccessPerformanceAwards),
     //     mAccuracy(s.mAccuracy), m0x8c(s.m0x8c), mSolo(s.mSolo), mOverdrive(s.mOverdrive), mSustain(s.mSustain), mScoreStreak(s.mScoreStreak), mBandContribution(s.mBandContribution),
     //     mCodaPoints(s.mCodaPoints), m0xa8(s.m0xa8), m0x09(s.m0x09), mTambourine(s.mTambourine), mHarmony(s.mHarmony), mFullCombo(s.mFullCombo), mNoScorePercent(s.mNoScorePercent), mCurrentHitStreak(s.mCurrentHitStreak) {
-        
+
     // }
 
     ~Stats(){}
@@ -138,7 +138,7 @@ public:
     int GetHitCount() const { return mHitCount; }
     float GetNotesHitFraction() const { return mNotesHitFraction; }
     int GetNumberOfSingers() const { return mNumberOfSingers; }
-    float GetVocalPartPercentage(int i) const { return m0x70[i]; }    
+    float GetVocalPartPercentage(int i) const { return m0x70[i]; }
     bool GetFailedDeploy() const { return mFailedDeploy; }
     int GetPlayersSaved() const { return mPlayersSaved; }
     int GetFillHitCount() const { return mFillHitCount; }
@@ -162,23 +162,23 @@ public:
     StreakInfo& AccessCurrentStreakInfo(){ return mCurrentHitStreak; }
     std::vector<int>& AccessBestSolos(){ return mBestSolos; }
     StreakInfo& AccessHitStreak(int index){
-        MILO_ASSERT(( 0) <= ( index) && ( index) < ( mHitStreaks.size()), 0x1C5);
+        MILO_ASSERT_RANGE(index, 0, mHitStreaks.size(), 0x1C5);
         return mHitStreaks[index];
     }
     StreakInfo& AccessMissStreak(int index){
-        MILO_ASSERT(( 0) <= ( index) && ( index) < ( mMissStreaks.size()), 0x1D3);
+        MILO_ASSERT_RANGE(index, 0, mMissStreaks.size(), 0x1D3);
         return mMissStreaks[index];
     }
     MultiplierInfo& AccessBestOverdriveDeployment(int index){
-        MILO_ASSERT(( 0) <= ( index) && ( index) < ( mBestOverdriveDeployments.size()), 0x1E1);
+        MILO_ASSERT_RANGE(index, 0, mBestOverdriveDeployments.size(), 0x1E1);
         return mBestOverdriveDeployments[index];
     }
     MultiplierInfo& AccessBestStreakMultiplier(int index){
-        MILO_ASSERT(( 0) <= ( index) && ( index) < ( mBestStreakMultipliers.size()), 0x1EF);
+        MILO_ASSERT_RANGE(index, 0, mBestStreakMultipliers.size(), 0x1EF);
         return mBestStreakMultipliers[index];
     }
     SingerStats& AccessSingerStats(int index){
-        MILO_ASSERT(( 0) <= ( index) && ( index) < ( mSingerStats.size()), 0xC6);
+        MILO_ASSERT_RANGE(index, 0, mSingerStats.size(), 0xC6);
         return mSingerStats[index];
     }
     void SetTimesSaved(int timesSaved) { mTimesSaved = timesSaved; }
@@ -211,7 +211,7 @@ public:
     void SetDoubleHarmonyPhraseCount(int doubleHarmonyPhraseCount) { mDoubleHarmonyPhraseCount = doubleHarmonyPhraseCount; }
     void SetTripleHarmonyHit(int tripleHarmonyHit) { mTripleHarmonyHit = tripleHarmonyHit; }
     void SetTripleHarmonyPhraseCount(int tripleHarmonyPhraseCount) { mTripleHarmonyPhraseCount = tripleHarmonyPhraseCount; }
-    
+
     template <class T> void SaveHighest(std::vector<T>&, const T&);
 
     int mHitCount;                             // 0x000

--- a/src/band3/meta_band/Asset.cpp
+++ b/src/band3/meta_band/Asset.cpp
@@ -6,7 +6,7 @@
 #include "utl/Symbols3.h"
 #include "AssetTypes.h"
 
-Asset::Asset(DataArray* pConfig, int index) : mName(gNullStr), mGender(0), mType(0), mBoutique(0), mPatchable(false), 
+Asset::Asset(DataArray* pConfig, int index) : mName(gNullStr), mGender(0), mType(0), mBoutique(0), mPatchable(false),
     mHidden(false), mIndex(index) {
     MILO_ASSERT(pConfig, 21);
     Symbol name = pConfig->Sym(0);
@@ -31,7 +31,7 @@ Asset::Asset(DataArray* pConfig, int index) : mName(gNullStr), mGender(0), mType
     DataArray* finishesArray = pConfig->FindArray(finishes, false);
     if (finishesArray != NULL) {
         if (assetType == 10 || (unsigned long)(assetType - 2) <= 1) {
-            for (int i = 1; i < finishesArray->Size(); i++) {  
+            for (int i = 1; i < finishesArray->Size(); i++) {
                 Symbol finish = finishesArray->Str(i);
                 mFinishes.push_back(finish);
             }
@@ -61,7 +61,7 @@ void Asset::GetFinishes(std::vector<Symbol>& v) const {
 }
 
 Symbol Asset::GetFinish(int index) const {
-    MILO_ASSERT(( 0) <= (index) && (index) < ( mFinishes.size()), 100);
+    MILO_ASSERT_RANGE(index, 0, mFinishes.size(), 100);
     return mFinishes[index];
 }
 

--- a/src/band3/meta_band/AssetProvider.cpp
+++ b/src/band3/meta_band/AssetProvider.cpp
@@ -42,7 +42,7 @@ void AssetProvider::Update(AssetType, AssetBoutique) {
         Asset* pAsset = it->second;
         MILO_ASSERT(pAsset, 0x46);
     }
-    
+
     std::sort(symbols.begin(), symbols.end());
 }
 
@@ -62,11 +62,11 @@ void AssetProvider::Text(int, int, UIListLabel* slot, UILabel* label) const {
     MILO_ASSERT(label, 0xc9);
 
     // ProfileAssets* profileAssets = mProfile.mProfileAssets;
-    
+
     // AssetMgr* pAssetMgr = AssetMgr::GetAssetMgr();
     // MILO_ASSERT(pAssetMgr, 0xd0);
 
-    
+
 }
 
 RndMat* AssetProvider::Mat(int, int, UIListMesh*) const {
@@ -106,7 +106,7 @@ void AssetProvider::UpdateExtendedText(int, int i_iData, UILabel* label) const {
 }
 
 Symbol AssetProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x165);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x165);
     return mAssets[data];
 }
 

--- a/src/band3/meta_band/BandProfile.cpp
+++ b/src/band3/meta_band/BandProfile.cpp
@@ -128,12 +128,12 @@ void BandProfile::GetPatchIndex(const PatchDir*) const {}
 
 // void BandProfile::GetCharacterStandinIndex(CharData*) const {}
 // StandIn* BandProfile::GetStandIn(int index) const {
-//     MILO_ASSERT(( 0) <= (index) && (index) < mStandIns.size(), 0x14d);
+//     MILO_ASSERT_RANGE(index, 0, mStandIns.size(), 0x14d);
 //     return mStandIns[index];
 // }
 
 // StandIn* BandProfile::AccessStandIn(int index) {
-//     MILO_ASSERT(( 0) <= (index) && (index) < mStandIns.size(), 0x14d);
+//     MILO_ASSERT_RANGE(index, 0, mStandIns.size(), 0x14d);
 //     return mStandIns[index];
 // }
 

--- a/src/band3/meta_band/CharProvider.cpp
+++ b/src/band3/meta_band/CharProvider.cpp
@@ -129,21 +129,21 @@ RndMat* CharProvider::Mat(int, int data, UIListMesh* slot) const {
 }
 
 Symbol CharProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x102);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x102);
     return mCharacters[data].unk8;
 }
 
 bool CharProvider::IsActive(int data) const {
     if(mCharacters.empty()) return false;
     else {
-        MILO_ASSERT(( 0) <= (data) && (data) < ( mCharacters.size()), 0x117);
+        MILO_ASSERT_RANGE(data, 0, mCharacters.size(), 0x117);
         CharacterEntry entry = mCharacters[data];
         return entry.mType != kCharacterEntryHeader;
     }
 }
 
 CharData* CharProvider::GetCharData(int idx){
-    MILO_ASSERT(( 0) <= (idx) && (idx) < ( mCharacters.size()), 0x11F);
+    MILO_ASSERT_RANGE(idx, 0, mCharacters.size(), 0x11F);
     CharacterEntry entry = mCharacters[idx];
     CharData* ret = entry.unk4;
     if(entry.mType == kCharacterEntryNew || entry.mType == kCharacterEntryHeader) ret = nullptr;
@@ -153,7 +153,7 @@ CharData* CharProvider::GetCharData(int idx){
 bool CharProvider::IsIndexNewChar(int idx){
     if(mCharacters.empty()) return false;
     else {
-        MILO_ASSERT(( 0) <= (idx) && (idx) < ( mCharacters.size()), 0x134);
+        MILO_ASSERT_RANGE(idx, 0, mCharacters.size(), 0x134);
         CharacterEntry entry = mCharacters[idx];
         return entry.mType == kCharacterEntryNew;
     }
@@ -162,7 +162,7 @@ bool CharProvider::IsIndexNewChar(int idx){
 bool CharProvider::IsIndexNone(int idx){
     if(mCharacters.empty()) return false;
     else {
-    MILO_ASSERT(( 0) <= (idx) && (idx) < ( mCharacters.size()), 0x141);
+        MILO_ASSERT_RANGE(idx, 0, mCharacters.size(), 0x141);
         CharacterEntry entry = mCharacters[idx];
         return entry.mType == kCharacterEntryNone;
     }
@@ -171,7 +171,7 @@ bool CharProvider::IsIndexNone(int idx){
 bool CharProvider::IsIndexCustomChar(int idx){
     if(mCharacters.empty()) return false;
     else {
-    MILO_ASSERT(( 0) <= (idx) && (idx) < ( mCharacters.size()), 0x14E);
+        MILO_ASSERT_RANGE(idx, 0, mCharacters.size(), 0x14E);
         CharacterEntry entry = mCharacters[idx];
         return entry.mType == kCharacterEntryCustom;
     }
@@ -180,7 +180,7 @@ bool CharProvider::IsIndexCustomChar(int idx){
 bool CharProvider::IsIndexPrefab(int idx){
     if(mCharacters.empty()) return false;
     else {
-    MILO_ASSERT(( 0) <= (idx) && (idx) < ( mCharacters.size()), 0x15B);
+        MILO_ASSERT_RANGE(idx, 0, mCharacters.size(), 0x15B);
         CharacterEntry entry = mCharacters[idx];
         return entry.mType == kCharacterEntryPrefab;
     }

--- a/src/band3/meta_band/CharacterCreatorPanel.cpp
+++ b/src/band3/meta_band/CharacterCreatorPanel.cpp
@@ -295,7 +295,7 @@ Symbol CharacterCreatorPanel::GetFaceHair(){
 
 void CharacterCreatorPanel::SetHeight(int height){
     if(mPreviewDesc){
-        MILO_ASSERT(( 0) <= (height) && (height) <= ( 10), 0x268);
+        MILO_ASSERT_RANGE_EQ(height, 0, 10, 0x268);
         mPreviewDesc->SetHeight(height / 10.0f);
         mClosetMgr->PreviewCharacter(true, false);
     }
@@ -305,14 +305,14 @@ int CharacterCreatorPanel::GetHeight(){
     if(!mPreviewDesc) return 0;
     else {
         float fHeight = mPreviewDesc->mHeight;
-        MILO_ASSERT(( 0.0f) <= (fHeight) && (fHeight) <= ( 1.0f), 0x276);
+        MILO_ASSERT_RANGE_EQ(fHeight, 0.0f, 1.0f, 0x276);
         return fHeight * 10.0f;
     }
 }
 
 void CharacterCreatorPanel::SetWeight(int weight){
     if(mPreviewDesc){
-        MILO_ASSERT(( 0) <= (weight) && (weight) <= ( 10), 0x282);
+        MILO_ASSERT_RANGE_EQ(weight, 0, 10, 0x282);
         mPreviewDesc->SetWeight(weight / 10.0f);
         mClosetMgr->PreviewCharacter(true, false);
     }
@@ -322,14 +322,14 @@ int CharacterCreatorPanel::GetWeight(){
     if(!mPreviewDesc) return 0;
     else {
         float fWeight = mPreviewDesc->mWeight;
-        MILO_ASSERT(( 0.0f) <= (fWeight) && (fWeight) <= ( 1.0f), 0x290);
+        MILO_ASSERT_RANGE_EQ(fWeight, 0.0f, 1.0f, 0x290);
         return fWeight * 10.0f;
     }
 }
 
 void CharacterCreatorPanel::SetBuild(int build){
     if(mPreviewDesc){
-        MILO_ASSERT(( 0) <= (build) && (build) <= ( 10), 0x29C);
+        MILO_ASSERT_RANGE_EQ(build, 0, 10, 0x29C);
         mPreviewDesc->SetMuscle(build / 10.0f);
         mClosetMgr->PreviewCharacter(true, false);
     }
@@ -339,7 +339,7 @@ int CharacterCreatorPanel::GetBuild(){
     if(!mPreviewDesc) return 0;
     else {
         float fBuild = mPreviewDesc->mMuscle;
-        MILO_ASSERT(( 0.0f) <= (fBuild) && (fBuild) <= ( 1.0f), 0x2AA);
+        MILO_ASSERT_RANGE_EQ(fBuild, 0.0f, 1.0f, 0x2AA);
         return fBuild * 10.0f;
     }
 }
@@ -801,3 +801,4 @@ inline RndMat* FaceOptionsProvider::Mat(int, int data, UIListMesh* mesh) const {
     }
     return nullptr;
 }
+

--- a/src/band3/meta_band/CymbalSelectionProvider.cpp
+++ b/src/band3/meta_band/CymbalSelectionProvider.cpp
@@ -23,18 +23,18 @@ void CymbalSelectionProvider::ReloadData(){
 }
 
 bool CymbalSelectionProvider::IsActive(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x2C);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x2C);
     if(unk20[data] == overshell_cymbals_continue && !mSlot->mCymbalConfiguration) return false;
     else return true;
 }
 
 void CymbalSelectionProvider::Text(int, int data, UIListLabel*, UILabel* label) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x36);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x36);
     label->SetTextToken(unk20[data]);
 }
 
 Symbol CymbalSelectionProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x3D);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x3D);
     return unk20[data];
 }
 

--- a/src/band3/meta_band/EyebrowsProvider.cpp
+++ b/src/band3/meta_band/EyebrowsProvider.cpp
@@ -32,7 +32,7 @@ RndMat* EyebrowsProvider::Mat(int, int data, UIListMesh* mesh) const {
 Symbol EyebrowsProvider::DataSymbol(int idx) const {
     int data = NumData() - 1;
     data = Clamp(0, data, idx);
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x41);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x41);
     return mEyebrows[data];
 }
 

--- a/src/band3/meta_band/FaceHairProvider.cpp
+++ b/src/band3/meta_band/FaceHairProvider.cpp
@@ -39,7 +39,7 @@ void FaceHairProvider::Text(int, int idx, UIListLabel* slot, UILabel* label) con
 }
 
 Symbol FaceHairProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x56);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x56);
     return mFaceHair->at(data);
 }
 

--- a/src/band3/meta_band/FaceTypeProvider.cpp
+++ b/src/band3/meta_band/FaceTypeProvider.cpp
@@ -26,7 +26,7 @@ void FaceTypeProvider::Text(int, int idx, UIListLabel* slot, UILabel* label) con
 }
 
 Symbol FaceTypeProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x32);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x32);
     return mFaceTypes[data];
 }
 

--- a/src/band3/meta_band/LessonProvider.cpp
+++ b/src/band3/meta_band/LessonProvider.cpp
@@ -106,6 +106,6 @@ void LessonProvider::Update(Symbol s){
 }
 
 const LessonProvider::LessonEntry& LessonProvider::GetLessonEntry(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0xD0);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0xD0);
     return mLessonEntries[data];
 }

--- a/src/band3/meta_band/NewAssetProvider.cpp
+++ b/src/band3/meta_band/NewAssetProvider.cpp
@@ -35,7 +35,7 @@ void NewAssetProvider::Text(int param_1, int index, UIListLabel* slot, UILabel* 
             label->SetTextToken(customize_new);
         } else {
             label->SetTextToken(gNullStr);
-        } 
+        }
     }
 }
 
@@ -60,7 +60,7 @@ void NewAssetProvider::UpdateExtendedText(int i, int i_iData, UILabel* label) co
 }
 
 Symbol NewAssetProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < (NumData()), 0x75);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x75);
     return mSymbols[data];
 }
 

--- a/src/band3/meta_band/OutfitProvider.cpp
+++ b/src/band3/meta_band/OutfitProvider.cpp
@@ -24,7 +24,7 @@ void OutfitProvider::Text(int, int data, UIListLabel* slot, UILabel* label) cons
 }
 
 Symbol OutfitProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x2C);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x2C);
     return unk20[data];
 }
 

--- a/src/band3/meta_band/OvershellPartSelectProvider.cpp
+++ b/src/band3/meta_band/OvershellPartSelectProvider.cpp
@@ -59,7 +59,7 @@ void OvershellPartSelectProvider::Clear(){
 int OvershellPartSelectProvider::NumData() const { return mPartSelections.size(); }
 
 Symbol OvershellPartSelectProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( mPartSelections.size()), 0xE5);
+    MILO_ASSERT_RANGE(data, 0, mPartSelections.size(), 0xE5);
     return mPartSelections[data].unk0;
 }
 

--- a/src/band3/meta_band/PrefabMgr.cpp
+++ b/src/band3/meta_band/PrefabMgr.cpp
@@ -53,7 +53,7 @@ void PrefabMgr::Init(BandUserMgr* mgr){
     else {
         MILO_ASSERT(TheBandUserMgr, 0x4C);
         ThePrefabMgr->unk5c = TheBandUserMgr;
-    }    
+    }
     DataRegisterFunc("prefab_is_customizable", OnPrefabIsCustomizable);
     DataRegisterFunc("prefab_toggle_customizable", OnPrefabToggleCustomizable);
     DataRegisterFunc("prefab_uses_profile_patches", OnPrefabUsesProfilePatches);
@@ -156,7 +156,7 @@ void PrefabMgr::EnableDebugPrefabs(){
 }
 
 PrefabChar* PrefabMgr::GetDefaultPrefab(int slotNum) const {
-    MILO_ASSERT(( 0) <= (slotNum) && (slotNum) < ( mDefaultPrefabs.size()), 0x132);
+    MILO_ASSERT_RANGE(slotNum, 0, mDefaultPrefabs.size(), 0x132);
     return mDefaultPrefabs[slotNum];
 }
 

--- a/src/band3/meta_band/ProfileMgr.cpp
+++ b/src/band3/meta_band/ProfileMgr.cpp
@@ -173,7 +173,7 @@ int ProfileMgr::GetSliderStepCount() const {
 }
 
 void ProfileMgr::PushAllOptions(){
-    
+
 }
 
 bool ProfileMgr::GetBassBoost() const { return mBassBoost; }
@@ -310,15 +310,16 @@ void ProfileMgr::SetSongToTaskMgrMsRaw(float ms){
         mGlobalOptionsDirty = true;
     }
 }
+
 float ProfileMgr::GetJoypadExtraLag(JoypadType type, LagContext ctx) const {
-    MILO_ASSERT(( 0) <= (type) && (type) < ( kJoypadNumTypes), 0x6DE);
-    MILO_ASSERT(( 0) <= (ctx) && (ctx) < ( kNumLagContexts), 0x6DF);
+    MILO_ASSERT_RANGE(type, 0, kJoypadNumTypes, 0x6DE);
+    MILO_ASSERT_RANGE(ctx, 0, kNumLagContexts, 0x6DF);
     return mJoypadExtraLagOffsets[type][ctx];
 }
 
 void ProfileMgr::SetJoypadExtraLag(JoypadType type, LagContext ctx, float lag){
-    MILO_ASSERT(( 0) <= (type) && (type) < ( kJoypadNumTypes), 0x6E5);
-    MILO_ASSERT(( 0) <= (ctx) && (ctx) < ( kNumLagContexts), 0x6E6);
+    MILO_ASSERT_RANGE(type, 0, kJoypadNumTypes, 0x6E5);
+    MILO_ASSERT_RANGE(ctx, 0, kNumLagContexts, 0x6E6);
     mJoypadExtraLagOffsets[type][ctx] = lag;
 }
 

--- a/src/band3/meta_band/SongSortMgr.h
+++ b/src/band3/meta_band/SongSortMgr.h
@@ -27,10 +27,10 @@ public:
         ~SongFilter(){}
 
         void AddFilter(FilterType type, Symbol s){
-            MILO_ASSERT(( 0) <= (type) && (type) < ( kNumFilterTypes), 0x5E);
+            MILO_ASSERT_RANGE(type, 0, kNumFilterTypes, 0x5E);
             filters[type].insert(s);
         }
-        
+
         std::vector<std::set<Symbol> > filters; // 0x0
         TrackType requiredTrackType; // 0x8
         std::vector<int> excludedSongs; // 0xc

--- a/src/band3/meta_band/TrainerProvider.cpp
+++ b/src/band3/meta_band/TrainerProvider.cpp
@@ -39,6 +39,6 @@ void TrainerProvider::Text(int i1, int i2, UIListLabel* slot, UILabel* label) co
 }
 
 Symbol TrainerProvider::DataSymbol(int data) const {
-    MILO_ASSERT(( 0) <= (data) && (data) < ( NumData()), 0x41);
+    MILO_ASSERT_RANGE(data, 0, NumData(), 0x41);
     return mTrainers[data];
 }

--- a/src/band3/tour/QuestFilterPanel.cpp
+++ b/src/band3/tour/QuestFilterPanel.cpp
@@ -29,7 +29,7 @@ Symbol QuestFilterPanel::GetSelectedFilter(){
 }
 
 inline Symbol QuestFilterProvider::DataSymbol(int i_iData) const {
-    MILO_ASSERT(( 0) <= ( i_iData) && ( i_iData) < ( NumData()), 0xD0);
+    MILO_ASSERT_RANGE( i_iData, 0, NumData(), 0xD0);
     return unk24[i_iData];
 }
 

--- a/src/band3/tour/TourDesc.cpp
+++ b/src/band3/tour/TourDesc.cpp
@@ -87,7 +87,7 @@ int TourDesc::GetIndex() const { return mIndex; }
 int TourDesc::GetNumGigs() const { return m_vEntries.size(); }
 
 TourDescEntry* TourDesc::GetTourDescEntryForGigNum(int i_iGigNum) const {
-    MILO_ASSERT_RANGE(i_iGigNum, 0, m_vEntries.size(), 0xB0);
+    MILO_ASSERT_RANGE( i_iGigNum, 0, m_vEntries.size(), 0xB0);
     return m_vEntries[i_iGigNum];
 }
 

--- a/src/band3/tour/TourDesc.cpp
+++ b/src/band3/tour/TourDesc.cpp
@@ -87,7 +87,7 @@ int TourDesc::GetIndex() const { return mIndex; }
 int TourDesc::GetNumGigs() const { return m_vEntries.size(); }
 
 TourDescEntry* TourDesc::GetTourDescEntryForGigNum(int i_iGigNum) const {
-    MILO_ASSERT(( 0) <= ( i_iGigNum) && ( i_iGigNum) < ( m_vEntries.size()), 0xB0);
+    MILO_ASSERT_RANGE(i_iGigNum, 0, m_vEntries.size(), 0xB0);
     return m_vEntries[i_iGigNum];
 }
 

--- a/src/band3/tour/TourProgress.cpp
+++ b/src/band3/tour/TourProgress.cpp
@@ -367,7 +367,7 @@ bool TourProgress::AreQuestFiltersEmpty() const {
 }
 
 Symbol TourProgress::GetQuestFilter(int i_iIndex) const {
-    MILO_ASSERT(( 0) <= ( i_iIndex) && ( i_iIndex) < ( kTour_NumQuestFilters), 0x2A2);
+    MILO_ASSERT_RANGE( i_iIndex, 0, kTour_NumQuestFilters, 0x2A2);
     return mQuestFilters[i_iIndex];
 }
 
@@ -382,7 +382,7 @@ bool TourProgress::HasQuestFilter(Symbol s) const {
 }
 
 void TourProgress::SetQuestFilter(int i_iIndex, Symbol s){
-    MILO_ASSERT(( 0) <= ( i_iIndex) && ( i_iIndex) < ( kTour_NumQuestFilters), 0x2C2);
+    MILO_ASSERT_RANGE( i_iIndex, 0, kTour_NumQuestFilters, 0x2C2);
     mQuestFilters[i_iIndex] = s;
     HandleDirty(3);
 }
@@ -472,3 +472,4 @@ BEGIN_HANDLERS(TourProgress)
     HANDLE_CHECK(0x373)
 END_HANDLERS
 #pragma pop
+

--- a/src/band3/tour/TourProgress.h
+++ b/src/band3/tour/TourProgress.h
@@ -7,7 +7,9 @@
 #include "tour/QuestJournal.h"
 #include "utl/BinStream.h"
 
-#define kTour_NumQuestFilters 3
+enum {
+    kTour_NumQuestFilters = 3,
+};
 
 class TourProgress : public TourSavable, public FixedSizeSaveable {
 public:

--- a/src/system/bandobj/BandCharDesc.cpp
+++ b/src/system/bandobj/BandCharDesc.cpp
@@ -809,7 +809,7 @@ int BandCharDesc::FindPatchIndex(BandCharDesc::Patch::Category cat, const char* 
 }
 
 BandCharDesc::Patch* BandCharDesc::GetPatch(int index){
-    MILO_ASSERT(( 0) <= (index) && (index) < ( mPatches.size()), 0x5CD);
+    MILO_ASSERT_RANGE(index, 0, mPatches.size(), 0x5CD);
     return &mPatches[index];
 }
 

--- a/src/system/bandobj/BandCrowdMeter.cpp
+++ b/src/system/bandobj/BandCrowdMeter.cpp
@@ -128,7 +128,7 @@ void BandCrowdMeter::Poll(){
             if(d15 < loc80){
                 float max = std::max(1.0f, loc80 - d15);
                 float min = std::min(loc80, d15 + (max * 0.1f));
-                curgrp->SetFrame(max, 1.0f);              
+                curgrp->SetFrame(max, 1.0f);
             }
             else if(d15 > loc80){
                 float max = std::max(1.0f, d15 - loc80);
@@ -170,7 +170,7 @@ TrackInstrument GetTrackInstrument(Symbol s){
 }
 
 void BandCrowdMeter::SetPlayerValue(int trackIdx, float val){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x13F);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x13F);
     mIconData[trackIdx].SetVal(val);
 }
 
@@ -223,22 +223,22 @@ void BandCrowdMeter::UpdateExcitement(bool b){
 }
 
 void BandCrowdMeter::SetPlayerIconState(int trackIdx, CrowdMeterState cstate){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x193);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x193);
     mIconData[trackIdx].unk0->SetState(cstate, false);
 }
 
 void BandCrowdMeter::SetPlayerQuarantined(int trackIdx, bool b){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x199);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x199);
     mIconData[trackIdx].unk0->SetQuarantined(b);
 }
 
 void BandCrowdMeter::DropInPlayer(int trackIdx){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x19F);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x19F);
     mIconData[trackIdx].unk0->DropIn();
 }
 
 void BandCrowdMeter::DropOutPlayer(int trackIdx){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x1A5);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x1A5);
     mIconData[trackIdx].unk0->DropOut();
 }
 
@@ -248,7 +248,7 @@ void BandCrowdMeter::SetMaxed(bool b){
 }
 
 void BandCrowdMeter::Deploy(int trackIdx){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x1B2);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x1B2);
     if(!mDisabled){
         if(!Deploying()) mBandEnergyDeployTrig->Trigger();
         mIconData[trackIdx].unk0->Deploy();
@@ -257,7 +257,7 @@ void BandCrowdMeter::Deploy(int trackIdx){
 }
 
 void BandCrowdMeter::StopDeploy(int trackIdx){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x1C1);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x1C1);
     if(!mDisabled){
         mIconData[trackIdx].unk1a = false;
         if(!Deploying()) mBandEnergyStopTrig->Trigger();
@@ -266,7 +266,7 @@ void BandCrowdMeter::StopDeploy(int trackIdx){
 }
 
 void BandCrowdMeter::EnablePlayer(int trackIdx){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x1D0);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x1D0);
     if(mIconData[trackIdx].unk18){
         mIconData[trackIdx].unk18 = false;
         if(!Draining()){
@@ -277,7 +277,7 @@ void BandCrowdMeter::EnablePlayer(int trackIdx){
 }
 
 void BandCrowdMeter::DisablePlayer(int trackIdx){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x1DE);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x1DE);
     if(!mIconData[trackIdx].unk18){
         if(mDisabledStartTrig && !Draining()){
             mDisabledStartTrig->Trigger();
@@ -287,7 +287,7 @@ void BandCrowdMeter::DisablePlayer(int trackIdx){
 }
 
 CrowdMeterIcon* BandCrowdMeter::PlayerIcon(int trackIdx){
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mIconData.size()), 0x1EA);
+    MILO_ASSERT_RANGE(trackIdx, 0, mIconData.size(), 0x1EA);
     return mIconData[trackIdx].unk0;
 }
 
@@ -304,7 +304,7 @@ void BandCrowdMeter::OnShowWorstCase(){
 }
 
 void BandCrowdMeter::SetIconVal(int idx, float f){
-    MILO_ASSERT(( 0) <= (idx) && (idx) < ( mIconData.size()), 0x1FF);
+    MILO_ASSERT_RANGE(idx, 0, mIconData.size(), 0x1FF);
     mIconData[idx].SetVal(f);
 }
 

--- a/src/system/bandobj/EndingBonus.cpp
+++ b/src/system/bandobj/EndingBonus.cpp
@@ -76,7 +76,7 @@ void EndingBonus::Reset(){
 }
 
 void EndingBonus::SetIconText(int slot_index, const char* cc){
-    MILO_ASSERT(( 0) <= (slot_index) && (slot_index) < ( mIconData.size()), 0x81);
+    MILO_ASSERT_RANGE(slot_index, 0, mIconData.size(), 0x81);
     mIconData[slot_index].mIcon->SetIcon(cc);
 }
 
@@ -87,12 +87,12 @@ void EndingBonus::Success(){
 }
 
 void EndingBonus::PlayerSuccess(int slot_index){
-    MILO_ASSERT(( 0) <= (slot_index) && (slot_index) < ( mIconData.size()), 0x90);
+    MILO_ASSERT_RANGE(slot_index, 0, mIconData.size(), 0x90);
     mIconData[slot_index].Succeeded();
 }
 
 void EndingBonus::PlayerFailure(int slot_index){
-    MILO_ASSERT(( 0) <= (slot_index) && (slot_index) < ( mIconData.size()), 0x96);
+    MILO_ASSERT_RANGE(slot_index, 0, mIconData.size(), 0x96);
     mIconData[slot_index].Failed();
 }
 

--- a/src/system/bandobj/MicInputArrow.cpp
+++ b/src/system/bandobj/MicInputArrow.cpp
@@ -73,7 +73,7 @@ void MicInputArrow::DrawShowing(){
 void MicInputArrow::SetMicMgr(MicManagerInterface* m){ mMicManagerInterface = m; }
 
 void MicInputArrow::SetMicConnected(bool connected, int arrowNum){
-    MILO_ASSERT(( 0) <= (arrowNum) && (arrowNum) < ( mConnectedFlags.size()), 0x94);
+    MILO_ASSERT_RANGE(arrowNum, 0, mConnectedFlags.size(), 0x94);
     if(connected != mConnectedFlags[arrowNum]){
         mConnectedFlags[arrowNum] = connected;
         if(connected) mConnectedTrigs[arrowNum]->Trigger();
@@ -81,22 +81,24 @@ void MicInputArrow::SetMicConnected(bool connected, int arrowNum){
     }
 }
 
-#define kNumArrows 3
+enum {
+    kNumArrows = 3,
+};
 
 void MicInputArrow::SetMicHidden(int arrowNum){
-    MILO_ASSERT(( 0) <= (arrowNum) && (arrowNum) < ( kNumArrows), 0xA6);
+    MILO_ASSERT_RANGE(arrowNum, 0, kNumArrows, 0xA6);
     mHiddenFlags[arrowNum] = true;
     mHiddenTrigs[arrowNum]->Trigger();
 }
 
 void MicInputArrow::SetMicPreview(int arrowNum){
-    MILO_ASSERT(( 0) <= (arrowNum) && (arrowNum) < ( kNumArrows), 0xAF);
+    MILO_ASSERT_RANGE(arrowNum, 0, kNumArrows, 0xAF);
     mHiddenFlags[arrowNum] = false;
     mPreviewTrigs[arrowNum]->Trigger();
 }
 
 void MicInputArrow::SetMicExtended(int arrowNum){
-    MILO_ASSERT(( 0) <= (arrowNum) && (arrowNum) < ( kNumArrows), 0xB7);
+    MILO_ASSERT_RANGE(arrowNum, 0, kNumArrows, 0xB7);
     mHiddenFlags[arrowNum] = false;
     mExtendedTrigs[arrowNum]->Trigger();
 }

--- a/src/system/bandobj/NoteTube.cpp
+++ b/src/system/bandobj/NoteTube.cpp
@@ -3,11 +3,11 @@
 #include "os/Debug.h"
 #include "decomp.h"
 
-NoteTube::NoteTube() : mPitched(false), mPart(-1), unk_0x24(false), mGlowLevel(-1), unk_0x2C(0), unk_0x2D(0), 
-    unk_0x30(0), unk_0x34(0), mEndX(0), mBackMat(0), mFrontMat(0), mBackPlate(0), mFrontPlate(0), mBackParent(0), 
+NoteTube::NoteTube() : mPitched(false), mPart(-1), unk_0x24(false), mGlowLevel(-1), unk_0x2C(0), unk_0x2D(0),
+    unk_0x30(0), unk_0x34(0), mEndX(0), mBackMat(0), mFrontMat(0), mBackPlate(0), mFrontPlate(0), mBackParent(0),
     mFrontParent(0), mXPos(0), mAlpha(1) { mPoints.reserve(100); }
 
-void NoteTube::SetNumPoints(int i) { 
+void NoteTube::SetNumPoints(int i) {
     if (i > mPoints.capacity()) MILO_WARN("Reallocating NoteTube point buffer to %d; please alert HUD/Track owner!", i);
     mPoints.resize(i);
 }
@@ -21,7 +21,7 @@ DECOMP_FORCEACTIVE(NoteTube, "point pos query out of bounds\n")
 
 void NoteTube::SetGlowLevel(int i) {
     mGlowLevel = 3 - i;
-    MILO_ASSERT(( 0) <= (mGlowLevel) && (mGlowLevel) < ( NumGlowLevels()), 73);
+    MILO_ASSERT_RANGE(mGlowLevel, 0, NumGlowLevels(), 73);
 }
 
 void NoteTube::BakePlates() {
@@ -129,8 +129,8 @@ void NoteTube::LookupPitchedUVCoordinates(float& f1, float& f2, float& f3, float
     }
 }
 
-TubePlate::TubePlate(int i) : mMesh(Hmx::Object::New<RndMesh>()), mParent(0), mAllocationCount(i), 
-    mBeginX(3.40282346638528859812e38), mWidthX(0), mBaked(0), mActiveMs(3.40282346638528859812e38), 
+TubePlate::TubePlate(int i) : mMesh(Hmx::Object::New<RndMesh>()), mParent(0), mAllocationCount(i),
+    mBeginX(3.40282346638528859812e38), mWidthX(0), mBaked(0), mActiveMs(3.40282346638528859812e38),
     mInvalidateMs(3.40282346638528859812e38), mMatSize(0), mDeploy(0) {
     mMesh->Verts().reserve(mAllocationCount, true);
     mMesh->Faces().reserve(mAllocationCount);

--- a/src/system/bandobj/TrackPanelDir.cpp
+++ b/src/system/bandobj/TrackPanelDir.cpp
@@ -367,7 +367,7 @@ void TrackPanelDir::CleanUpChordMeshes(){
 }
 
 TrackInstrument TrackPanelDir::GetInstrument(int trackIdx) const {
-    MILO_ASSERT(( 0) <= (trackIdx) && (trackIdx) < ( mInstruments.size()), 0x275);
+    MILO_ASSERT_RANGE(trackIdx, 0, mInstruments.size(), 0x275);
     return mInstruments[trackIdx];
 }
 

--- a/src/system/bandobj/TrackPanelDirBase.cpp
+++ b/src/system/bandobj/TrackPanelDirBase.cpp
@@ -211,7 +211,7 @@ bool TrackPanelDirBase::ReservedVocalPlayerSlot(int i){
 }
 
 BandTrack* TrackPanelDirBase::GetBandTrackInSlot(int slot){
-    MILO_ASSERT(( 0) <= (slot) && (slot) < ( mTracks.size()), 0x180);
+    MILO_ASSERT_RANGE(slot, 0, mTracks.size(), 0x180);
     return mTracks[slot];
 }
 

--- a/src/system/beatmatch/RGUtl.cpp
+++ b/src/system/beatmatch/RGUtl.cpp
@@ -23,7 +23,7 @@ void RGSetTuning(const std::vector<int>& vec){
     int i5 = 0;
     for(int i = 0; i < vec.size(); i++){
         int note = *stringPtr + i + i5;
-        MILO_ASSERT(( 0) <= (note) && (note) < ( 256), 0x45);
+        MILO_ASSERT_RANGE(note, 0, 256, 0x45);
         *tunedPtr = note;
         stringPtr++;
         tunedPtr++;
@@ -32,7 +32,7 @@ void RGSetTuning(const std::vector<int>& vec){
 }
 
 unsigned char RGGetTuning(int string){
-    MILO_ASSERT(( 0) <= (string) && (string) < ( 6), 0x4C);
+    MILO_ASSERT_RANGE(string, 0, 6, 0x4C);
     return gTunedNotes[string];
 }
 

--- a/src/system/obj/Dir.cpp
+++ b/src/system/obj/Dir.cpp
@@ -281,7 +281,7 @@ void ObjectDir::PostLoad(BinStream& bs){
     if(gRev > 0x17){
         int revs2 = bs.Cached() ? 0 : PopRev(this);
         int offset = PopRev(this);
-        MILO_ASSERT(( 0) <= (offset) && (offset) <= ( mSubDirs.size()), 0x466);
+        MILO_ASSERT_RANGE_EQ(offset, 0, mSubDirs.size(), 0x466);
         if(revs2 != 2){
             for(int i = mSubDirs.size() - offset - 1; i >= 0; i--){
                 bool bbb = false;

--- a/src/system/os/DateTime.cpp
+++ b/src/system/os/DateTime.cpp
@@ -91,7 +91,7 @@ DECOMP_FORCEACTIVE(DateTime, "%02d")
 
 namespace {
     Symbol MonthToken(int month){
-        MILO_ASSERT(( 0) <= (month) && (month) <= ( 11), 0xF5);
+        MILO_ASSERT_RANGE_EQ(month, 0, 11, 0xF5);
         static Symbol month_symbols[12] = {
             "month_january", "month_february", "month_march", "month_april",
             "month_may", "month_june", "month_july", "month_august",

--- a/src/system/os/Debug.h
+++ b/src/system/os/Debug.h
@@ -106,6 +106,19 @@ extern int* gpDbgFrameID;
 #  define MILO_CATCH(msgName) else if (const char* msgName = nullptr)
 #endif
 
+// Bounds checking asserts
+// Use these instead of MILO_ASSERT when you see their associated patterns.
+// The strange whitespace occurs because MWCC doesn't trim whitespace in
+// macro arguments during expansion.
+
+// ( min) <= (value) && (value) < ( max)
+#define MILO_ASSERT_RANGE(value, min, max, line) \
+    MILO_ASSERT((min) <= (value) && (value) < (max), line)
+
+// ( min) <= (value) && (value) <= ( max)
+#define MILO_ASSERT_RANGE_EQ(value, min, max, line) \
+    MILO_ASSERT((min) <= (value) && (value) <= (max), line)
+
 class DebugNotifier {
 public:
     DebugNotifier& operator<<(const char* c){

--- a/src/system/os/Joypad.cpp
+++ b/src/system/os/Joypad.cpp
@@ -37,7 +37,7 @@ namespace {
 
     static DataNode OnJoypadIsButtonDownPadNum(DataArray* arr){
         int pad = arr->Int(1);
-        MILO_ASSERT(( 0) <= (pad) && (pad) < ( kNumJoypads), 0x80);
+        MILO_ASSERT_RANGE(pad, 0, kNumJoypads, 0x80);
         int ret = gJoypadData[pad].mButtons & 1 << arr->Int(2);
         return DataNode(ret != 0);
     }
@@ -106,7 +106,7 @@ namespace {
 
 }
 
-JoypadData::JoypadData() : mButtons(0), mUser(0), mConnected(false), mVibrateEnabled(true), unk66(false), unk67(false), unk68(false), 
+JoypadData::JoypadData() : mButtons(0), mUser(0), mConnected(false), mVibrateEnabled(true), unk66(false), unk67(false), unk68(false),
     mHasAnalogSticks(false), mTranslateSticks(false), mIgnoreButtonMask(0), mGreenCymbalMask(0), mYellowCymbalMask(0), mBlueCymbalMask(0),
     mSecondaryPedalMask(0), mCymbalMask(0), mIsDrum(false), mType(kJoypadNone), mControllerType(), mHasGreenCymbal(false), mHasYellowCymbal(false),
     mHasBlueCymbal(false), mHasSecondaryPedal(false) {
@@ -251,7 +251,7 @@ void JoypadPushThroughMsg(const Message& msg){
 }
 
 void AssociateUserAndPad(LocalUser* iUser, int iPadNum){
-    MILO_ASSERT(( 0) <= (iPadNum) && (iPadNum) < ( kNumJoypads), 0x61C);
+    MILO_ASSERT_RANGE(iPadNum, 0, kNumJoypads, 0x61C);
     gJoypadData[iPadNum].mUser = iUser;
 }
 
@@ -270,7 +270,7 @@ int GetUsersPadNum(LocalUser* user){
 }
 
 LocalUser* JoypadGetUserFromPadNum(int iPadNum){
-    MILO_ASSERT(( 0) <= (iPadNum) && (iPadNum) < ( kNumJoypads), 0x633);
+    MILO_ASSERT_RANGE(iPadNum, 0, kNumJoypads, 0x633);
     return gJoypadData[iPadNum].mUser;
 }
 

--- a/src/system/os/Joypad.h
+++ b/src/system/os/Joypad.h
@@ -3,8 +3,10 @@
 #include "utl/Symbol.h"
 #include "obj/Msg.h"
 
-#define kNumJoypads 4
-#define kNumPressureButtons 8
+enum {
+    kNumJoypads = 4,
+    kNumPressureButtons = 8,
+};
 
 enum JoypadAction {
     kAction_None = 0,
@@ -233,7 +235,7 @@ public:
     bool mHasGreenCymbal;
     bool mHasYellowCymbal;
     bool mHasBlueCymbal;
-    bool mHasSecondaryPedal;    
+    bool mHasSecondaryPedal;
     int unk98;
 
     JoypadData();

--- a/src/system/synth/MidiInstrument.cpp
+++ b/src/system/synth/MidiInstrument.cpp
@@ -241,6 +241,6 @@ void MidiInstrument::Pause(bool b){
 }
 
 void MidiInstrument::SetFineTune(float cents){
-    MILO_ASSERT(( -100.f) <= (cents) && (cents) < ( 100.f), 0x1F9);
+    MILO_ASSERT_RANGE(cents, -100.f, 100.f, 0x1F9);
     mFineTuneCents = cents;
 }

--- a/src/system/ui/UIGridProvider.cpp
+++ b/src/system/ui/UIGridProvider.cpp
@@ -30,7 +30,7 @@ int UIGridProvider::NumDataForSublistIndex(int idx) const {
     if(idx < masternum / mWidth) numData = mWidth;
     else numData = masternum % mWidth;
 
-    MILO_ASSERT(( 0) <= (numData) && (numData) <= ( mWidth), 0xB9);
+    MILO_ASSERT_RANGE_EQ(numData, 0, mWidth, 0xB9);
     return numData;
 }
 

--- a/src/system/ui/UIListLabel.cpp
+++ b/src/system/ui/UIListLabel.cpp
@@ -17,7 +17,7 @@ const char* UIListLabel::GetDefaultText() const {
 UILabel* UIListLabel::ElementLabel(int display) const {
     if(mElements.empty()) return 0;
     else {
-        MILO_ASSERT(( 0) <= (display) && (display) < ( mElements.size()), 0x6E);
+        MILO_ASSERT_RANGE(display, 0, mElements.size(), 0x6E);
         UIListLabelElement* le = dynamic_cast<UIListLabelElement*>(mElements[display]);
         MILO_ASSERT(le, 0x71);
         return le->mLabel;

--- a/src/system/utl/HxGuid.cpp
+++ b/src/system/utl/HxGuid.cpp
@@ -35,7 +35,7 @@ bool HxGuid::IsNull() const {
 }
 
 int HxGuid::Chunk32(int i) const {
-    MILO_ASSERT(( 0) <= (i) && (i) < ( 4), 0x4F);
+    MILO_ASSERT_RANGE(i, 0, 4, 0x4F);
     return mData[i];
 }
 

--- a/src/system/utl/IntPacker.cpp
+++ b/src/system/utl/IntPacker.cpp
@@ -18,7 +18,7 @@ void IntPacker::AddBool(bool b){
 
 void IntPacker::AddS(int num, unsigned int bits){
     int max = 1 << bits - 1;
-    MILO_ASSERT_RANGE(num, -max, max, 0x21);
+    MILO_ASSERT_RANGE( num, -max, max, 0x21);
     Add(num, bits);
 }
 

--- a/src/system/utl/IntPacker.cpp
+++ b/src/system/utl/IntPacker.cpp
@@ -18,7 +18,7 @@ void IntPacker::AddBool(bool b){
 
 void IntPacker::AddS(int num, unsigned int bits){
     int max = 1 << bits - 1;
-    MILO_ASSERT(( -max) <= ( num) && ( num) < ( max), 0x21);
+    MILO_ASSERT_RANGE(num, -max, max, 0x21);
     Add(num, bits);
 }
 


### PR DESCRIPTION
Replaces asserts of the following patterns with new macros:

- `( min) <= (value) && (value) < ( max)` -> `MILO_ASSERT_RANGE(value, min, max, line)`
- `( min) <= (value) && (value) <= ( max)` -> `MILO_ASSERT_RANGE_EQ(value, min, max, line)`

MWCC doesn't trim leading/trailing whitespace from macro arguments, so not only do we know that this was most likely a macro, but we also know which argument is the first in the parameter list. The only strange bit is that some of these asserts also have a leading space on the `value` argument, but that could easily be marked off as a typo.