### PR TITLE
start on UsbWii

### DIFF
--- a/config/SZBE69_B8/objects.json
+++ b/config/SZBE69_B8/objects.json
@@ -1412,7 +1412,7 @@
             "system/ui/UITrigger.cpp": "NonMatching",
             "system/ui/Utl.cpp": "NonMatching",
 
-            "system/usbwii/UsbWii.cpp": "MISSING",
+            "system/usbwii/UsbWii.cpp": "NonMatching",
 
             "system/utl/BeatMap.cpp": "NonMatching",
             "system/utl/BinStream.cpp": "NonMatching",

--- a/src/sdk/RVL_SDK/revolution/usb/hid.h
+++ b/src/sdk/RVL_SDK/revolution/usb/hid.h
@@ -1,0 +1,40 @@
+#ifndef RVL_SDK_HID_H
+#define RVL_SDK_HID_H
+#include "revolution/IPC.h"
+#include "types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _HIDClient {
+    _HIDClient *next;
+    void *attachHandler;
+    unsigned long user;
+} _HIDClient;
+
+typedef struct HIDDevice {
+    long fd;
+    u16 vid;
+    u16 pid;
+    u8 iInterface;
+    u8 endpoint_address_in;
+    u8 endpoint_address_out;
+    u8 inst;
+    void *p_hdd;
+    void *p_hcd;
+    void *p_hid;
+    void *p_hed0;
+    void *p_hed1;
+} HIDDevice;
+
+typedef int (*AttachHandler_t)(_HIDClient *client, HIDDevice *device, unsigned long user);
+typedef int (*DetachHandler_t)(long result, unsigned long user);
+
+int HIDOpenAsync(void *memory, void *callback, void *user);
+void HIDRegisterClient(_HIDClient *client, AttachHandler_t handler);
+void HIDUnregisterClientAsync(_HIDClient *client, DetachHandler_t handler, void *user);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/system/usbwii/UsbWii.cpp
+++ b/src/system/usbwii/UsbWii.cpp
@@ -1,0 +1,289 @@
+#include "usbwii/UsbWii.h"
+#include "utl/MemMgr.h"
+
+UsbWii *gsTheUsbWii;
+
+// static u32 UsbWii::sUSBOpenCloseResult = 0;
+
+void UsbWii::ClearDevice(int num) {
+    UsbDevice *device = &sDevices[num];
+    memset(device, 0, sizeof(UsbDevice));
+    device->state = 0;
+    device->type = kUsbNone;
+    device->ledNum = -1;
+    device->unk6 = 0;
+}
+
+void UsbWii::DbgVerifyNoBufferOverrun(int unk) {}
+
+void UsbWii::KeepAlive(int unk) {}
+
+bool UsbWii::AddDevice(HIDDevice *device, UsbType type) {
+    // check if we already have this device in our list
+    for (int i = 0; i < 4; i++) {
+        if (sDevices[i].dd == device) {
+            sDevices[i].state = 0;
+            return false;
+        }
+    }
+    // if we don't, find a free spot and add the device
+    for (int i = 0; i < 4; i++) {
+        if (sDevices[i].dd == NULL) {
+            sDevices[i].dd = device;
+            sDevices[i].type = type;
+            return true;
+        }
+    }
+    // failed to add the device
+    return false;
+}
+
+int UsbWii::UsbAttachHandler(_HIDClient *client, HIDDevice *device, unsigned long user) {
+    if (!mDiscError) {
+        if (user != NULL) {
+            UsbType type = (UsbType)GetType(device);
+            if (type != kUsbNone && (type > kUsbNone && type < kUsbTypeMax)) {
+                return AddDevice(device, (UsbType)type);
+            }
+            return 0;
+        }
+        for (int i = 0; i < 4; i++) {
+            if (sDevices[i].dd == device) {
+                ClearDevice(i);
+            }
+        }
+    }
+    return 0;
+}
+
+int UsbWii::GetType(HIDDevice *device) {
+    // Harmonix Music Systems / Mad Catz vendor ID
+    if (device->vid == 0x1BAD) {
+        switch (device->pid) {
+        // MIDI Pro Adapter, Drums
+        case 0x3138:
+            return kUsbMidiDrums;
+        // RB1 Drums
+        case 5:
+            return kUsbDrums;
+        // RB1 Guitar
+        case 4:
+            return kUsbGuitar;
+        // RB2 Guitar
+        case 0x3010:
+            return kUsbGuitarRb2;
+        // RB2 Drums
+        case 0x3110:
+            return kUsbDrumsRb2;
+        // MIDI Pro Adapter, Keyboard
+        case 0x3338:
+            return kUsbMidiKeyboardMpa;
+        // RB3 Keyboard
+        case 0x3330:
+            return kUsbMidiKeyboard;
+        // RB3 Squire / MPA in Squire mode
+        case 0x3538:
+        case 0x3530:
+            return kUsbMidiGuitarSquire;
+        // RB3 Mustang / MPA in Mustang mode
+        case 0x3438:
+        case 0x3430:
+            return kUsbMidiGuitarMustang;
+        }
+    }
+#ifdef MILO_DEBUG
+    // only in this build does the game check for PS3 instruments
+    // Sony Computer Entertainment vendor ID
+    if (device->vid != 0x12BA) {
+        return kUsbNone;
+    } else {
+        // PS3 Drums
+        if (device->pid == 0x210)
+            return kUsbDrums;
+        // PS3 Guitar
+        else if (device->pid == 0x200)
+            return kUsbGuitar;
+        else
+            return kUsbNone;
+    }
+#endif
+}
+
+bool UsbWii::HasUnifiedLEDCalbertMsg(UsbType type) {
+    switch (type) {
+    case kUsbGuitarRb2:
+    case kUsbUnused:
+        return true;
+    }
+    return false;
+}
+
+int UsbWii::GetJoypadType(int num) const {
+    switch (sDevices[num].type) {
+    case kUsbDrums:
+        return kJoypadWiiHxDrums;
+    case kUsbDrumsRb2:
+        return kJoypadWiiHxDrumsRb2;
+    case kUsbGuitar:
+        return kJoypadWiiHxGuitar;
+    case kUsbGuitarRb2:
+        return kJoypadWiiHxGuitarRb2;
+    case kUsbUnused:
+        return kJoypadWiiCoreGuitar;
+    case kUsbMidiKeyboardMpa:
+        return kJoypadWiiMidiBoxKeyboard;
+    case kUsbMidiDrums:
+        return kJoypadWiiMidiBoxDrums;
+    case kUsbMidiGuitarMustang:
+        return kJoypadWiiButtonGuitar;
+    case kUsbMidiGuitarSquire:
+        return kJoypadWiiRealGuitar22Fret;
+    case kUsbMidiKeyboard:
+        return kJoypadWiiKeytar;
+    }
+    return 0;
+}
+
+inline bool UsbWii::IsDeviceActive(int num) {
+    bool stateValid = false;
+    bool deviceValid = false;
+    if (num < 4 && sDevices[num].type != kUsbNone) {
+        deviceValid = true;
+    }
+    if (deviceValid && sDevices[num].state >= 2) {
+        stateValid = true;
+    }
+    if (stateValid && (sDevices[num].flags & kUsbFlagActive) == 0) {
+        return false;
+    }
+    return true;
+}
+
+bool UsbWii::IsActive(int num) const { return IsDeviceActive(num); }
+
+void UsbWii::UsbOpenCloseCallback(long result, unsigned long unk) {
+    sUSBOpenCloseResult = result;
+}
+
+bool UsbWii::OpenLib() {
+    static int _x = MemFindHeap("main");
+    MemPushHeap(_x);
+    usbMem = _MemAlloc(0x3AE0, 0x20);
+    MemPopHeap();
+    if (usbMem != NULL) {
+        sUSBOpenCloseResult = OPENCLOSE_START_MAGIC;
+        int r;
+        do {
+            r = HIDOpenAsync(usbMem, UsbOpenCloseCallback, 0);
+            if (r == 0) {
+                return WaitForUSBOpenCloseResult();
+            }
+        } while (r == -5);
+    }
+    return false;
+}
+
+void UsbWii::SetLED(int num, int led) {
+    if (!IsDeviceActive(num)) {
+        return;
+    }
+    sDevices[num].flags |= kUsbFlagHasLED;
+    sDevices[num].ledNum = led;
+}
+
+void UsbWii::SetInactive(int num) {
+    if (num >= 4)
+        return;
+    sDevices[num].flags = (sDevices[num].flags & ~kUsbFlagActive) | kUsbFlagInactive;
+}
+
+void UsbWii::UsbReadInstrCallback(
+    HIDDevice *device, long result, u8 *bytes, unsigned long length, unsigned long user
+) {
+    // error during read
+    if (result != 0) {
+        if (sDevices[user].state == kUsbStateDone) {
+            sDevices[user].state = kUsbStateReading;
+            if ((sDevices[user].flags & kUsbFlagInactive) == 0) {
+                sDevices[user].inactivity = 0;
+            }
+        }
+        // fatal error / device disconnected?
+        if (result == -4) {
+            ClearDevice(user);
+            return;
+        }
+        return;
+    }
+    // D-PAD correction
+    if ((sDevices[user].packet[2] & 8) == 0) {
+        switch (sDevices[user].packet[2]) {
+        case 0:
+            sDevices[user].packet[2] = 1;
+            break;
+        case 2:
+            sDevices[user].packet[2] = 8;
+            break;
+        case 4:
+            sDevices[user].packet[2] = 2;
+            break;
+        case 6:
+            sDevices[user].packet[2] = 4;
+            break;
+        }
+    } else {
+        sDevices[user].packet[2] = 0;
+    }
+    // fill in the button mask
+    sDevices[user].buttonMask = (sDevices[user].packet[2] << 16)
+        | (sDevices[user].packet[1] << 8) | sDevices[user].packet[0];
+    // fill in the stick values
+    sDevices[user].lstickX = sDevices[user].packet[3];
+    sDevices[user].lstickY = sDevices[user].packet[4];
+    sDevices[user].rstickX = sDevices[user].packet[5];
+    sDevices[user].rstickY = sDevices[user].packet[6];
+    // fill in the pressure values
+    sDevices[user].pressures[0] = sDevices[user].packet[11];
+    sDevices[user].pressures[1] = sDevices[user].packet[12];
+    sDevices[user].pressures[2] = sDevices[user].packet[13];
+    sDevices[user].pressures[3] = sDevices[user].packet[14];
+    // copy over the extra values
+    for (int i = 0; i < 0x10; i++) {
+        sDevices[user].extended[i] = sDevices[user].packet[5 + i];
+    }
+    // check if buttons are pressed for inactivity reading
+    int buttonsPressed = sDevices[user].buttonMask;
+    if (sDevices[user].type == kUsbGuitar || sDevices[user].type == kUsbGuitarRb2)
+        buttonsPressed &= ~0x20;
+    if (buttonsPressed == 0) {
+        if ((sDevices[user].flags & kUsbFlagInactive) != 0)
+            sDevices[user].inactivity += 1;
+    } else if ((sDevices[user].flags & kUsbFlagInactive) == 0) {
+        sDevices[user].flags |= kUsbFlagActive;
+    } else {
+        sDevices[user].inactivity = 0;
+    }
+    // send another request if we're done reading
+    if (sDevices[user].state == kUsbStateDone) {
+        sDevices[user].state = kUsbStateReading;
+        RequestReadInstr(user, false);
+        return;
+    }
+}
+
+UsbWii::UsbWii() {
+    usbMem = NULL;
+    for (int i = 0; i < 4; i++)
+        ClearDevice(i);
+    OpenLib();
+    HIDRegisterClient(&client, UsbAttachHandler);
+    gsTheUsbWii = this;
+}
+
+UsbWii::~UsbWii() {
+    gsTheUsbWii = NULL;
+    sUSBOpenCloseResult = OPENCLOSE_START_MAGIC;
+    HIDUnregisterClientAsync(&client, UsbDetachHandler, NULL);
+    WaitForUSBOpenCloseResult();
+    CloseLib();
+}

