### PR TITLE
Update dtk_symbol_importer.py

### DIFF
--- a/tools/ghidra-scripts/dtk_symbol_importer.py
+++ b/tools/ghidra-scripts/dtk_symbol_importer.py
@@ -6,6 +6,7 @@
 import subprocess
 
 from ghidra.program.model.symbol import *
+from ghidra.program.model.symbol import SourceType, SymbolType, SymbolUtilities
 
 # Read/demangle symbols file
 f = askFile("Symbols File", "OK")


### PR DESCRIPTION
after this fix, the dtk symbol importer should work in ghidra regardless of version (shoutouts to nathan)