### PR TITLE
A couple project configuration misc. things

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 root = true
 
 [*]
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,24 +49,6 @@
       "problemMatcher": []
     },
     {
-      "label": "ninja report SZBE69",
-      "type": "shell",
-      "command": "ninja",
-      "args": [
-        "build/SZBE69/report.json"
-      ],
-      "problemMatcher": []
-    },
-    {
-      "label": "ninja report SZBE69_B8",
-      "type": "shell",
-      "command": "ninja",
-      "args": [
-        "build/SZBE69_B8/report.json"
-      ],
-      "problemMatcher": []
-    },
-    {
       "label": "all_source",
       "type": "shell",
       "command": "ninja all_source",


### PR DESCRIPTION
- Rely on .gitattributes to normalize line endings instead of .editorconfig `end_of_line`; avoids annoyances regarding undo/redo stacks getting dropped due to the automatic conversion on save.
- Remove report.json tasks from VS Code config, now that dtk-template generates it naturally through the default Ninja rule.