--- a/src/system/usbwii/UsbWii.h
+++ b/src/system/usbwii/UsbWii.h
@@ -1,0 +1,95 @@
+#pragma once
+#include "RVL_SDK/revolution/usb/hid.h"
+#include "os/Joypad.h"
+
+#define OPENCLOSE_START_MAGIC 0x12341234
+
+enum UsbFlags {
+    kUsbFlagHasLED = 0x1,
+    kUsbFlagActive = 0x10,
+    kUsbFlagInactive = 0x20
+};
+
+enum UsbState {
+    kUsbStateInactive = 0,
+    kUsbStateInit = 1,
+    kUsbStateReady = 2,
+    kUsbStateUnk = 3,
+    kUsbStateReading = 4,
+    kUsbStateDone = 5
+};
+
+typedef struct _UsbDevice {
+    HIDDevice *dd; // 0x0
+    u32 type; // 0x4
+    u32 state; // 0x8
+    u32 flags; // 0xC
+    u32 inactivity; // 0x10
+    u8 unk_0x14[0x2]; // 0x14
+    s16 ledNum; // 0x16
+    u32 unk6; // 0x18
+    u32 buttonMask; // 0x1C
+    u16 lstickX; // 0x20
+    u16 lstickY; // 0x22
+    u16 rstickX; // 0x24
+    u16 rstickY; // 0x26
+    u8 pressures[4]; // 0x28
+    u8 extended[0x10]; // 0x2C
+    u8 unk_0x3C[0x4]; // 0x3C
+    u8 packet[0x40]; // 0x40
+    u8 unk_0x80[0x80]; // 0x80
+} UsbDevice; // 0x100
+
+enum UsbType {
+    kUsbNone = 0,
+    kUsbGuitar = 1,
+    kUsbGuitarRb2 = 2,
+    kUsbDrums = 3,
+    kUsbDrumsRb2 = 4,
+    kUsbMidiGuitarMustang = 5,
+    kUsbMidiGuitarSquire = 6,
+    kUsbMidiKeyboard = 7,
+    kUsbUnused = 8,
+    kUsbMidiKeyboardMpa = 9,
+    kUsbMidiDrums = 10,
+    kUsbTypeMax = 11,
+};
+
+class UsbWii {
+public:
+    UsbWii();
+    ~UsbWii();
+
+    static UsbDevice sDevices[4];
+    static void ClearDevice(int num);
+    static bool AddDevice(HIDDevice *device, UsbType type);
+    static int GetType(HIDDevice *device);
+    static void DbgVerifyNoBufferOverrun(int unk);
+    static void KeepAlive(int unk);
+    static bool HasUnifiedLEDCalbertMsg(UsbType type);
+    static void RequestReadInstr(int num, bool unk);
+
+    static inline bool IsDeviceActive(int num);
+
+    static int
+    UsbAttachHandler(_HIDClient *client, HIDDevice *device, unsigned long user);
+    static int UsbDetachHandler(long result, unsigned long user);
+    static void UsbOpenCloseCallback(long result, unsigned long unk);
+    static void UsbReadInstrCallback(
+        HIDDevice *device, long result, u8 *bytes, unsigned long length, unsigned long user
+    );
+
+    bool OpenLib();
+    bool CloseLib();
+    int GetJoypadType(int num) const;
+    bool IsActive(int num) const;
+    void SetInactive(int num);
+    void SetLED(int num, int led);
+    int WaitForUSBOpenCloseResult();
+
+    _HIDClient client;
+    void *usbMem;
+
+    static bool mDiscError;
+    static int sUSBOpenCloseResult;
+};


### PR DESCRIPTION
Backbone entertainment decided it was a good idea to have a Sony controller in the whitelist on a Nintendo game and promptly went bankrupt after Nintendo pressed the bankrupt backbone button in retaliation. This plan backfired for Nintendo as gremlins would later find the Backbone Box and take Rock Band out of it.