### PR TITLE
Some SaveLoadManager handlers for reference

### DIFF
--- a/config/SZBE69_B8/objects.json
+++ b/config/SZBE69_B8/objects.json
@@ -245,7 +245,7 @@
             "band3/meta_band/ProfileAssets.cpp": "Matching",
             "band3/meta_band/ProfileMgr.cpp": "NonMatching",
             "band3/meta_band/RetryAudioPanel.cpp": "NonMatching",
-            "band3/meta_band/SaveLoadManager.cpp": "MISSING",
+            "band3/meta_band/SaveLoadManager.cpp": "NonMatching",
             "band3/meta_band/SaveLoadStatusPanel.cpp": "Matching",
             "band3/meta_band/SavedSetlist.cpp": "NonMatching",
             "band3/meta_band/SelectDifficultyPanel.cpp": "LinkIssues",

--- a/src/band3/meta_band/SaveLoadManager.cpp
+++ b/src/band3/meta_band/SaveLoadManager.cpp
@@ -1,0 +1,49 @@
+#include "SaveLoadManager.h"
+#include "game/BandUser.h"
+#include "meta/Profile.h"
+#include "net_band/RockCentralMsgs.h"
+#include "obj/Data.h"
+#include "obj/MessageTimer.h"
+#include "obj/ObjMacros.h"
+#include "os/Memcard.h"
+#include "os/User.h"
+#include "utl/Symbols2.h"
+#include "utl/Symbols3.h"
+#include "utl/Symbols4.h"
+
+#pragma push
+#pragma dont_inline on
+BEGIN_HANDLERS(SaveLoadManager)
+    HANDLE_ACTION(autosave, AutoSave())
+    HANDLE_ACTION(autoload, AutoLoad())
+    HANDLE_ACTION(delete_saves, ManualDelete())
+    HANDLE_ACTION(manual_save, ManualSave(_msg->Obj<LocalBandUser>(2)))
+    HANDLE_EXPR(is_autosave_enabled, IsAutosaveEnabled(_msg->Obj<LocalBandUser>(2)))
+    HANDLE_ACTION(enable_autosave, EnableAutosave(_msg->Obj<LocalBandUser>(2)))
+    HANDLE_ACTION(disable_autosave, DisableAutosave(_msg->Obj<LocalBandUser>(2)))
+    HANDLE_ACTION(handle_eventresponse_start, HandleEventResponseStart(_msg->Int(2)))
+    HANDLE_ACTION(
+        handle_eventresponse, HandleEventResponse(_msg->Obj<LocalUser>(2), _msg->Int(3))
+    )
+    if (sym == get_dialog_msg) { // This handler doesn't return. Why?
+        GetDialogMsg();
+        timer.~MessageTimer();
+    }
+    HANDLE_EXPR(get_dialog_opt1, GetDialogOpt1())
+    HANDLE_EXPR(get_dialog_opt2, GetDialogOpt2())
+    HANDLE_EXPR(get_dialog_opt3, GetDialogOpt3())
+    HANDLE_EXPR(get_dialog_focus_option, GetDialogFocusOption())
+    HANDLE_EXPR(is_initial_load_done, IsInititalLoadDone())
+    HANDLE_EXPR(is_idle, IsIdle())
+    HANDLE_ACTION(activate, Activate())
+    HANDLE_ACTION(printout_savesize_info, PrintoutSaveSizeInfo())
+    HANDLE_MESSAGE(ProfileSwappedMsg)
+    HANDLE_MESSAGE(DeviceChosenMsg)
+    HANDLE_MESSAGE(NoDeviceChosenMsg)
+    HANDLE_MESSAGE(MCResultMsg)
+    HANDLE_MESSAGE(RockCentralOpCompleteMsg)
+    HANDLE_MESSAGE(SigninChangedMsg)
+    HANDLE_SUPERCLASS(MsgSource)
+    HANDLE_CHECK(0xF27)
+END_HANDLERS
+#pragma pop

--- a/src/band3/meta_band/SaveLoadManager.h
+++ b/src/band3/meta_band/SaveLoadManager.h
@@ -1,13 +1,44 @@
 #pragma once
+#include "game/BandUser.h"
+#include "meta/Profile.h"
+#include "net_band/RockCentralMsgs.h"
 #include "obj/Msg.h"
+#include "os/Memcard.h"
 
 class SaveLoadManager : public MsgSource {
 public:
+    SaveLoadManager();
+    virtual ~SaveLoadManager();
     void AutoSave();
+    void AutoLoad();
+    void EnableAutosave(LocalBandUser *);
+    void DisableAutosave(LocalBandUser *);
+    void ManualSave(LocalBandUser *);
+    void ManualDelete();
+    bool IsAutosaveEnabled(LocalBandUser *);
+    void GetDialogMsg();
+    Symbol GetDialogOpt1();
+    Symbol GetDialogOpt2();
+    Symbol GetDialogOpt3();
+    int GetDialogFocusOption();
+    bool IsInititalLoadDone();
+    bool IsIdle();
+    void Activate();
+    void PrintoutSaveSizeInfo();
     void Poll();
     void AutoSaveNow();
+    virtual DataNode Handle(DataArray *, bool);
+    void HandleEventResponseStart(int i1);
+    void HandleEventResponse(LocalUser *, int i1);
 
     static void Init();
+
+    DataNode OnMsg(const ProfileSwappedMsg &);
+    DataNode OnMsg(const DeviceChosenMsg &);
+    DataNode OnMsg(const NoDeviceChosenMsg &);
+    DataNode OnMsg(const MCResultMsg &);
+    DataNode OnMsg(const RockCentralOpCompleteMsg &);
+    DataNode OnMsg(const SigninChangedMsg &);
 };
 
 DECLARE_MESSAGE(SaveLoadMgrStatusUpdateMsg, "saveloadmgr_status_update_msg")

--- a/src/system/os/Memcard.h
+++ b/src/system/os/Memcard.h
@@ -74,3 +74,11 @@ DECLARE_MESSAGE(DeviceChosenMsg, "device_chosen")
 DeviceChosenMsg(int i) : Message(Type(), i) {}
 int Device() const { return mData->Int(2); }
 END_MESSAGE
+
+DECLARE_MESSAGE(NoDeviceChosenMsg, "no_device_chosen")
+NoDeviceChosenMsg() : Message(Type()) {}
+END_MESSAGE
+
+DECLARE_MESSAGE(MCResultMsg, "mc_result")
+MCResultMsg(int i) : Message(Type(), i) {}
+END_MESSAGE


### PR DESCRIPTION
This is SaveLoadManager::Handle *mostly* matched (94%)
I'm not sure what's going on with the `get_dialog_msg` handler. It doesn't make a DataNode to return as far as I can tell.